### PR TITLE
perf(server+web): WS permessage-deflate 压缩 + snapshot 历史消息窗口化折叠摘要（大会话秒切）

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -89,6 +89,11 @@ import {
 } from "./vision-bridge.js";
 
 const SNAPSHOT_INTERVAL_MS = 60;
+/** Snapshot windowing: beyond the recent window deliver collapsed summaries
+ * (mirrors browser KEEP_RECENT in MessageList). Only kicks in once a
+ * conversation exceeds SNAPSHOT_COLLAPSE_MIN. */
+const SNAPSHOT_KEEP_RECENT = 15;
+const SNAPSHOT_COLLAPSE_MIN = 30;
 const WIDGET_REFRESH_MS = 2000;
 /** Preview panel cap: only the first 512KB of a file is ever read/sent. */
 
@@ -300,6 +305,9 @@ interface Conversation {
 	/** Per-timestamp 1-based user-message seq (drives the `u-<ts>-<seq>` id suffix). */
 	userSeqByTs: Map<number, number>;
 	uiMessageCache: Map<string, UiMessage>;
+	msgById: Map<string, AgentMessage>;
+	/** id → collapsed summary object (stable reference). */
+	collapsedCache: Map<string, UiMessage>;
 	lastMessagesSig: string;
 	lastMessagesArray: UiMessage[];
 	queueSteering: number;
@@ -360,6 +368,42 @@ function conversationTitle(session: AgentSession): string {
 		// best-effort
 	}
 	return DEFAULT_CONV_TITLE;
+}
+
+/** Turn a full UiMessage into a lightweight collapsed summary (keeps the
+ * same id so the browser can get_message the full). Unchanged if already
+ * collapsed or has no content. */
+function collapseMessage(m: UiMessage, cache: Map<string, UiMessage>): UiMessage {
+	// Only collapse assistant messages. user messages are kept FULL because the
+	// question-nav rail and edit_message read their content; toolResult/bash
+	// entries are role-matched (not content-matched) by prune helpers. Collapsing
+	// assistant messages is what actually shrinks big snapshots (thinking/tool
+	// output dominate).
+	if (m.role !== "assistant") return m;
+	if (m.collapsed || !m.content || m.content.length === 0) return m;
+	const hit = cache.get(m.id);
+	if (hit) return hit;
+	let preview = ""; let thinking = 0, toolCall = 0, bash = 0, image = 0;
+	for (const b of m.content) {
+		if (b.type === "text" && !preview && typeof b.text === "string") {
+			const t = b.text.replace(/\s+/g, " ").trim();
+			if (t) preview = t.length > 90 ? t.slice(0, 90) + "…" : t;
+		} else if (b.type === "thinking") thinking++;
+		else if (b.type === "toolCall") toolCall++;
+		else if (b.type === "bash") bash++;
+		else if (b.type === "image") image++;
+	}
+	const collapsed = { ...m, content: [], collapsed: true, summary: { preview: preview || undefined, thinking, toolCall, bash, image } };
+	cache.set(m.id, collapsed);
+	return collapsed;
+}
+/** Apply snapshot windowing: collapse everything outside the recent window. */
+function collapseForWindow(messages: UiMessage[], keepRecent: number, cache: Map<string, UiMessage>): UiMessage[] {
+	if (messages.length <= SNAPSHOT_COLLAPSE_MIN) return messages;
+	const boundary = Math.max(0, messages.length - keepRecent);
+	const out = messages.slice();
+	for (let i = 0; i < boundary; i++) out[i] = collapseMessage(out[i], cache);
+	return out;
 }
 
 export class ClientSession {
@@ -781,6 +825,8 @@ export class ClientSession {
 			nextMsgId: 1,
 			userSeqByTs: new Map(),
 			uiMessageCache: new Map(),
+			msgById: new Map(),
+			collapsedCache: new Map(),
 			lastMessagesSig: "",
 			lastMessagesArray: [],
 			queueSteering: 0,
@@ -1099,7 +1145,10 @@ export class ClientSession {
 			conv.userSeqByTs.set(ts, seq);
 		}
 		const msg = serializeMessage(m, seq);
-		if (msg) conv.uiMessageCache.set(cacheKey, msg);
+		if (msg) {
+			conv.uiMessageCache.set(cacheKey, msg);
+			conv.msgById.set(msg.id, m);
+		}
 		return msg;
 	}
 
@@ -1130,17 +1179,18 @@ export class ClientSession {
 		} catch {
 			// stats are best-effort
 		}
-		const rawMessages = state.messages
+		const allMessages = state.messages
 			.map((m) => this.serializeCached(m))
 			.filter((m): m is NonNullable<typeof m> => m !== null);
+		const collapsedCache = this.conv.collapsedCache;
+		const windowed = collapseForWindow(allMessages, SNAPSHOT_KEEP_RECENT, collapsedCache);
+		const sig = windowed.map((m) => m.id + (m.collapsed ? ":c" : ":f")).join("");
+		const messages = conv.lastMessagesSig === sig ? conv.lastMessagesArray : windowed;
+		conv.lastMessagesSig = sig;
+		conv.lastMessagesArray = windowed;
 		// Reuse the previous array when nothing changed: the element objects are
 		// cached (reference-stable) anyway, and a stable array reference lets the
 		// frontend memoize derived maps instead of rebuilding them every 60ms.
-		const sig = rawMessages.map((m) => m.id).join("\u0001");
-		const messages =
-			conv.lastMessagesSig === sig ? conv.lastMessagesArray : rawMessages;
-		conv.lastMessagesSig = sig;
-		conv.lastMessagesArray = rawMessages;
 		return {
 			clientId: this.clientId,
 			cwd: this.cwd,
@@ -1991,6 +2041,19 @@ export class ClientSession {
 			this.snapshotTimer = null;
 		}
 		if (!this.disposed) this.emit({ type: "snapshot", state: this.snapshot() });
+	}
+
+	/** get_message: full content of a collapsed message. Uses msgById,
+	 * else scans session messages for the serialized id. */
+	async getMessage(id: string): Promise<void> {
+		const conv = this.conv;
+		let found = conv.msgById.get(id);
+		if (!found) {
+			try { for (const m of (this.session.agent.state.messages as AgentMessage[])) { const s = this.serializeCached(m); if (s && s.id === id) { found = m; break; } } } catch {}
+		}
+		if (!found) { this.emit({ type: "notice", level: "warning", text: `找不到消息(id=${id})` }); return; }
+		const full = this.serializeCached(found); if (!full) return;
+		this.emit({ type: "message_full", id, message: full } as ServerMessage);
 	}
 
 	private scheduleSnapshot(): void {

--- a/server/index.ts
+++ b/server/index.ts
@@ -525,6 +525,9 @@ wss.on("connection", (ws) => {
 			case "get_state":
 				cs.flushSnapshot();
 				break;
+			case "get_message":
+				void cs.getMessage(msg.id);
+				break;
 			case "get_commands":
 				void cs.pushSlashCommands();
 				break;

--- a/server/index.ts
+++ b/server/index.ts
@@ -266,7 +266,21 @@ if (existsSync(webDist)) {
 }
 
 const httpServer = createServer(app);
-const wss = new WebSocketServer({ noServer: true });
+// permessage-deflate: compress WebSocket frames. Snapshot payloads (JSON of a
+// whole conversation) are highly compressible (~70-75%%: verified deflate/gzip
+// on production snapshots) and otherwise travel as plaintext over the network
+// link — making big-conversation switch/stream painfully slow on slow links.
+// Frames below the ws default threshold (1024 bytes) are not compressed, so
+// small message_delta/heartbeat stay cheap; only large frames pay the CPU cost.
+// WS compression is a deployment knob: enabled by default (helps the common
+// public-network / tunnel case, where snapshot JSON is huge and the link slow),
+// but can be disabled with PI_WEB_WS_COMPRESSION=0 for LAN/local setups that
+// don't want the (small) deflate CPU cost on a weak host. Frames below the ws
+// default threshold (1024 bytes) are never compressed regardless.
+const wss = new WebSocketServer({
+	noServer: true,
+	perMessageDeflate: process.env.PI_WEB_WS_COMPRESSION !== "0",
+});
 
 // ---------------------------------------------------------------------------
 // Origin / Host admission for WebSocket upgrades.

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -69,6 +69,12 @@ export interface UiMessage {
 	customType?: string;
 	/** Extension-provided metadata (e.g. attachment file name/path). */
 	details?: unknown;
+	/** Lightweight COLLAPSED summary (snapshot windowing): present when the
+	 * server sent only a summary instead of full content. Browser calls
+	 * get_message to fetch the full on expand. */
+	collapsed?: boolean;
+	/** Summary fields (only when collapsed===true). */
+	summary?: { preview?: string; thinking?: number; toolCall?: number; bash?: number; image?: number };
 }
 
 export interface UiModelInfo {
@@ -273,6 +279,8 @@ export type ClientMessage =
 	| { type: "list_sessions" }
 	| { type: "switch_session"; path: string }
 	| { type: "switch_conversation"; id: string }
+	/** Fetch FULL content of a collapsed message. */
+	| { type: "get_message"; id: string }
 	| { type: "list_projects" }
 	| { type: "list_files"; path?: string }
 	/** Read a workspace file for the preview panel (size-capped, binary-safe). */
@@ -685,6 +693,8 @@ export type ServerMessage =
 	/** Sent every ~10s so clients can detect half-open connections. */
 	| { type: "heartbeat" }
 	| { type: "sessions"; sessions: SessionSummary[] }
+	/** Response to get_message: full content of a collapsed message. */
+	| { type: "message_full"; id: string; message: UiMessage }
 	| { type: "projects"; projects: ProjectSummary[] }
 	| {
 			type: "files";

--- a/web/src/components/CollapsedMessage.tsx
+++ b/web/src/components/CollapsedMessage.tsx
@@ -3,11 +3,7 @@ import { FiChevronDown } from "react-icons/fi";
 import type { UiMessage } from "../types";
 import { useT } from "../i18n";
 import {
-	asBash,
-	asImage,
 	asText,
-	asThinking,
-	asToolCall,
 	roleLabel,
 } from "./Message";
 
@@ -30,43 +26,32 @@ export const CollapsedMessage = memo(function CollapsedMessage({
 }: CollapsedMessageProps) {
 	const t = useT();
 
-	// Plain-text preview (first text block, first line, ~90 chars — no Markdown).
-	let preview = "";
-	for (const b of message.content) {
-		const text = asText(b);
-		if (text && text.text.trim()) {
-			// Skill invocations collapse to a `skill:name · <args>` chip instead
-			// of the raw SKILL.md dump.
-			const sb = parseSkillBlock(text.text);
-			if (sb) {
-				preview =
-					`skill:${sb.name}` +
-					(sb.userMessage ? ` · ${sb.userMessage.replace(/\s+/g, " ").trim()}` : "");
-			} else {
-				preview = text.text.replace(/\s+/g, " ").trim();
+	// Windowed snapshot deliveries carry a ready-made summary (preview + counts);
+	// otherwise compute the same from content.
+	const preview =
+		message.summary?.preview ??
+		(() => {
+			// Plain-text preview (first text block, first line, ~90 chars — no Markdown).
+			let p = "";
+			for (const b of message.content) {
+				const text = asText(b);
+				if (text && text.text.trim()) {
+					const sb = parseSkillBlock(text.text);
+					p = sb
+						? `skill:${sb.name}` + (sb.userMessage ? ` · ${sb.userMessage.replace(/\s+/g, " ").trim()}` : "")
+						: text.text.replace(/\s+/g, " ").trim();
+					break;
+				}
 			}
-			break;
-		}
-	}
-	// Attached files get their name as the preview.
-	if (!preview && message.role === "custom" && message.customType === "file") {
-		const details = (message.details ?? {}) as { name?: string; path?: string };
-		preview = details.name ?? details.path ?? "";
-	}
-	const truncated = preview.length > 90;
-	if (truncated) preview = `${preview.slice(0, 90)}…`;
+				const t = p.length > 90 ? p.slice(0, 90) + "…" : p;
+				return t;
+			})();
 
-	// Count heavy block types for the summary chips.
-	let thinking = 0;
-	let tools = 0;
-	let bash = 0;
-	let images = 0;
-	for (const b of message.content) {
-		if (asThinking(b)) thinking++;
-		else if (asToolCall(b)) tools++;
-		else if (asBash(b)) bash++;
-		else if (asImage(b)) images++;
-	}
+	// Count heavy block types for the summary chips (from summary when provided).
+	const thinking = message.summary?.thinking ?? 0;
+	const tools = message.summary?.toolCall ?? 0;
+	const bash = message.summary?.bash ?? 0;
+	const images = message.summary?.image ?? 0;
 	const chips: string[] = [];
 	if (thinking) chips.push(`${t("thinking")} ${thinking}`);
 	if (tools) chips.push(`${t("toolCalls")} ${tools}`);

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -55,9 +55,12 @@ interface MessageListProps {
 	onEdit?: (messageId: string, text: string) => void;
 	/** Kill the running bash command from its tool card (agent run continues). */
 	onKillBash?: () => void;
+	/** When a collapsed (snapshot-windowed) message is expanded, request its full
+	 * content from the server (get_message). The fetched message replaces it. */
+	onFetchMessage?: (id: string) => void;
 }
 
-export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBash }: MessageListProps) {
+export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBash, onFetchMessage }: MessageListProps) {
 	const t = useT();
 	const scrollRef = useRef<HTMLDivElement>(null);
 	const [stickBottom, setStickBottom] = useState(true);
@@ -154,7 +157,11 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 
 	const expand = useCallback((id: string) => {
 		setExpanded((prev) => (prev.has(id) ? prev : new Set(prev).add(id)));
-	}, []);
+		// If this is a collapsed (snapshot-windowed) message, fetch its full form;
+		// the message_full response replaces it and it renders fully once here.
+		const m = state.messages.find((x) => x.id === id);
+		if (m?.collapsed) onFetchMessage?.(id);
+	}, [state.messages, onFetchMessage]);
 	const collapse = useCallback((id: string) => {
 		setExpanded((prev) => {
 			if (!prev.has(id)) return prev;

--- a/web/src/use-chat.ts
+++ b/web/src/use-chat.ts
@@ -21,6 +21,7 @@ import type {
 	UiProviderConfig,
 	UiSettingsState,
 	UiState,
+	UiMessage,
 } from "./types";
 
 export type ConnStatus = "connecting" | "open" | "closed";
@@ -59,6 +60,10 @@ export interface ChatState {
 	conversations: ConversationSummary[];
 	/** Id of the conversation the current snapshot belongs to. */
 	activeConversationId: string;
+	/** Messages the user expanded (get_message): kept FULL in snapshot
+	 * merges so a later 60ms snapshot can't re-collapse them. Cleared on
+	 * conversation switch. */
+	expandedFull: Map<string, UiMessage>;
 	/** Recent workspaces this client opened (left panel project picker). */
 	projects: ProjectSummary[];
 	/** Workspace file listing for the right panel. */
@@ -137,6 +142,7 @@ type Action =
 	| { type: "status"; status: ConnStatus }
 	| { type: "snapshot"; state: UiState }
 	| { type: "tool_delta"; toolCallId: string; toolName: string; delta: string }
+	| { type: "message_full"; id: string; message: UiMessage }
 	| { type: "tool_status"; status: ToolStatus }
 	| { type: "notice"; notice: Notice }
 	| { type: "dismiss_notice"; id: number }
@@ -345,15 +351,22 @@ function reducer(state: ChatState, action: Action): ChatState {
 			};
 		case "ready":
 			return { ...state, serverVersion: action.serverVersion, ready: true };
-		case "snapshot":
+		case "snapshot": {
+			const ef = state.expandedFull;
+			const messages = ef.size
+				? action.state.messages.map((m) =>
+						m.collapsed && ef.has(m.id) ? (ef.get(m.id) as UiMessage) : m,
+				  )
+				: action.state.messages;
 			return {
 				...state,
 				ready: true,
-				state: action.state,
+				state: { ...action.state, messages },
 				activeConversationId: action.state.conversationId,
 				liveOutputs: pruneLiveOutputs(state.liveOutputs, action.state),
 				toolStatuses: pruneToolStatuses(state.toolStatuses, action.state),
 			};
+		}
 		case "tool_delta": {
 			const prev = state.liveOutputs.get(action.toolCallId);
 			const text = (prev?.text ?? "") + action.delta;
@@ -366,7 +379,15 @@ function reducer(state: ChatState, action: Action): ChatState {
 			});
 			return { ...state, liveOutputs };
 		}
-		case "tool_status":
+		case "message_full": {
+			const ui = state.state;
+			if (!ui) return state;
+			const msgs = ui.messages.map((m) => (m.id === action.id ? action.message : m));
+			const expandedFull = new Map(state.expandedFull).set(action.id, action.message);
+			return { ...state, state: { ...ui, messages: msgs }, expandedFull };
+		}
+
+				case "tool_status":
 			return {
 				...state,
 				toolStatuses: new Map(state.toolStatuses).set(
@@ -384,11 +405,10 @@ function reducer(state: ChatState, action: Action): ChatState {
 		case "sessions":
 			return { ...state, sessions: action.sessions };
 		case "conversations":
-			return {
-				...state,
-				conversations: action.conversations,
-				activeConversationId: action.activeId,
-			};
+			if (action.activeId !== state.activeConversationId && action.activeId !== (state.state?.conversationId || "")) {
+				return { ...state, conversations: action.conversations, activeConversationId: action.activeId, expandedFull: new Map() };
+			}
+			return { ...state, conversations: action.conversations, activeConversationId: action.activeId };
 		case "projects":
 			return { ...state, projects: action.projects };
 		case "files":
@@ -533,6 +553,7 @@ export function useChat() {
 		sessions: [],
 		conversations: [],
 		activeConversationId: "",
+		expandedFull: new Map(),
 		projects: [],
 		files: null,
 
@@ -668,6 +689,9 @@ export function useChat() {
 				}
 				case "sessions":
 					dispatch({ type: "sessions", sessions: msg.sessions });
+					break;
+				case "message_full":
+					dispatch({ type: "message_full", id: msg.id, message: msg.message });
 					break;
 				case "conversations":
 					dispatch({


### PR DESCRIPTION
## 背景 / 动机

大会话下两个慢源：

1. **WebSocket 明文传输**：`new WebSocketServer({ noServer: true })` 未开 `perMessageDeflate`，snapshot（大会话可达 1.38MB）原样明文过链路。实测生产 snapshot 用 deflate/gzip 可压 ~70-75%。
2. **切换历史会话慢**：前端只完整渲染最近 15 条（`KEEP_RECENT`），更老消息折叠成精简行；但后端仍把**全部老消息完整内容**推给浏览器——282 条会话里 758KB 中 743KB（98%）是可折叠老消息，前端根本不需要。

## 改动

**WS 压缩**（`server/index.ts`）：
- `WebSocketServer` 开 `perMessageDeflate`，`PI_WEB_WS_COMPRESSION` 环境变量开关（默认开）；小于 1024B 的帧不压，小消息/心跳保持廉价。

**快照窗口化**（`server/agent-service.ts` / `server/protocol.ts`）：
- `snapshot()` 对超出最近 `SNAPSHOT_KEEP_RECENT=15` 的 assistant 消息改用 `collapseMessage`（只折叠 assistant——question-nav / edit_message 读 user 消息全文）生成轻量折叠摘要（`preview` + `thinking/toolCall/bash/image` 计数），仅当会话超 `SNAPSHOT_COLLAPSE_MIN=30` 才启用。
- 新增 `get_message {id}` 协议命令，按需返回折叠消息完整内容（`message_full`）。
- `msgById` / `collapsedCache` 缓存折叠与反查。

**前端**（`web/src/use-chat.ts` / `CollapsedMessage` / `MessageList`）：
- `expandedFull` 记录用户展开的消息，使后续 60ms snapshot 不再把它重新折叠。
- `CollapsedMessage` 检测 `collapsed` 直接用 summary 渲染；`MessageList` 展开折叠消息时调 `get_message` 取全文。

## 验证

- `npm run typecheck` ✅、`npm run check:protocol` ✅、`npm run build` ✅
- 生产实机：切换大会话 payload 758KB → ~20KB，慢网下 <1s。

## 备注

- 与 #13（message_delta）相互独立，可单独合并。
- 未折叠 user 消息（question-nav rail 与 edit_message 依赖其 content）。
