### PR TITLE
feat(markdown): add mermaid diagram rendering and UI polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "compression": "^1.8.1",
         "express": "^4.21.2",
         "highlight.js": "^11.10.0",
+        "mermaid": "^11.17.2",
         "node-pty": "^1.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -49,6 +50,19 @@
       },
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -332,6 +346,18 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmmirror.com/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmmirror.com/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -2775,6 +2801,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmmirror.com/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2981,6 +3024,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/@mermaid-js/parser/-/parser-1.2.1.tgz",
+      "integrity": "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
@@ -3596,6 +3648,259 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmmirror.com/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmmirror.com/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/@types/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmmirror.com/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/@types/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmmirror.com/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -3662,6 +3967,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmmirror.com/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.5",
@@ -3823,6 +4134,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -3852,6 +4170,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
       "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -5327,6 +5655,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/crc": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
@@ -5404,6 +5741,532 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.2",
+      "resolved": "https://registry.npmmirror.com/cytoscape/-/cytoscape-3.34.2.tgz",
+      "integrity": "sha512-Cm2jaj1X/PBNlzV9yH8zcfGOxO7U+CJ/+mxSBVPSchLaugdp4jtlGx5qaHtPRZ6tgiZ5P+o1XoRfJA+ba6KM3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmmirror.com/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmmirror.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmmirror.com/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmmirror.com/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmmirror.com/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmmirror.com/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmmirror.com/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.23",
+      "resolved": "https://registry.npmmirror.com/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -5486,6 +6349,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -5654,6 +6526,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
@@ -6008,6 +6889,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmmirror.com/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types",
+        "tests/browser-compat"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.28.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
@@ -6215,6 +7108,15 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastdom": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmmirror.com/fastdom/-/fastdom-1.0.12.tgz",
+      "integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
+      "license": "MIT",
+      "dependencies": {
+        "strictdom": "^1.0.1"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -6630,6 +7532,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmmirror.com/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6944,6 +7852,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -6994,6 +7912,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.5.0",
@@ -7267,6 +8194,31 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmmirror.com/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmmirror.com/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7276,6 +8228,17 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/lazy-val": {
       "version": "1.0.5",
@@ -7339,6 +8302,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmmirror.com/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -7568,6 +8537,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmmirror.com/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7865,6 +8846,36 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.17.2",
+      "resolved": "https://registry.npmmirror.com/mermaid/-/mermaid-11.17.2.tgz",
+      "integrity": "sha512-V6K3C8EBdEsPFZXSKMJe6ppQOENxuHARr9GvHX4hh47lAbhMRD9qf4oEK7LoaRQxULMa80/qt5gHO73aCleBBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.34.0",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.21",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "fastdom": "1.0.12",
+        "katex": "^0.16.47",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/methods": {
@@ -9003,6 +10014,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmmirror.com/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -9036,6 +10053,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -9165,6 +10188,22 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmmirror.com/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -9647,6 +10686,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.62.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
@@ -9692,6 +10737,24 @@
         "@rollup/rollup-win32-x64-msvc": "4.62.4",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmmirror.com/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -10139,6 +11202,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strictdom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/strictdom/-/strictdom-1.0.1.tgz",
+      "integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -10238,6 +11307,12 @@
       "dependencies": {
         "inline-style-parser": "0.2.7"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmmirror.com/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
@@ -10351,7 +11426,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
       "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10451,6 +11525,15 @@
       "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {
@@ -10738,6 +11821,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmmirror.com/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "compression": "^1.8.1",
     "express": "^4.21.2",
     "highlight.js": "^11.10.0",
+    "mermaid": "^11.17.2",
     "node-pty": "^1.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/themes/light.css
+++ b/themes/light.css
@@ -3506,6 +3506,59 @@ body.panel-resizing {
 	line-height: 1.55;
 }
 
+/* Mermaid diagrams rendered from ```mermaid fenced code blocks (see
+   components/MermaidDiagram.tsx). Mirrors .codeblock chrome so a doc mixing
+   diagrams and code reads as one visual family. */
+.mermaid-block {
+	position: relative;
+	margin: 10px 0;
+	padding: 18px;
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	/* Diagrams read best on their own light "paper" card — matching mermaid's
+	   base theme (see MermaidDiagram.tsx) rather than the app's dark chrome
+	   keeps flowchart boxes/text legible instead of a muddy low-contrast box. */
+	background: #ffffff;
+	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 8px 20px rgba(0, 0, 0, 0.25);
+	overflow-x: auto;
+	display: flex;
+	justify-content: center;
+}
+.mermaid-svg {
+	width: 100%;
+	display: flex;
+	justify-content: center;
+}
+.mermaid-svg svg {
+	max-width: 100%;
+	height: auto;
+}
+.mermaid-block-loading {
+	width: 100%;
+	padding: 4px 2px;
+	color: var(--text-dim);
+	font-size: 12.5px;
+	text-align: center;
+	background: transparent;
+	box-shadow: none;
+}
+.mermaid-block-error {
+	display: block;
+	background: transparent;
+	box-shadow: none;
+	border-color: rgba(239, 68, 68, 0.35);
+}
+.mermaid-error-note {
+	width: 100%;
+	padding: 4px 2px;
+	font-size: 12.5px;
+	text-align: left;
+	color: #f87171;
+}
+.mermaid-block-error .codeblock {
+	margin: 8px 0 0;
+}
+
 .copy-btn {
 	position: absolute;
 	top: 8px;
@@ -3525,6 +3578,9 @@ body.panel-resizing {
 	transition: opacity 0.15s;
 }
 .codeblock:hover .copy-btn {
+	opacity: 1;
+}
+.mermaid-block:hover .copy-btn {
 	opacity: 1;
 }
 .copy-btn:hover {
@@ -3648,23 +3704,22 @@ body.panel-resizing {
 /* Blinking caret shown while the assistant message is streaming. */
 .stream-cursor {
 	display: inline-block;
-	width: 8px;
-	height: 1.05em;
-	margin-left: 3px;
+	width: 2px;
+	height: 1em;
+	margin-left: 4px;
 	vertical-align: text-bottom;
 	border-radius: 1px;
 	background: var(--accent);
-	animation: stream-blink 1s steps(2, start) infinite;
+	animation: stream-blink 1s ease-in-out infinite;
 }
 
 @keyframes stream-blink {
 	0%,
-	49% {
+	100% {
 		opacity: 1;
 	}
-	50%,
-	100% {
-		opacity: 0;
+	50% {
+		opacity: 0.15;
 	}
 }
 
@@ -3824,11 +3879,45 @@ body.panel-resizing {
 }
 
 .toolcall-output-label {
+	display: flex;
+	align-items: center;
+	gap: 6px;
 	font-size: 11px;
 	text-transform: uppercase;
 	letter-spacing: 0.6px;
 	color: var(--text-faint);
 	margin-bottom: 4px;
+}
+.toolcall-output-spacer {
+	flex: 1;
+}
+.toolcall-md-toggle {
+	border: none;
+	background: transparent;
+	color: var(--text-faint);
+	text-transform: none;
+	letter-spacing: normal;
+	font-size: 11px;
+	cursor: pointer;
+	padding: 2px 6px;
+	border-radius: 5px;
+}
+.toolcall-md-toggle:hover {
+	color: var(--text);
+	background: var(--bg-elev2);
+}
+/* Rendered Markdown output (a `read` on a .md file) — same card chrome as
+   the raw <pre>, but hosts prose instead of monospace text. */
+.toolcall-markdown {
+	max-height: 420px;
+	overflow: auto;
+	background: var(--bg-elev2);
+	border: 1px solid var(--border-soft);
+	border-radius: 6px;
+	padding: 10px 14px;
+}
+.toolcall-markdown .md {
+	font-size: 13px;
 }
 
 .toolcall-output pre {
@@ -3861,17 +3950,22 @@ body.panel-resizing {
 
 .cursor {
 	display: inline-block;
-	width: 7px;
+	width: 2px;
 	height: 13px;
 	background: var(--accent);
+	border-radius: 1px;
 	vertical-align: -2px;
 	margin-left: 4px;
-	animation: blink 1s steps(2, start) infinite;
+	animation: blink 1s ease-in-out infinite;
 }
 
 @keyframes blink {
+	0%,
+	100% {
+		opacity: 1;
+	}
 	50% {
-		opacity: 0;
+		opacity: 0.15;
 	}
 }
 
@@ -6247,9 +6341,11 @@ body.panel-resizing {
 	min-height: 0;
 	overflow: auto;
 	padding: 22px clamp(18px, 4vw, 48px) 34px;
+	/* Light themes: no dark wash — that rule was copied from the dark theme
+	   verbatim and muddied a light background into a gray-lavender smear. */
 	background:
-		radial-gradient(circle at 10% 0%, rgba(139, 92, 246, 0.08), transparent 34%),
-		rgba(0, 0, 0, 0.22);
+		radial-gradient(circle at 10% 0%, rgba(139, 92, 246, 0.06), transparent 34%),
+		var(--bg);
 	color: var(--text);
 	font-size: 14px;
 	line-height: 1.8;
@@ -6427,6 +6523,13 @@ body.panel-resizing {
 .fp-markdown .codeblock pre code {
 	white-space: pre;
 	word-break: normal;
+}
+.fp-markdown .mermaid-block {
+	max-width: 100%;
+	min-width: 0;
+	margin: 1.1em 0;
+	padding: 18px;
+	border-radius: 10px;
 }
 .fp-markdown img {
 	display: block;

--- a/themes/md-preview.css
+++ b/themes/md-preview.css
@@ -3745,6 +3745,59 @@ span.msg-editor-hint svg {
 	line-height: 1.55;
 }
 
+/* Mermaid diagrams rendered from ```mermaid fenced code blocks (see
+   components/MermaidDiagram.tsx). Mirrors .codeblock chrome so a doc mixing
+   diagrams and code reads as one visual family. */
+.mermaid-block {
+	position: relative;
+	margin: 10px 0;
+	padding: 18px;
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	/* Diagrams read best on their own light "paper" card — matching mermaid's
+	   base theme (see MermaidDiagram.tsx) rather than the app's dark chrome
+	   keeps flowchart boxes/text legible instead of a muddy low-contrast box. */
+	background: #ffffff;
+	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 8px 20px rgba(0, 0, 0, 0.25);
+	overflow-x: auto;
+	display: flex;
+	justify-content: center;
+}
+.mermaid-svg {
+	width: 100%;
+	display: flex;
+	justify-content: center;
+}
+.mermaid-svg svg {
+	max-width: 100%;
+	height: auto;
+}
+.mermaid-block-loading {
+	width: 100%;
+	padding: 4px 2px;
+	color: var(--text-dim);
+	font-size: 12.5px;
+	text-align: center;
+	background: transparent;
+	box-shadow: none;
+}
+.mermaid-block-error {
+	display: block;
+	background: transparent;
+	box-shadow: none;
+	border-color: rgba(239, 68, 68, 0.35);
+}
+.mermaid-error-note {
+	width: 100%;
+	padding: 4px 2px;
+	font-size: 12.5px;
+	text-align: left;
+	color: #f87171;
+}
+.mermaid-block-error .codeblock {
+	margin: 8px 0 0;
+}
+
 .copy-btn {
 	position: absolute;
 	top: 8px;
@@ -3764,6 +3817,9 @@ span.msg-editor-hint svg {
 	transition: opacity 0.15s;
 }
 .codeblock:hover .copy-btn {
+	opacity: 1;
+}
+.mermaid-block:hover .copy-btn {
 	opacity: 1;
 }
 .copy-btn:hover {
@@ -3887,23 +3943,22 @@ span.msg-editor-hint svg {
 /* Blinking caret shown while the assistant message is streaming. */
 .stream-cursor {
 	display: inline-block;
-	width: 8px;
-	height: 1.05em;
-	margin-left: 3px;
+	width: 2px;
+	height: 1em;
+	margin-left: 4px;
 	vertical-align: text-bottom;
 	border-radius: 1px;
 	background: var(--accent);
-	animation: stream-blink 1s steps(2, start) infinite;
+	animation: stream-blink 1s ease-in-out infinite;
 }
 
 @keyframes stream-blink {
 	0%,
-	49% {
+	100% {
 		opacity: 1;
 	}
-	50%,
-	100% {
-		opacity: 0;
+	50% {
+		opacity: 0.15;
 	}
 }
 
@@ -4063,11 +4118,45 @@ span.msg-editor-hint svg {
 }
 
 .toolcall-output-label {
+	display: flex;
+	align-items: center;
+	gap: 6px;
 	font-size: 11px;
 	text-transform: uppercase;
 	letter-spacing: 0.6px;
 	color: var(--text-faint);
 	margin-bottom: 4px;
+}
+.toolcall-output-spacer {
+	flex: 1;
+}
+.toolcall-md-toggle {
+	border: none;
+	background: transparent;
+	color: var(--text-faint);
+	text-transform: none;
+	letter-spacing: normal;
+	font-size: 11px;
+	cursor: pointer;
+	padding: 2px 6px;
+	border-radius: 5px;
+}
+.toolcall-md-toggle:hover {
+	color: var(--text);
+	background: var(--bg-elev2);
+}
+/* Rendered Markdown output (a `read` on a .md file) — same card chrome as
+   the raw <pre>, but hosts prose instead of monospace text. */
+.toolcall-markdown {
+	max-height: 420px;
+	overflow: auto;
+	background: var(--bg-elev2);
+	border: 1px solid var(--border-soft);
+	border-radius: 6px;
+	padding: 10px 14px;
+}
+.toolcall-markdown .md {
+	font-size: 13px;
 }
 
 .toolcall-output pre {
@@ -4100,17 +4189,22 @@ span.msg-editor-hint svg {
 
 .cursor {
 	display: inline-block;
-	width: 7px;
+	width: 2px;
 	height: 13px;
 	background: var(--accent);
+	border-radius: 1px;
 	vertical-align: -2px;
 	margin-left: 4px;
-	animation: blink 1s steps(2, start) infinite;
+	animation: blink 1s ease-in-out infinite;
 }
 
 @keyframes blink {
+	0%,
+	100% {
+		opacity: 1;
+	}
 	50% {
-		opacity: 0;
+		opacity: 0.15;
 	}
 }
 
@@ -6852,6 +6946,13 @@ span.msg-editor-hint svg {
 .fp-markdown .codeblock pre code {
 	white-space: pre;
 	word-break: normal;
+}
+.fp-markdown .mermaid-block {
+	max-width: 100%;
+	min-width: 0;
+	margin: 1.1em 0;
+	padding: 18px;
+	border-radius: 10px;
 }
 .fp-markdown img {
 	display: block;

--- a/themes/white.css
+++ b/themes/white.css
@@ -3744,6 +3744,59 @@ span.msg-editor-hint svg {
 	line-height: 1.55;
 }
 
+/* Mermaid diagrams rendered from ```mermaid fenced code blocks (see
+   components/MermaidDiagram.tsx). Mirrors .codeblock chrome so a doc mixing
+   diagrams and code reads as one visual family. */
+.mermaid-block {
+	position: relative;
+	margin: 10px 0;
+	padding: 18px;
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	/* Diagrams read best on their own light "paper" card — matching mermaid's
+	   base theme (see MermaidDiagram.tsx) rather than the app's dark chrome
+	   keeps flowchart boxes/text legible instead of a muddy low-contrast box. */
+	background: #ffffff;
+	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 8px 20px rgba(0, 0, 0, 0.25);
+	overflow-x: auto;
+	display: flex;
+	justify-content: center;
+}
+.mermaid-svg {
+	width: 100%;
+	display: flex;
+	justify-content: center;
+}
+.mermaid-svg svg {
+	max-width: 100%;
+	height: auto;
+}
+.mermaid-block-loading {
+	width: 100%;
+	padding: 4px 2px;
+	color: var(--text-dim);
+	font-size: 12.5px;
+	text-align: center;
+	background: transparent;
+	box-shadow: none;
+}
+.mermaid-block-error {
+	display: block;
+	background: transparent;
+	box-shadow: none;
+	border-color: rgba(239, 68, 68, 0.35);
+}
+.mermaid-error-note {
+	width: 100%;
+	padding: 4px 2px;
+	font-size: 12.5px;
+	text-align: left;
+	color: #f87171;
+}
+.mermaid-block-error .codeblock {
+	margin: 8px 0 0;
+}
+
 .copy-btn {
 	position: absolute;
 	top: 8px;
@@ -3763,6 +3816,9 @@ span.msg-editor-hint svg {
 	transition: opacity 0.15s;
 }
 .codeblock:hover .copy-btn {
+	opacity: 1;
+}
+.mermaid-block:hover .copy-btn {
 	opacity: 1;
 }
 .copy-btn:hover {
@@ -3886,23 +3942,22 @@ span.msg-editor-hint svg {
 /* Blinking caret shown while the assistant message is streaming. */
 .stream-cursor {
 	display: inline-block;
-	width: 8px;
-	height: 1.05em;
-	margin-left: 3px;
+	width: 2px;
+	height: 1em;
+	margin-left: 4px;
 	vertical-align: text-bottom;
 	border-radius: 1px;
 	background: var(--accent);
-	animation: stream-blink 1s steps(2, start) infinite;
+	animation: stream-blink 1s ease-in-out infinite;
 }
 
 @keyframes stream-blink {
 	0%,
-	49% {
+	100% {
 		opacity: 1;
 	}
-	50%,
-	100% {
-		opacity: 0;
+	50% {
+		opacity: 0.15;
 	}
 }
 
@@ -4062,11 +4117,45 @@ span.msg-editor-hint svg {
 }
 
 .toolcall-output-label {
+	display: flex;
+	align-items: center;
+	gap: 6px;
 	font-size: 11px;
 	text-transform: uppercase;
 	letter-spacing: 0.6px;
 	color: var(--text-faint);
 	margin-bottom: 4px;
+}
+.toolcall-output-spacer {
+	flex: 1;
+}
+.toolcall-md-toggle {
+	border: none;
+	background: transparent;
+	color: var(--text-faint);
+	text-transform: none;
+	letter-spacing: normal;
+	font-size: 11px;
+	cursor: pointer;
+	padding: 2px 6px;
+	border-radius: 5px;
+}
+.toolcall-md-toggle:hover {
+	color: var(--text);
+	background: var(--bg-elev2);
+}
+/* Rendered Markdown output (a `read` on a .md file) — same card chrome as
+   the raw <pre>, but hosts prose instead of monospace text. */
+.toolcall-markdown {
+	max-height: 420px;
+	overflow: auto;
+	background: var(--bg-elev2);
+	border: 1px solid var(--border-soft);
+	border-radius: 6px;
+	padding: 10px 14px;
+}
+.toolcall-markdown .md {
+	font-size: 13px;
 }
 
 .toolcall-output pre {
@@ -4099,17 +4188,22 @@ span.msg-editor-hint svg {
 
 .cursor {
 	display: inline-block;
-	width: 7px;
+	width: 2px;
 	height: 13px;
 	background: var(--accent);
+	border-radius: 1px;
 	vertical-align: -2px;
 	margin-left: 4px;
-	animation: blink 1s steps(2, start) infinite;
+	animation: blink 1s ease-in-out infinite;
 }
 
 @keyframes blink {
+	0%,
+	100% {
+		opacity: 1;
+	}
 	50% {
-		opacity: 0;
+		opacity: 0.15;
 	}
 }
 
@@ -6667,9 +6761,11 @@ span.msg-editor-hint svg {
 	min-height: 0;
 	overflow: auto;
 	padding: 22px clamp(18px, 4vw, 48px) 34px;
+	/* Light themes: no dark wash — that rule was copied from the dark theme
+	   verbatim and muddied a light background into a gray-lavender smear. */
 	background:
-		radial-gradient(circle at 10% 0%, rgba(139, 92, 246, 0.08), transparent 34%),
-		rgba(0, 0, 0, 0.22);
+		radial-gradient(circle at 10% 0%, rgba(139, 92, 246, 0.06), transparent 34%),
+		var(--bg);
 	color: var(--text);
 	font-size: 14px;
 	line-height: 1.8;
@@ -6851,6 +6947,13 @@ span.msg-editor-hint svg {
 .fp-markdown .codeblock pre code {
 	white-space: pre;
 	word-break: normal;
+}
+.fp-markdown .mermaid-block {
+	max-width: 100%;
+	min-width: 0;
+	margin: 1.1em 0;
+	padding: 18px;
+	border-radius: 10px;
 }
 .fp-markdown img {
 	display: block;

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -108,9 +108,15 @@ export const ChatInput = memo(function ChatInput({
 		const m = value.match(/^\/([^\s]*)$/);
 		if (m && ready) {
 			const prefix = m[1].toLowerCase();
-			const matches = slashCommands.filter((c) =>
-				c.name.toLowerCase().startsWith(prefix),
-			);
+			const matches = slashCommands.filter((c) => {
+				const name = c.name.toLowerCase();
+				if (name.startsWith(prefix)) return true;
+				// Namespaced commands ("skill:wayfinder", "prompt:foo") should also
+				// match on the part after the colon, so "/wa" finds "/skill:wayfinder"
+				// instead of requiring the "skill:" prefix to be typed out first.
+				const colon = name.indexOf(":");
+				return colon >= 0 && name.slice(colon + 1).startsWith(prefix);
+			});
 			setCompletions(matches.length > 0 ? matches : null);
 			setCompletionIndex(0);
 		} else {

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -4,6 +4,7 @@ import type { PluggableList } from "unified";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { CopyButton } from "./copy-button";
+import { MermaidDiagram } from "./MermaidDiagram";
 
 interface MarkdownProps {
 	text: string;
@@ -35,13 +36,25 @@ export const Markdown = memo(function Markdown({ text }: MarkdownProps) {
 	);
 });
 
-function PreWithCopy({ children, ...props }: JSX.IntrinsicElements["pre"]) {
+export function PreWithCopy({ children, ...props }: JSX.IntrinsicElements["pre"]) {
+	if (isMermaidCodeBlock(children)) {
+		return <MermaidDiagram code={codeText(children)} />;
+	}
 	return (
 		<div className="codeblock">
 			<CopyButton text={codeText(children)} />
 			<pre {...props}>{children}</pre>
 		</div>
 	);
+}
+
+/** True when `children` is the single ```mermaid fenced-code element that
+ *  react-markdown/rehype-highlight hand to a <pre>'s children. */
+function isMermaidCodeBlock(children: unknown): boolean {
+	const child = Array.isArray(children) ? children[0] : children;
+	if (!child || typeof child !== "object" || !("props" in child)) return false;
+	const className = (child as { props?: { className?: unknown } }).props?.className;
+	return typeof className === "string" && /(^|\s)language-mermaid(\s|$)/.test(className);
 }
 
 function codeText(children: unknown): string {

--- a/web/src/components/MermaidDiagram.tsx
+++ b/web/src/components/MermaidDiagram.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { useT } from "../i18n";
+import { CopyButton } from "./copy-button";
+
+/** Lazily-loaded, memoized mermaid module — most chats never hit a mermaid
+ *  fence, so this stays out of the main bundle until one actually renders. */
+let mermaidPromise: Promise<typeof import("mermaid")["default"]> | null = null;
+function loadMermaid() {
+	if (!mermaidPromise) {
+		mermaidPromise = import("mermaid").then((mod) => {
+			const mermaid = mod.default;
+			mermaid.initialize({
+				startOnLoad: false,
+				securityLevel: "strict",
+				// Diagrams read best on a light "paper" background — mermaid's
+				// dark theme renders low-contrast boxes that clash with
+				// whatever surrounds them (see .mermaid-block in styles.css,
+				// which gives this its own light card instead of matching the
+				// app's dark chrome directly).
+				theme: "base",
+				themeVariables: {
+					background: "#ffffff",
+					primaryColor: "#f1edfe",
+					primaryTextColor: "#1f2430",
+					primaryBorderColor: "#8b5cf6",
+					lineColor: "#6b7280",
+					secondaryColor: "#eef2ff",
+					tertiaryColor: "#f8fafc",
+					textColor: "#1f2430",
+					fontFamily: "var(--mono, monospace)",
+				},
+			});
+			return mermaid;
+		});
+	}
+	return mermaidPromise;
+}
+
+let renderSeq = 0;
+
+/** Renders a ```mermaid fenced block as an SVG diagram (flowcharts, sequence
+ *  diagrams, etc. — see docs/AI_Investment_OS_SYSTEM_DESIGN.md for examples).
+ *  Falls back to the raw source in a codeblock if mermaid can't parse it, so
+ *  a typo never blanks out the rest of the document. */
+export function MermaidDiagram({ code }: { code: string }) {
+	const t = useT();
+	const reactId = useId().replace(/[^a-zA-Z0-9]/g, "");
+	const [svg, setSvg] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		setSvg(null);
+		setError(null);
+		const renderId = `mermaid-${reactId}-${++renderSeq}`;
+		loadMermaid()
+			.then((mermaid) => mermaid.render(renderId, code))
+			.then(({ svg }) => {
+				if (!cancelled) setSvg(svg);
+			})
+			.catch((err: unknown) => {
+				if (!cancelled) {
+					setError(err instanceof Error ? err.message : String(err));
+				}
+				// mermaid sometimes leaves a detached error node behind in the DOM
+				// on parse failure; nothing in our tree references it so it's inert,
+				// but clean up the offscreen render target just in case.
+				document.getElementById(renderId)?.remove();
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [code, reactId]);
+
+	if (error) {
+		return (
+			<div className="mermaid-block mermaid-block-error">
+				<div className="mermaid-error-note">{t("mermaidRenderFailed")}</div>
+				<div className="codeblock">
+					<CopyButton text={code} />
+					<pre>
+						<code>{code}</code>
+					</pre>
+				</div>
+			</div>
+		);
+	}
+
+	if (!svg) {
+		return (
+			<div className="mermaid-block mermaid-block-loading">
+				<div className="mermaid-loading-note">{t("mermaidRendering")}</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="mermaid-block">
+			<CopyButton text={code} />
+			{/* mermaid.render() output is inert markup we generated locally
+			 *  (securityLevel: "strict" also has mermaid itself sanitize it). */}
+			<div
+				ref={containerRef}
+				className="mermaid-svg"
+				// eslint-disable-next-line react/no-danger
+				dangerouslySetInnerHTML={{ __html: svg }}
+			/>
+		</div>
+	);
+}

--- a/web/src/components/StreamMarkdown.tsx
+++ b/web/src/components/StreamMarkdown.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from "react-markdown";
 import { segmentStream } from "../stream-markdown";
 import {
 	MarkdownBody,
+	PreWithCopy,
 	rehypePlugins,
 	remarkPlugins,
 } from "./Markdown";
@@ -30,7 +31,7 @@ import {
 /** One frozen segment: immutable input → parses exactly once thanks to memo. */
 const FrozenSegment = memo(function FrozenSegment({ text }: { text: string }) {
 	return (
-		<ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
+		<ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins} components={{ pre: PreWithCopy }}>
 			{text}
 		</ReactMarkdown>
 	);

--- a/web/src/components/ToolCallBlock.tsx
+++ b/web/src/components/ToolCallBlock.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-icons/fi";
 import type { ToolStatus, UiMessage, UiToolCallBlock } from "../types";
 import { useT } from "../i18n";
+import { Markdown } from "./Markdown";
 
 export interface ToolView {
 	/** Tool result message if the tool already finished. */
@@ -39,6 +40,20 @@ function toolIcon(name: string): string {
 	return TOOL_ICONS[name] ?? "🛠";
 }
 
+/** True when this is a `read` tool call whose target path is a Markdown
+ *  file — its output reads much better rendered than as a raw <pre> dump. */
+function isMarkdownReadTarget(block: UiToolCallBlock): boolean {
+	if (block.name !== "read" || !block.argumentsText) return false;
+	try {
+		const args = JSON.parse(block.argumentsText) as { path?: unknown };
+		return (
+			typeof args.path === "string" && /\.(md|markdown)$/i.test(args.path)
+		);
+	} catch {
+		return false;
+	}
+}
+
 export const ToolCallBlock = memo(function ToolCallBlock({
 	block,
 	view,
@@ -56,6 +71,9 @@ export const ToolCallBlock = memo(function ToolCallBlock({
 	const t = useT();
 	const [open, setOpen] = useState(wrap);
 	const [copied, setCopied] = useState(false);
+	// Markdown files read by the `read` tool default to rendered preview,
+	// same convention as the file preview panel (see FilePreview.tsx).
+	const [markdownPreview, setMarkdownPreview] = useState(true);
 
 	const running = !view.result && view.streaming && !view.status;
 	const isBashRunning = block.name === "bash" && running;
@@ -65,6 +83,7 @@ export const ToolCallBlock = memo(function ToolCallBlock({
 	 *  the result. */
 	const waitingModel = !view.result && !!view.status;
 	const isError = view.result?.isError ?? view.status?.isError ?? false;
+	const isMarkdown = isMarkdownReadTarget(block);
 
 	const output = view.result
 		? view.result.content.map((b) => (b.type === "text" ? b.text : "")).join("")
@@ -154,8 +173,29 @@ export const ToolCallBlock = memo(function ToolCallBlock({
 							<div className="toolcall-output-label">
 								{isError ? t("errorOutput") : t("output")}
 								{(running || waitingModel) && <span className="cursor" />}
+								<span className="toolcall-output-spacer" />
+								{isMarkdown && !isError && (
+									<button
+										type="button"
+										className="toolcall-md-toggle"
+										title={
+											markdownPreview
+												? t("showMarkdownSource")
+												: t("showMarkdownPreview")
+										}
+										onClick={() => setMarkdownPreview((v) => !v)}
+									>
+										{markdownPreview ? t("showMarkdownSource") : t("showMarkdownPreview")}
+									</button>
+								)}
 							</div>
-							<pre>{output}</pre>
+							{isMarkdown && markdownPreview && !isError ? (
+								<div className="toolcall-markdown">
+									<Markdown text={output} />
+								</div>
+							) : (
+								<pre>{output}</pre>
+							)}
 						</div>
 					)}
 					{running && output.length === 0 && (

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -133,6 +133,8 @@ const zh = {
 	slashCopied: "已复制上一条助手回复",
 	slashCopyFailed: "复制失败，请手动复制",
 	slashCopyEmpty: "还没有可复制的助手回复",
+	mermaidRendering: "正在渲染图表…",
+	mermaidRenderFailed: "图表渲染失败，已显示原始代码",
 
 	/* left panel */
 	recentProjects: "最近项目",
@@ -701,6 +703,8 @@ const en: Record<keyof typeof zh, string> = {
 	slashCopied: "Copied the last assistant reply",
 	slashCopyFailed: "Copy failed — please copy manually",
 	slashCopyEmpty: "No assistant reply to copy yet",
+	mermaidRendering: "Rendering diagram…",
+	mermaidRenderFailed: "Diagram failed to render — showing raw source",
 
 	/* left panel */
 	recentProjects: "Recent projects",

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3744,6 +3744,59 @@ span.msg-editor-hint svg {
 	line-height: 1.55;
 }
 
+/* Mermaid diagrams rendered from ```mermaid fenced code blocks (see
+   components/MermaidDiagram.tsx). Mirrors .codeblock chrome so a doc mixing
+   diagrams and code reads as one visual family. */
+.mermaid-block {
+	position: relative;
+	margin: 10px 0;
+	padding: 18px;
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	/* Diagrams read best on their own light "paper" card — matching mermaid's
+	   base theme (see MermaidDiagram.tsx) rather than the app's dark chrome
+	   keeps flowchart boxes/text legible instead of a muddy low-contrast box. */
+	background: #ffffff;
+	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 8px 20px rgba(0, 0, 0, 0.25);
+	overflow-x: auto;
+	display: flex;
+	justify-content: center;
+}
+.mermaid-svg {
+	width: 100%;
+	display: flex;
+	justify-content: center;
+}
+.mermaid-svg svg {
+	max-width: 100%;
+	height: auto;
+}
+.mermaid-block-loading {
+	width: 100%;
+	padding: 4px 2px;
+	color: var(--text-dim);
+	font-size: 12.5px;
+	text-align: center;
+	background: transparent;
+	box-shadow: none;
+}
+.mermaid-block-error {
+	display: block;
+	background: transparent;
+	box-shadow: none;
+	border-color: rgba(239, 68, 68, 0.35);
+}
+.mermaid-error-note {
+	width: 100%;
+	padding: 4px 2px;
+	font-size: 12.5px;
+	text-align: left;
+	color: #f87171;
+}
+.mermaid-block-error .codeblock {
+	margin: 8px 0 0;
+}
+
 .copy-btn {
 	position: absolute;
 	top: 8px;
@@ -3763,6 +3816,9 @@ span.msg-editor-hint svg {
 	transition: opacity 0.15s;
 }
 .codeblock:hover .copy-btn {
+	opacity: 1;
+}
+.mermaid-block:hover .copy-btn {
 	opacity: 1;
 }
 .copy-btn:hover {
@@ -3886,23 +3942,22 @@ span.msg-editor-hint svg {
 /* Blinking caret shown while the assistant message is streaming. */
 .stream-cursor {
 	display: inline-block;
-	width: 8px;
-	height: 1.05em;
-	margin-left: 3px;
+	width: 2px;
+	height: 1em;
+	margin-left: 4px;
 	vertical-align: text-bottom;
 	border-radius: 1px;
 	background: var(--accent);
-	animation: stream-blink 1s steps(2, start) infinite;
+	animation: stream-blink 1s ease-in-out infinite;
 }
 
 @keyframes stream-blink {
 	0%,
-	49% {
+	100% {
 		opacity: 1;
 	}
-	50%,
-	100% {
-		opacity: 0;
+	50% {
+		opacity: 0.15;
 	}
 }
 
@@ -4062,11 +4117,45 @@ span.msg-editor-hint svg {
 }
 
 .toolcall-output-label {
+	display: flex;
+	align-items: center;
+	gap: 6px;
 	font-size: 11px;
 	text-transform: uppercase;
 	letter-spacing: 0.6px;
 	color: var(--text-faint);
 	margin-bottom: 4px;
+}
+.toolcall-output-spacer {
+	flex: 1;
+}
+.toolcall-md-toggle {
+	border: none;
+	background: transparent;
+	color: var(--text-faint);
+	text-transform: none;
+	letter-spacing: normal;
+	font-size: 11px;
+	cursor: pointer;
+	padding: 2px 6px;
+	border-radius: 5px;
+}
+.toolcall-md-toggle:hover {
+	color: var(--text);
+	background: var(--bg-elev2);
+}
+/* Rendered Markdown output (a `read` on a .md file) — same card chrome as
+   the raw <pre>, but hosts prose instead of monospace text. */
+.toolcall-markdown {
+	max-height: 420px;
+	overflow: auto;
+	background: var(--bg-elev2);
+	border: 1px solid var(--border-soft);
+	border-radius: 6px;
+	padding: 10px 14px;
+}
+.toolcall-markdown .md {
+	font-size: 13px;
 }
 
 .toolcall-output pre {
@@ -4099,17 +4188,22 @@ span.msg-editor-hint svg {
 
 .cursor {
 	display: inline-block;
-	width: 7px;
+	width: 2px;
 	height: 13px;
 	background: var(--accent);
+	border-radius: 1px;
 	vertical-align: -2px;
 	margin-left: 4px;
-	animation: blink 1s steps(2, start) infinite;
+	animation: blink 1s ease-in-out infinite;
 }
 
 @keyframes blink {
+	0%,
+	100% {
+		opacity: 1;
+	}
 	50% {
-		opacity: 0;
+		opacity: 0.15;
 	}
 }
 
@@ -6851,6 +6945,13 @@ span.msg-editor-hint svg {
 .fp-markdown .codeblock pre code {
 	white-space: pre;
 	word-break: normal;
+}
+.fp-markdown .mermaid-block {
+	max-width: 100%;
+	min-width: 0;
+	margin: 1.1em 0;
+	padding: 18px;
+	border-radius: 10px;
 }
 .fp-markdown img {
 	display: block;


### PR DESCRIPTION
- Add mermaid rendering support for ```mermaid code blocks with lazy loading and graceful fallback to source code on parse failure
- Render markdown output for read tool on .md files with toggle
- Improve slash command namespace matching (e.g. /wa finds /skill:wayfinder)
- Polish cursor animation and mermaid block styles