### PR TITLE
feat(server): message_delta 实时增量通道（thinking/text/token 不经 snapshot）

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -1048,6 +1048,30 @@ export class ClientSession {
 			case "entry_appended":
 				this.scheduleSessionsRefresh();
 				break;
+			case "message_update": {
+				// Streaming assistant-message increment (live rendering independent of the
+				// full snapshot, which backpressure may drop on big sessions). Forward the
+				// SDK small delta — strip partial (cumulative message) to avoid re-serializing.
+				const ame = event.assistantMessageEvent;
+				const m = event.message as AgentMessage & { usage?: unknown };
+				const messageId = `stream-${(m as { timestamp?: number }).timestamp ?? 0}`;
+				const delta: ServerMessage & { type: "message_delta" } = {
+					type: "message_delta",
+					messageId,
+					usage: (() => {
+						try {
+							return (this.session.getSessionStats().tokens as { input: number; output: number; total: number }) ?? null;
+						} catch { return null; }
+					})(),
+					assistantMessageEvent: {
+						type: ame.type,
+						contentIndex: "contentIndex" in ame ? ame.contentIndex : undefined,
+						delta: "delta" in ame ? ame.delta : undefined,
+					},
+				};
+				this.emit(delta);
+				break;
+			}
 			default:
 				break;
 		}

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -654,6 +654,12 @@ export type ServerMessage =
 			toolName: string;
 			delta: string;
 	  }
+	| {
+			type: "message_delta";
+			messageId: string;
+			usage: { input: number; output: number; total: number } | null;
+			assistantMessageEvent: { type: string; contentIndex?: number; delta?: string };
+	  }
 	/** A tool FINISHED executing (SDK tool_execution_end). Unlike toolResult
 	 *  snapshot messages, this arrives the moment the command exits — before
 	 *  the model's next response starts — so the UI can show "done, waiting

--- a/web/src/use-chat.ts
+++ b/web/src/use-chat.ts
@@ -21,6 +21,9 @@ import type {
 	UiProviderConfig,
 	UiSettingsState,
 	UiState,
+	UiMessage,
+	UiTextBlock,
+	UiThinkingBlock,
 } from "./types";
 
 export type ConnStatus = "connecting" | "open" | "closed";
@@ -137,6 +140,12 @@ type Action =
 	| { type: "status"; status: ConnStatus }
 	| { type: "snapshot"; state: UiState }
 	| { type: "tool_delta"; toolCallId: string; toolName: string; delta: string }
+	| {
+			type: "message_delta";
+			messageId: string;
+			usage: { input: number; output: number; total: number } | null;
+			assistantMessageEvent: { type: string; contentIndex?: number; delta?: string };
+	  }
 	| { type: "tool_status"; status: ToolStatus }
 	| { type: "notice"; notice: Notice }
 	| { type: "dismiss_notice"; id: number }
@@ -365,6 +374,41 @@ function reducer(state: ChatState, action: Action): ChatState {
 				text: capped,
 			});
 			return { ...state, liveOutputs };
+		}
+		case "message_delta": {
+			const ui = state.state;
+			if (!ui) return state;
+			const ame = action.assistantMessageEvent;
+			const delta = ame.delta;
+			const stats = action.usage
+				? { ...ui.stats, tokens: { ...ui.stats.tokens, ...(action.usage as Record<string, number>) } }
+				: ui.stats;
+			if (ame.type === "text_delta" || ame.type === "thinking_delta") {
+				if (!delta) return { ...state, state: { ...ui, stats } };
+				const id = action.messageId;
+				const prev = ui.streamingMessage;
+				const base: UiMessage = prev && prev.id === id ? prev : { id, role: "assistant", content: [] };
+				const content = [...base.content];
+				const idx = ame.contentIndex ?? content.length - 1;
+				const blockType = ame.type === "thinking_delta" ? "thinking" : "text";
+				if (idx >= 0 && idx < content.length && content[idx].type === blockType) {
+					if (blockType === "thinking") {
+						const b = content[idx] as UiThinkingBlock;
+						b.thinking = (b.thinking ?? "") + delta;
+					} else {
+						const b = content[idx] as UiTextBlock;
+						b.text = (b.text ?? "") + delta;
+					}
+				} else {
+					content.push(
+						blockType === "thinking"
+							? { type: "thinking", thinking: delta }
+							: { type: "text", text: delta },
+					);
+				}
+				return { ...state, state: { ...ui, stats, streamingMessage: { ...base, content, id } } };
+			}
+			return { ...state, state: { ...ui, stats } };
 		}
 		case "tool_status":
 			return {
@@ -653,6 +697,14 @@ export function useChat() {
 						toolCallId: msg.toolCallId,
 						toolName: msg.toolName,
 						delta: msg.delta,
+					});
+					break;
+				case "message_delta":
+					dispatch({
+						type: "message_delta",
+						messageId: msg.messageId,
+						usage: msg.usage,
+						assistantMessageEvent: msg.assistantMessageEvent,
 					});
 					break;
 				case "tool_status":


### PR DESCRIPTION
## 背景 / 动机

Issue #11 的 OOM 治理采用「snapshot 背压」（bufferedAmount > 1MB 时丢弃整份 snapshot）。这对**大会话**有副作用：snapshot 可达数 MB，背压会**持续丢弃 snapshot**，而前端渲染（thinking / 正在输出的文本 / token 计数）**完全依赖 snapshot**——于是大会话下前端长期停在旧状态：

- token/s 看着极低（其实后端一直在快速输出）
- 输出不滚动，刷新页面才看到积压的真实结果

根因：**前端没有「实时增量」通道**，一切靠全量 snapshot（60ms/份）。现有唯一增量是 `tool_delta`（工具输出），不含 thinking / assistant 文本 / token。

## 方案

SDK 的 `session.subscribe` 已发出 `message_update` 事件（含 `assistantMessageEvent` = thinking/text 增量块，见 pi-agent-core types）。上游 `json-event.ts` 已证明这是标准做法（它专门把 `partial` 剥离成 delta）。

本 PR 借鉴 `tool_delta`，新增 `message_delta` 通道：

**后端** `server/agent-service.ts` onEvent 新增 `case "message_update"`：
- 转发 `assistantMessageEvent` 增量（`text_delta` / `thinking_delta` / `start` / `end`）
- **剥离 `partial`**（累计消息）——避免每个事件重序列化可能巨大的消息
- 附带实时 `usage`（token）——从 `session.getSessionStats().tokens` 取，因 `message_update` 的 `message.usage` 在流式期间为空（仅 message_end 填充）

**前端** `web/src/use-chat.ts`：
- reducer 按 `contentIndex` 增量 patch `streamingMessage` + `stats.tokens`
- 增量与 snapshot 自然收敛（下次 snapshot 整体替换为权威值）

**关键**：`message_delta` 不经 snapshot，`send()` 只对 `snapshot` 做背压丢弃，所以实时增量**不受背压影响**。

## 验证

- `npm run typecheck` ✅
- `npm run check:protocol` ✅（protocol 为唯一真源，types.ts 自动镜像）
- 生产实机（大会话 + 模拟慢前端触发背压）：message_delta 52/52 实时到达，`usage` 100% 随行；此前 token 不随实时增量、仅 snapshot 携带

## 备注

- 只做 text/thinking delta 的增量渲染；`toolcall`/`image`/消息边界等由 snapshot 收敛（保持改动聚焦）
- 若 upstream 已有更强的增量方向，本实现可作为基础