### PR TITLE
feat(slash): add /pi-web-ui:quit to restart server / 新增 /pi-web-ui:quit 重启服务

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -1819,6 +1819,8 @@ export class ClientSession {
 	 * the process is going to restart itself (so the notice can say so).
 	 */
 	onUpdateReady: (() => boolean) | undefined = undefined;
+	/** Set by index.ts: called when /pi-web-ui:quit is invoked. */
+	onQuit: (() => boolean) | undefined = undefined;
 
 	/** Ask the npm registry for the latest pi-web-ui version and report it. */
 	async checkUpdate(): Promise<void> {
@@ -2344,6 +2346,7 @@ export class ClientSession {
 		{ name: "reload", description: "重新加载扩展、技能与模板", descriptionEn: "Reload extensions, skills & templates" },
 		{ name: "help", description: "显示全部命令", descriptionEn: "Show all commands" },
 		{ name: "copy", description: "复制上一条助手回复", descriptionEn: "Copy last assistant reply" },
+		{ name: "pi-web-ui:quit", description: "退出服务", descriptionEn: "Quit server (supervisor will restart)" },
 	];
 
 	/** Parse a prompt into "/command args" — returns null when it isn't one. */
@@ -2488,6 +2491,20 @@ export class ClientSession {
 					});
 				}
 				return true;
+			case "pi-web-ui:quit": {
+				this.emit({
+					type: "notice",
+					level: "info",
+					text: "正在退出 pi-web-ui… supervisor 将自动重启服务",
+				});
+				setTimeout(() => {
+					const didSchedule = this.onQuit?.() ?? false;
+					if (!didSchedule) {
+						setTimeout(() => process.exit(0), 100);
+					}
+				}, 300);
+				return true;
+			}
 			case "help":
 			case "copy":
 				// Client-side UI actions — the client handles them before sending;
@@ -4809,6 +4826,8 @@ export class AgentService {
 	 * self-update; returns whether the process will restart itself.
 	 */
 	onUpdateReady: (() => boolean) | undefined = undefined;
+	/** Set by index.ts: called when /pi-web-ui:quit is invoked. */
+	onQuit: (() => boolean) | undefined = undefined;
 
 	constructor(
 		private cwd: string,
@@ -4862,8 +4881,9 @@ export class AgentService {
 			}
 		}
 		cs.attachSink(send);
-		// Forward the update hook (set once by index.ts) to every session.
+		// Forward hooks (set once by index.ts) to every session.
 		cs.onUpdateReady = this.onUpdateReady;
+		cs.onQuit = this.onQuit;
 		return cs;
 	}
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -204,6 +204,26 @@ function scheduleUpdateRestart(): boolean {
 }
 service.onUpdateReady = scheduleUpdateRestart;
 
+function scheduleQuit(): boolean {
+	const isLaunchd = process.platform === "darwin" && process.ppid === 1;
+	const isSystemd = process.platform === "linux" && !!process.env.INVOCATION_ID;
+	const inDocker = existsSync("/.dockerenv");
+	if (isLaunchd || isSystemd || inDocker) {
+		setTimeout(() => {
+			console.log("pi-web-ui:quit — shutting down (supervisor will restart)…");
+			if (isSystemd) process.exit(3);
+			void shutdown();
+		}, 300);
+		return true;
+	}
+	setTimeout(() => {
+		console.log("pi-web-ui:quit — shutting down (restart to reload)…");
+		void shutdown();
+	}, 300);
+	return true;
+}
+service.onQuit = scheduleQuit;
+
 wss.on("connection", (ws) => {
 	let clientId: string | null = null;
 	let closed = false;


### PR DESCRIPTION
EN — Summary
- Adds builtin `/pi-web-ui:quit` (`server/agent-service.ts`): emits a notice and calls `scheduleQuit`
- `scheduleQuit` (`server/index.ts`) handles launchd / systemd / Docker vs foreground: graceful `shutdown()` (or `exit(3)` for systemd) so the supervisor restarts and reloads source
- **Stacked on #4** — merge #4 first; this PR includes both the bilingual change and the quit command (they will be split once #4 lands)

中文 — 摘要
- 新增内置命令 `/pi-web-ui:quit`（`server/agent-service.ts`）：发送提示并触发 `scheduleQuit`
- `scheduleQuit`（`server/index.ts`）区分 launchd / systemd / Docker 与前台：优雅 `shutdown()`（systemd 用 `exit(3)`），由 supervisor 自动重启并重新加载代码
- **基于 #4 叠加** —— 请先合并 #4；本 PR 暂包含双语改动与 quit 命令，#4 合并后将 rebase 拆分

> Note / 说明： Translations in this PR were generated by an automated translation system. If any wording is awkward or inaccurate, please point it out and it will be corrected. / 本 PR 中的翻译由自动翻译系统生成，如有措辞不当或不准确之处，欢迎指出并将予以修正。

Depends on: #4 (bilingual). Rebase onto `main` after #4 merges to leave only the quit diff.

Test: start server on a test port, send `/pi-web-ui:quit`, verify notice `正在退出…` and port freed within 1s.