### PR TITLE
Fix possible by not specifying a USER, a program in the container may run as 'root' in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,5 @@ ENV PORT=8787
 EXPOSE 8787
 # Session data (per-client chat history) lives here — mount a volume.
 VOLUME ["/app/.pi-web"]
+USER node
 CMD ["node", "dist/server/index.js"]


### PR DESCRIPTION
Small change to `Dockerfile` — a scan flagged the code below and it looked genuine. It is around line 28.

The Dockerfile lacks an explicit USER instruction, causing processes (e.g., the Node.js app) to run as root. This unnecessary privilege elevates any compromise of the container to full system control, enabling unrestricted file system access, privilege escalation, and potential host breach. The issue is a high‑risk CWE‑250 violation.

Add a non‑root USER directive to avoid running the container as root.

For reference: rule `dockerfile.security.missing-user.missing-user`, [CWE-250 (Execution with Unnecessary Privileges)](https://cwe.mitre.org/data/definitions/250.html). Rated high.

Take or leave whichever parts are useful. If this is not the right approach, closing is fine.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
