### PR TITLE
Fix: keep background runs alive when opening history sessions

### DIFF
--- a/docs/architecture-core.md
+++ b/docs/architecture-core.md
@@ -61,7 +61,7 @@
 - 上限 `MAX_OPEN_CONVERSATIONS = 8` **按项目计**，超出时 new_chat 发 warning notice。
 - 所有对话共享**一个 ModelRuntime**（首个对话创建时播种，`makeRuntimeFactory` 传入复用）——顶栏换模型对全部对话生效。**消息序列化缓存（msgIds/uiMessageCache/签名）按对话隔离**：两个对话可能产生相同的 (role, timestamp) 键，共享会串号。
 - `snapshot` 带 `conversationId`；`conversations`（ServerMessage）只推**当前项目已入列**的对话 + `activeId`（activeId 可能未入列，如刚 new_chat 还没跑过）；`switch_conversation`（ClientMessage）只在同项目内切换。
-- 行为不变的部分：`switch_session`（恢复持久会话）替换**当前**对话的 runtime（成功后视作已继续）；`edit_message` 在**当前**对话内 fork；`dispose` 遍历销毁全部对话；attachSink 重连时补推 conversations。
+- `switch_session`（恢复持久会话）会为目标会话创建独立 runtime，再按上述生命周期把当前对话移到后台；若目标会话已在运行列表中则直接复用其 conversation，绝不因打开历史记录中断当前生成。回归测试：`tests/switch-session-background-test.mjs`。`edit_message` 在**当前**对话内 fork；`dispose` 遍历销毁全部对话；attachSink 重连时补推 conversations。
 - 前端：左栏「运行的对话」区（≥1 个时显示，活跃高亮、流式绿点），MessageList 以 conversationId 为 key 强制切换重挂载。
 
 ## 其他桥接

--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -2571,24 +2571,94 @@ export class ClientSession {
 		}
 	}
 
-	/** Switch the active session to a persisted one (from listSessions). */
+	/** Open a persisted session as the active conversation (from listSessions).
+	 *
+	 * A persisted-session click must follow the same ownership rule as
+	 * new_chat/switch_conversation: every open conversation keeps its own
+	 * runtime. AgentSessionRuntime.switchSession() tears down (and aborts) the
+	 * current runtime, which would otherwise stop a response merely because the
+	 * user opened history while it was streaming.
+	 */
 	async switchSession(path: string): Promise<void> {
 		if (this.quiesceBlocked()) return;
+		let openedRuntime: AgentSessionRuntime | null = null;
+		let openedTerminals: TerminalManager | null = null;
 		try {
-			await this.runtime.switchSession(path);
-			await this.bindSession();
-			// The resumed session carries its own cwd — sync it into the ACTIVE
-			// conversation (other open conversations are untouched).
-			this.conv.cwd = this.runtime.cwd;
-			this.cwd = this.runtime.cwd;
-			this.conv.title = conversationTitle(this.runtime.session);
+			const targetPath = resolve(path);
+
+			// A session may already be open in the running-conversation map. Reuse it
+			// instead of creating a second writer for the same JSONL transcript.
+			for (const conv of this.convs.values()) {
+				const sessionFile = conv.session.sessionFile;
+				if (sessionFile && resolve(sessionFile) === targetPath) {
+					await this.switchConversation(conv.id);
+					return;
+				}
+			}
+
+			const sessionManager = SessionManager.open(targetPath);
+			const targetCwd = sessionManager.getCwd();
+			const conversationId = this.nextConversationId();
+			openedTerminals = this.makeTerminalManager(conversationId, targetCwd);
+			openedRuntime = await createAgentSessionRuntime(
+				this.makeRuntimeFactory(openedTerminals),
+				{
+					cwd: targetCwd,
+					agentDir: this.agentDir,
+					sessionManager,
+				},
+			);
+
+			// Only displace the old active conversation after the replacement runtime
+			// is known-good. This keeps a failed history open entirely non-destructive.
+			const oldListed = this.conv.listed;
+			const displaced = this.displaceActive();
+			const openInProject =
+				[...this.convs.values()].filter((c) => c.cwd === targetCwd).length +
+				1 -
+				(displaced?.cwd === targetCwd ? 1 : 0);
+			if (openInProject > MAX_OPEN_CONVERSATIONS) {
+				// displaceActive() may have promoted a streaming conversation into the
+				// running list. Roll that presentation-only mutation back because no
+				// switch will take place.
+				this.conv.listed = oldListed;
+				openedTerminals.killAll();
+				await openedRuntime.dispose();
+				openedRuntime = null;
+				openedTerminals = null;
+				this.emit({
+					type: "notice",
+					level: "warning",
+					text: `当前项目运行的对话已达上限（${MAX_OPEN_CONVERSATIONS} 个），请先打开某个对话并离开（不继续对话）以移出列表`,
+				});
+				return;
+			}
+
+			const conv = this.makeConversation(
+				openedRuntime,
+				conversationId,
+				openedTerminals,
+			);
 			// Deliberately resumed — must not be dismissed when the user later
 			// switches away without sending a new message.
-			this.conv.promptedSinceActive = true;
+			conv.promptedSinceActive = true;
+			this.convs.set(conv.id, conv);
+			this.activeId = conv.id;
+			openedRuntime = null;
+			openedTerminals = null;
+			if (displaced) this.removeConversation(displaced.id);
+			await this.bindSession();
+			this.cwd = targetCwd;
+			this.conv.lastActiveAt = Date.now();
+			this.webUi.refresh();
 			this.emitConversations();
-			// switchSession replaced the runtime — its resource cache is fresh.
+			this.goalSvc.emitGoalStatus();
+			this.pushTerminals();
+			// The restored conversation has a fresh project-bound resource cache.
 			void this.pushSlashCommands();
 		} catch (err) {
+			openedTerminals?.killAll();
+			if (openedRuntime) await openedRuntime.dispose().catch(() => {});
 			this.emit({
 				type: "notice",
 				level: "error",

--- a/tests/switch-session-background-test.mjs
+++ b/tests/switch-session-background-test.mjs
@@ -1,0 +1,249 @@
+// Opening a persisted history session must not abort a response that is
+// already streaming in another conversation.
+//
+// Usage: npm run build && node tests/switch-session-background-test.mjs [port]
+import { createServer } from "node:http";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { realpathSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+import WebSocket from "ws";
+
+const PORT = Number(process.argv[2] || 8955);
+const MOCK_PORT = PORT + 1;
+const base = mkdtempSync(join(tmpdir(), "pi-web-switch-session-"));
+const workdir = join(base, "work");
+const dataDir = join(base, "data");
+const agentDir = join(base, "agent");
+mkdirSync(workdir, { recursive: true });
+mkdirSync(dataDir, { recursive: true });
+mkdirSync(agentDir, { recursive: true });
+
+const mock = createServer(async (req, res) => {
+	let body = "";
+	for await (const chunk of req) body += chunk;
+	let payload;
+	try {
+		payload = JSON.parse(body);
+	} catch {
+		res.writeHead(400).end("bad json");
+		return;
+	}
+	const last = payload.messages?.at(-1);
+	const prompt = typeof last?.content === "string"
+		? last.content
+		: last?.content?.filter?.((part) => part.type === "text").map((part) => part.text).join(" ") ?? "";
+	const slow = prompt.includes("SLOW");
+	const first = slow ? "background-" : "seed-";
+	const lastChunk = slow ? "finished" : "message";
+	res.writeHead(200, {
+		"content-type": "text/event-stream",
+		"cache-control": "no-cache",
+	});
+	const writeChunk = (content) => res.write(
+		`data: ${JSON.stringify({
+			id: "switch-session-test",
+			object: "chat.completion.chunk",
+			created: Date.now(),
+			model: payload.model,
+			choices: [{ index: 0, delta: { content }, finish_reason: null }],
+		})}\n\n`,
+	);
+	writeChunk(first);
+	if (slow) await sleep(2500);
+	writeChunk(lastChunk);
+	res.write(
+		`data: ${JSON.stringify({
+			id: "switch-session-test",
+			object: "chat.completion.chunk",
+			created: Date.now(),
+			model: payload.model,
+			choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+		})}\n\n`,
+	);
+	res.write("data: [DONE]\n\n");
+	res.end();
+});
+await new Promise((resolve) => mock.listen(MOCK_PORT, "127.0.0.1", resolve));
+
+writeFileSync(
+	join(agentDir, "auth.json"),
+	JSON.stringify({ main: { type: "api_key", key: "switch-session-test" } }),
+);
+writeFileSync(
+	join(agentDir, "models.json"),
+	JSON.stringify({
+		providers: {
+			main: {
+				api: "openai-completions",
+				baseUrl: `http://127.0.0.1:${MOCK_PORT}`,
+				apiKey: "switch-session-test",
+				models: [{
+					id: "switch-session-mock",
+					name: "Switch Session Mock",
+					input: ["text"],
+					contextWindow: 32000,
+					maxTokens: 4096,
+				}],
+			},
+		},
+	}),
+);
+
+const repoRoot = realpathSync(new URL("../", import.meta.url));
+const server = spawn(process.execPath, ["dist/server/index.js"], {
+	cwd: repoRoot,
+	env: {
+		...process.env,
+		PORT: String(PORT),
+		PI_WEB_DATA_DIR: dataDir,
+		PI_WEB_CWD: workdir,
+		PI_CODING_AGENT_DIR: agentDir,
+	},
+	stdio: "ignore",
+	windowsHide: true,
+});
+
+const waitForPort = async (port, timeout = 15000) => {
+	const started = Date.now();
+	while (Date.now() - started < timeout) {
+		try {
+			const response = await fetch(`http://127.0.0.1:${port}/health`);
+			if (response.ok) return;
+		} catch {
+			/* starting */
+		}
+		await sleep(100);
+	}
+	throw new Error(`server did not start on ${port}`);
+};
+
+class Client {
+	constructor(ws) {
+		this.ws = ws;
+		this.received = [];
+		this.state = null;
+		this.messages = [];
+		this.conversations = [];
+		ws.on("message", (data) => {
+			const message = JSON.parse(data.toString());
+			this.received.push(message);
+			if (message.type === "snapshot") {
+				this.state = message.state;
+				this.messages = message.state.messages ?? [];
+			} else if (
+				message.type === "snapshot_delta" &&
+				this.state &&
+				this.state.rev === message.baseRev &&
+				message.conversationId === this.state.conversationId
+			) {
+				this.state = { ...this.state, ...message.state };
+				this.messages = [...this.messages, ...message.appended];
+			} else if (message.type === "conversations") {
+				this.conversations = message.conversations;
+			}
+		});
+	}
+	send(message) {
+		this.ws.send(JSON.stringify(message));
+	}
+	async waitForType(type, predicate = () => true, timeout = 15000) {
+		const started = Date.now();
+		while (Date.now() - started < timeout) {
+			for (let i = 0; i < this.received.length; i++) {
+				const message = this.received[i];
+				if (message.type !== type || !predicate(message)) continue;
+				this.received.splice(i, 1);
+				return message;
+			}
+			await sleep(50);
+		}
+		throw new Error(`timeout waiting for ${type}`);
+	}
+	async waitForState(predicate, timeout = 15000) {
+		const started = Date.now();
+		while (Date.now() - started < timeout) {
+			if (this.state && predicate(this.state)) return this.state;
+			await sleep(50);
+		}
+		throw new Error("timeout waiting for state");
+	}
+	async waitForMessage(predicate, timeout = 15000) {
+		const started = Date.now();
+		while (Date.now() - started < timeout) {
+			const message = this.messages.find(predicate);
+			if (message) return message;
+			await sleep(50);
+		}
+		throw new Error("timeout waiting for message");
+	}
+}
+
+let client;
+try {
+	await waitForPort(PORT);
+	const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
+	await new Promise((resolve, reject) => {
+		ws.once("open", resolve);
+		ws.once("error", reject);
+	});
+	client = new Client(ws);
+	client.send({ type: "hello", clientId: "switch-session-background-test" });
+	await client.waitForType("ready");
+	await client.waitForState((state) => Boolean(state.conversationId));
+
+	client.send({ type: "set_model", modelId: "main/switch-session-mock" });
+	await client.waitForState((state) => state.model?.id === "switch-session-mock");
+
+	client.send({ type: "prompt", text: "seed" });
+	await client.waitForMessage((message) => message.role === "assistant");
+	const historyPath = client.state.sessionFile;
+	if (!historyPath) throw new Error("seed session was not persisted");
+
+	const seedConversationId = client.state.conversationId;
+	client.send({ type: "new_chat" });
+	await client.waitForState((state) => state.conversationId !== seedConversationId);
+
+	client.send({ type: "prompt", text: "SLOW background run" });
+	const streamingState = await client.waitForState(
+		(state) => state.isStreaming && state.conversationId !== seedConversationId,
+	);
+	const backgroundConversationId = streamingState.conversationId;
+
+	client.send({ type: "switch_session", path: historyPath });
+	await client.waitForState((state) => state.conversationId !== backgroundConversationId);
+	await client.waitForType(
+		"conversations",
+		(message) => message.conversations.some(
+			(conversation) =>
+				conversation.id === backgroundConversationId && conversation.isStreaming,
+		),
+	);
+	console.log("✓ history switch leaves the active stream running in background");
+
+	await client.waitForType(
+		"conversations",
+		(message) => message.conversations.some(
+			(conversation) =>
+				conversation.id === backgroundConversationId && !conversation.isStreaming,
+		),
+		15000,
+	);
+	client.send({ type: "switch_conversation", id: backgroundConversationId });
+	await client.waitForState((state) => state.conversationId === backgroundConversationId);
+	await client.waitForMessage(
+		(message) =>
+			message.role === "assistant" &&
+			JSON.stringify(message.content).includes("background-finished"),
+	);
+	console.log("✓ background response completes and remains recoverable");
+} catch (error) {
+	console.error(`✗ ${error.message}`);
+	process.exitCode = 1;
+} finally {
+	client?.ws.close();
+	server.kill();
+	mock.close();
+}


### PR DESCRIPTION
# Fix: keep background runs alive when opening history sessions

## What changed

- Open persisted history sessions as independent `AgentSessionRuntime` instances.
- Reuse an already-open conversation when its session file is selected, avoiding duplicate JSONL writers.
- Apply the existing conversation displacement and per-project runtime cap after the target runtime is ready.
- Keep failed history opens non-destructive and clean up the temporary runtime.
- Document the concurrency behavior and add an end-to-end regression test.

## Verification

- `npm run typecheck`
- `npm run build`
- `npm test` — 18 files, 151 tests passed
- `node tests/switch-session-background-test.mjs` — background response continued and was recovered
- `node tests/conv-cwd-test.mjs` — passed
- Playwright smoke check against `http://localhost:8787/` — page, history list, and chat input loaded
