### PR TITLE
fix(web): 移动端左栏 drawer 不应被只读 list_/get_ 查询立即收回

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -201,7 +201,16 @@ export function App() {
 	// so RightPanel's polling effect doesn't churn (send is stable).
 	const panelSend = useCallback(
 		(msg: ClientMessage) => {
-			setDrawer(null);
+			// Only close the mobile drawer on an explicit navigation/action. Mounting
+			// LeftPanel fires read-only list_* probes that must NOT collapse the
+			// freshly-opened drawer (they run through panelSend too). Otherwise the
+			// drawer opens and immediately snaps shut.
+			if (
+				!msg.type.startsWith("list_") &&
+				!msg.type.startsWith("get_")
+			) {
+				setDrawer(null);
+			}
 			return send(msg);
 		},
 		[send],
@@ -390,6 +399,7 @@ export function App() {
 								toolStatuses={chat.toolStatuses}
 								onEdit={onEditMessage}
 								onKillBash={() => send({ type: "abort_bash" })}
+								onFetchMessage={(id) => send({ type: "get_message", id })}
 							/>
 						) : (
 							<div className="boot-wait">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -399,7 +399,6 @@ export function App() {
 								toolStatuses={chat.toolStatuses}
 								onEdit={onEditMessage}
 								onKillBash={() => send({ type: "abort_bash" })}
-								onFetchMessage={(id) => send({ type: "get_message", id })}
 							/>
 						) : (
 							<div className="boot-wait">


### PR DESCRIPTION
## 背景 / 动机

手机/窄窗口点左上三横线，左栏 drawer（LeftPanel）弹出动画刚结束就被立即收回，随后再点失灵。

**根因**：`panelSend`（LeftPanel 的 send 包装）无条件 `setDrawer(null)`；而 LeftPanel 挂载时 `useEffect` 立即发只读 `list_sessions` / `list_projects` 探针（也走 panelSend）→ drawer 刚打开就被收回；首次后 state 错乱致再点失灵。

## 改动

`web/src/App.tsx` 的 `panelSend`：仅对主动导航/操作命令（非 `list_` / `get_` 前缀，即 `set_cwd` / `switch_*` / `new_chat` 等）关 drawer，只读查询不关。

## 验证

- `npm run typecheck` ✅
- 生产实机手机 + 窄窗口验收 OK：drawer 正常弹开保持，点会话/目录才关闭。
