### PR TITLE
feat(slash): slash commands follow UI language / 斜杠命令跟随界面语言

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -2325,21 +2325,25 @@ export class ClientSession {
 	static NATIVE_COMMANDS: {
 		name: string;
 		description: string;
+		descriptionEn: string;
 		argumentHint?: string;
+		argumentHintEn?: string;
 	}[] = [
-		{ name: "new", description: "新建对话" },
-		{ name: "model", description: "切换模型", argumentHint: "[名称]" },
-		{ name: "compact", description: "压缩上下文", argumentHint: "[说明]" },
-		{ name: "cwd", description: "切换工作目录", argumentHint: "<路径>" },
+		{ name: "new", description: "新建对话", descriptionEn: "New chat" },
+		{ name: "model", description: "切换模型", descriptionEn: "Switch model", argumentHint: "[名称]", argumentHintEn: "[name]" },
+		{ name: "compact", description: "压缩上下文", descriptionEn: "Compact context", argumentHint: "[说明]", argumentHintEn: "[instructions]" },
+		{ name: "cwd", description: "切换工作目录", descriptionEn: "Switch workspace", argumentHint: "<路径>", argumentHintEn: "<path>" },
 		{
 			name: "thinking",
 			description: "设置思考强度",
-			argumentHint: "<off|low|medium|high>",
+			descriptionEn: "Set thinking level",
+			argumentHint: "<off|low|medium|high|xhigh|max>",
+			argumentHintEn: "<off|low|medium|high|xhigh|max>",
 		},
-		{ name: "resume", description: "刷新会话列表" },
-		{ name: "reload", description: "重新加载扩展、技能与模板" },
-		{ name: "help", description: "显示全部命令" },
-		{ name: "copy", description: "复制上一条助手回复" },
+		{ name: "resume", description: "刷新会话列表", descriptionEn: "Refresh session list" },
+		{ name: "reload", description: "重新加载扩展、技能与模板", descriptionEn: "Reload extensions, skills & templates" },
+		{ name: "help", description: "显示全部命令", descriptionEn: "Show all commands" },
+		{ name: "copy", description: "复制上一条助手回复", descriptionEn: "Copy last assistant reply" },
 	];
 
 	/** Parse a prompt into "/command args" — returns null when it isn't one. */

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -154,8 +154,10 @@ export interface SlashCommandInfo {
 	 *  names are suffixed by the SDK ("new:2"), like the CLI. */
 	name: string;
 	description?: string;
+	descriptionEn?: string;
 	/** Argument placeholder shown in the picker (e.g. "<路径>", "[说明]"). */
 	argumentHint?: string;
+	argumentHintEn?: string;
 	/** Where the command comes from: web-native builtin / SDK extension /
 	 *  prompt template / skill. */
 	source: "builtin" | "extension" | "prompt" | "skill";

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { FiSend, FiSquare, FiPaperclip, FiArrowUp } from "react-icons/fi";
 import type { ChatState } from "../use-chat";
 import type { ClientMessage, SlashCommandInfo } from "../types";
-import { useT } from "../i18n";
+import { useT, useI18n } from "../i18n";
 import { isRasterImage } from "../image-paste";
 
 import { ModelThinking } from "./ModelThinking";
@@ -51,6 +51,11 @@ export function ChatInput({
 	onManageModels,
 }: ChatInputProps) {
 	const t = useT();
+	const { locale } = useI18n();
+	const slashDesc = (c: SlashCommandInfo) =>
+		locale === "en" && c.descriptionEn ? c.descriptionEn : (c.description ?? "");
+	const slashHint = (c: SlashCommandInfo) =>
+		locale === "en" && c.argumentHintEn ? c.argumentHintEn : (c.argumentHint ?? "");
 	const [text, setText] = useState("");
 	const [dragOver, setDragOver] = useState(false);
 	/** Slash-command picker: non-null while open (filtered by the current input). */
@@ -460,9 +465,9 @@ export function ChatInput({
 								{SOURCE_LABEL[c.source]}
 							</span>
 							<span className="slash-desc">
-								{c.description}
+								{slashDesc(c)}
 								{c.argumentHint && (
-									<span className="slash-hint">{c.argumentHint}</span>
+									<span className="slash-hint">{slashHint(c)}</span>
 								)}
 							</span>
 						</button>
@@ -497,9 +502,9 @@ export function ChatInput({
 											{SOURCE_LABEL[c.source]}
 										</span>
 										<span className="slash-help-desc">
-											{c.description}
+											{slashDesc(c)}
 											{c.argumentHint && (
-												<span className="slash-hint">{c.argumentHint}</span>
+												<span className="slash-hint">{slashHint(c)}</span>
 											)}
 										</span>
 									</div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -127,8 +127,10 @@ export interface SlashCommandInfo {
 	 *  "skill:review", "templatename"). */
 	name: string;
 	description?: string;
+	descriptionEn?: string;
 	/** Argument placeholder shown in the picker (e.g. "<路径>", "[说明]"). */
 	argumentHint?: string;
+	argumentHintEn?: string;
 	/** Where the command comes from: web-native builtin / SDK extension /
 	 *  prompt template / skill. */
 	source: "builtin" | "extension" | "prompt" | "skill";


### PR DESCRIPTION
EN — Summary
- `SlashCommandInfo` now carries `descriptionEn` / `argumentHintEn` (`server/protocol.ts`, `web/src/types.ts`)
- `NATIVE_COMMANDS` stores bilingual pairs (`server/agent-service.ts`), e.g. zh `新建对话` / en `New chat`
- `ChatInput` selects the field matching the UI locale (`zh`/`en`) so only one language shows; switching language updates the picker instantly
- Chinese source text preserved verbatim; no more concatenated `中文 / English` strings

中文 — 摘要
- `SlashCommandInfo` 新增 `descriptionEn` / `argumentHintEn`（`server/protocol.ts`、`web/src/types.ts`）
- `NATIVE_COMMANDS` 存储中英双语（`server/agent-service.ts`），例如 中文 `新建对话` / 英文 `New chat`
- `ChatInput` 按界面语言（`zh`/`en`）选择对应字段，只显示一种语言；切换语言后下拉列表立即更新
- 中文文案保持原样，不再以 `中文 / English` 形式拼接

> Note / 说明： Translations in this PR were generated by an automated translation system. If any wording is awkward or inaccurate, please point it out and it will be corrected. / 本 PR 中的翻译由自动翻译系统生成，如有措辞不当或不准确之处，欢迎指出并将予以修正。

Test: `npm --prefix pi-web-ui run typecheck && npm --prefix pi-web-ui run build` pass; toggle language, type `/`, verify `新建对话` vs `New chat`.

Stack: independent branch `feat/slash-bilingual` on `chrisjbray/pi-web-ui`, base `xing-shuyin:main`.