### PR TITLE
fix(server): retain idle conversations with pending pi-subagents wake subscriptions

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -43,6 +43,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { BgServerTracker } from "./bg-servers.js";
+import { hasPendingWaitSubscription, shouldRetainActive } from "./wait-subscription-scan.js";
 import type { PluginAgentTool, PluginCommandDef, PluginToolEvent } from "./plugins.js";
 import { syncPluginToolsIntoSession } from "./plugins.js";
 import { SettingsService } from "./settings-service.js";
@@ -2471,21 +2472,26 @@ export class ClientSession {
 		// An isolated reviewer can keep working while the main session is idle;
 		// retain that conversation so its review is not disposed when the user
 		// switches away without sending another prompt.
-		if (conv.goal.reviewing || conv.wizardRunning) {
+		// 同时检查磁盘上的未过期 wait-subscription 记录：后台子代理运行结束后
+		// 仍欠本会话一次唤醒回合；此时释放运行时会杀死 pi-subagents 扩展宿主，
+		// 唤醒永远无法送达（会话表现为无限期停摆）。保留是自限的：记录过期后
+		// 不再阻止释放。
+		// Also retain when a non-expired pi-subagents wait-subscription record
+		// exists on disk for this session: a finished background subagent run
+		// still owes this conversation a wake-up turn.
+		const retained = shouldRetainActive({
+			reviewing: conv.goal.reviewing,
+			wizardRunning: conv.wizardRunning,
+			streaming: conv.session.isStreaming,
+			openTerminals: conv.terminals.list().length,
+			listed: conv.listed,
+			promptedSinceActive: conv.promptedSinceActive,
+			hasPendingWake: hasPendingWaitSubscription({ sessionId: conv.session.sessionFile }),
+		});
+		if (retained) {
 			conv.listed = true;
 			return null;
 		}
-		if (conv.session.isStreaming) {
-			conv.listed = true;
-			return null;
-		}
-		// Terminal state is a reason to keep an otherwise idle conversation alive:
-		// switching chats must not kill a PTY the user or agent may still need.
-		if (conv.terminals.list().length > 0) {
-			conv.listed = true;
-			return null;
-		}
-		if (conv.listed && conv.promptedSinceActive) return null;
 		return conv;
 	}
 

--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -2486,7 +2486,7 @@ export class ClientSession {
 			openTerminals: conv.terminals.list().length,
 			listed: conv.listed,
 			promptedSinceActive: conv.promptedSinceActive,
-			hasPendingWake: hasPendingWaitSubscription({ sessionId: conv.session.sessionFile }),
+			hasPendingWake: () => hasPendingWaitSubscription({ sessionId: conv.session.sessionFile }),
 		});
 		if (retained) {
 			conv.listed = true;

--- a/server/wait-subscription-scan.ts
+++ b/server/wait-subscription-scan.ts
@@ -6,16 +6,18 @@
 // 记录是独立的小 JSON 文件，存放在共享目录
 //   <tmp>/pi-subagents-<scope>/wait-subscriptions/<token>.json
 // 其中 scope 与 pi-subagents/src/shared/types.ts 的 resolveTempScopeId() 一致：
-//   PI_SUBAGENTS_TEMP_ROOT 环境变量优先，否则 uid-N / user-X / home-X / shared。
+//   PI_SUBAGENTS_TEMP_ROOT 环境变量优先，否则 uid-N / user-<用户名> /
+//   home-<主目录> / shared（完整 fallback 链见 resolveTempScopeId 注释）。
 // 记录的 sessionId 是会话 .jsonl 文件的绝对路径（AgentSession.sessionFile），
 // 记录自带 expiresAt（毫秒时间戳），因此任何基于它的保留策略都是自限的：
 // 记录过期后即不再触发保留，内存/运行时开销有硬上界。
 //
 // fail-open / fail-closed 决策：只有「能完整解析为合法 wait-subscription 记录、
 // sessionId 匹配且未过期」的文件才算证据（→ fail-closed 保留运行时）。
-// 损坏 JSON、格式不符、外部会话的记录一律视为「无证据」（→ fail-open 允许
-// 释放）：这些文件无法给出可信的过期时间，若 fail-closed 会造成运行时永久
-// 泄漏；而误释放的最坏后果只是本 bug 已知的行为（重开聊天时唤醒）。
+// 损坏 JSON、格式不符（含非有限数值，见 parseRecord）、外部会话的记录一律
+// 视为「无证据」（→ fail-open 允许释放）：这些文件无法给出可信的过期时间，
+// 若 fail-closed 会造成运行时永久泄漏；而误释放的最坏后果只是本 bug 已知的
+// 行为（重开聊天时唤醒）。
 // ---------------------------------------------------------------------------
 // Scan for pending "wait subscription" records (pi-subagents). A pending record
 // means the conversation's session is owed a wake-up turn by a finished
@@ -24,7 +26,7 @@
 // and the fail-open vs fail-closed rationale.
 
 import { readdirSync, readFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir, userInfo } from "node:os";
 import path from "node:path";
 
 /** 与 pi-subagents WaitSubscriptionRecord 的必填字段保持一致（结构校验）。 */
@@ -41,7 +43,11 @@ interface WaitSubscriptionRecord {
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-/** 严格结构校验：任何字段缺失/类型不符都视为「外部格式」，不算证据。 */
+/**
+ * 严格结构校验：任何字段缺失/类型不符（含非有限数值 —— 例如 JSON 里的 1e999
+ * 经 JSON.parse 变成 Infinity）都视为「外部格式」，不算证据（fail-open）。
+ * 非有限 expiresAt 会破坏「记录过期即自限」的不变量，必须挡在校验层。
+ */
 function parseRecord(value: unknown): WaitSubscriptionRecord | undefined {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
 	const record = value as Partial<WaitSubscriptionRecord>;
@@ -52,8 +58,8 @@ function parseRecord(value: unknown): WaitSubscriptionRecord | undefined {
 		|| (record.targetKind !== "async" && record.targetKind !== "foreground")
 		|| typeof record.runId !== "string"
 		|| typeof record.requestedId !== "string"
-		|| typeof record.createdAt !== "number"
-		|| typeof record.expiresAt !== "number") return undefined;
+		|| typeof record.createdAt !== "number" || !Number.isFinite(record.createdAt)
+		|| typeof record.expiresAt !== "number" || !Number.isFinite(record.expiresAt)) return undefined;
 	return record as WaitSubscriptionRecord;
 }
 
@@ -66,19 +72,43 @@ function sanitizeTempScopeSegment(value: string): string {
 }
 
 /**
- * 复刻 pi-subagents 的临时目录 scope（resolveTempScopeId）：仅在本机
- * 同 uid / 同用户的场景下运行，保持目录一致即可；不可得时退回 "shared"。
+ * 复刻 pi-subagents 的临时目录 scope（resolveTempScopeId，types.ts:2054）。
+ * Fallback 链与上游逐层对齐：
+ *   1. getuid() 可用 → `uid-<n>`；
+ *   2. USERNAME / USER / LOGNAME 环境变量 → `user-<名>`；
+ *   3. os.userInfo().username（try/catch，抛错则落到下一层）→ `user-<名>`；
+ *   4. USERPROFILE / HOME 环境变量，再退 os.homedir()（非空字符串才用）→
+ *      `home-<主目录>`；
+ *   5. 全部不可得 → "shared"。
  * Mirror of pi-subagents' temp-scope resolution so both sides agree on the
  * shared wait-subscriptions directory without importing pi-subagents.
+ * getuid / userInfo / homedir 可注入以便逐层测试（生产用 os 默认值）。
  */
-export function resolveTempScopeId(env: NodeJS.ProcessEnv = process.env): string {
-	if (typeof process.getuid === "function") return `uid-${process.getuid()}`;
+export function resolveTempScopeId(
+	env: NodeJS.ProcessEnv = process.env,
+	getuid: (() => number) | null | undefined = process.getuid?.bind(process),
+	userInfoFn: (() => { username?: string | null }) | null = userInfo,
+	homedirFn: (() => string) | null = homedir,
+): string {
+	if (typeof getuid === "function") return `uid-${getuid()}`;
 	for (const key of ["USERNAME", "USER", "LOGNAME"] as const) {
 		const value = env[key];
 		if (value) return `user-${sanitizeTempScopeSegment(value)}`;
 	}
-	const homedir = env.USERPROFILE ?? env.HOME;
-	if (homedir) return `home-${sanitizeTempScopeSegment(homedir)}`;
+	try {
+		const username = userInfoFn?.().username;
+		if (username) return `user-${sanitizeTempScopeSegment(username)}`;
+	} catch {
+		// Fall through to home-directory-based scoping.
+	}
+	const homedirEnv = env.USERPROFILE ?? env.HOME;
+	if (homedirEnv) return `home-${sanitizeTempScopeSegment(homedirEnv)}`;
+	try {
+		const fallbackHomedir = homedirFn?.();
+		if (fallbackHomedir) return `home-${sanitizeTempScopeSegment(fallbackHomedir)}`;
+	} catch {
+		// Fall through to the last-resort shared scope.
+	}
 	return "shared";
 }
 
@@ -97,33 +127,49 @@ export interface PendingWakeScanOptions {
 	/** 会话标识 = pi-subagents 记录中的 sessionId = session .jsonl 绝对路径。 */
 	sessionId?: string;
 	now?: () => number;
+	/** I/O 警告出口（测试可静音）。默认 console.warn。 */
+	warn?: (message: string, error: unknown) => void;
 }
 
 /**
  * 磁盘扫描：该会话是否还有未过期的 wake 订阅记录。
  * Does the session still have a non-expired wait-subscription record on disk?
- * 任何 I/O / 解析错误都按「无证据」处理（见文件头 fail-open 说明）。
+ * 任何 I/O / 解析错误都按「无证据」处理（fail-open，见文件头说明）；
+ * 非 ENOENT 的 I/O 错误会 console.warn 一次（与 pi-subagents :142 对齐），
+ * ENOENT（目录/文件尚不存在）保持静默。
  */
 export function hasPendingWaitSubscription(options: PendingWakeScanOptions): boolean {
 	const sessionId = options.sessionId;
 	if (!sessionId) return false;
 	const now = options.now ?? Date.now;
+	const warn = options.warn ?? ((message: string, error: unknown) => console.warn(message, error));
+	const isNotFound = (error: unknown): boolean =>
+		typeof error === "object" && error !== null && "code" in error
+		&& (error as NodeJS.ErrnoException).code === "ENOENT";
 	const dir = options.subscriptionsDir ?? resolveSubscriptionsDir();
 	let files: string[];
 	try {
 		files = readdirSync(dir).filter((file) => file.endsWith(".json"));
-	} catch {
+	} catch (error) {
+		if (!isNotFound(error)) warn(`Failed to scan wait subscriptions in '${dir}':`, error);
 		return false; // 目录缺失 / 不可读 → 无证据
 	}
 	for (const file of files) {
 		let value: unknown;
 		try {
 			value = JSON.parse(readFileSync(path.join(dir, file), "utf-8"));
-		} catch {
+		} catch (error) {
+			if (!isNotFound(error)) warn(`Failed to read wait subscription '${path.join(dir, file)}':`, error);
 			continue; // 损坏 JSON → 无证据（fail-open）
 		}
 		const record = parseRecord(value);
 		if (!record) continue; // 外部格式 → 无证据
+		// 与 pi-subagents 的读取路径对齐（:154/:326）：文件名必须是
+		// `<token>.json` —— 被重命名过的记录永远不会被上游消费，这里同样
+		// 视为无证据（fail-open），保证与宿主行为一致。
+		// Parity with pi-subagents: only files named `<token>.json` can ever
+		// fire, so renamed records count as no evidence.
+		if (path.basename(file) !== `${record.token}.json`) continue;
 		if (record.sessionId !== sessionId) continue; // 别的会话
 		if (record.expiresAt <= now()) continue; // 已过期 → 不再保留
 		return true;
@@ -139,8 +185,13 @@ export interface DisplacementDecisionInput {
 	openTerminals: number;
 	listed: boolean;
 	promptedSinceActive: boolean;
-	/** 磁盘扫描结果：存在未过期 wake 订阅。 */
-	hasPendingWake: boolean;
+	/**
+	 * 磁盘扫描结果：存在未过期 wake 订阅。可传 thunk 延迟求值 —— 只在前面的
+	 * 保留条件都不命中时才会被调用，避免每次置换都做同步磁盘 I/O。
+	 * Pending-wake evidence; pass a thunk to defer the disk scan — it is only
+	 * invoked at this precedence point, after the cheaper checks pass.
+	 */
+	hasPendingWake: boolean | (() => boolean);
 }
 
 /**
@@ -153,7 +204,10 @@ export function shouldRetainActive(input: DisplacementDecisionInput): boolean {
 	if (input.reviewing || input.wizardRunning) return true;
 	if (input.streaming) return true;
 	if (input.openTerminals > 0) return true;
-	if (input.hasPendingWake) return true;
+	const hasPendingWake = typeof input.hasPendingWake === "function"
+		? input.hasPendingWake()
+		: input.hasPendingWake;
+	if (hasPendingWake) return true;
 	if (input.listed && input.promptedSinceActive) return true;
 	return false;
 }

--- a/server/wait-subscription-scan.ts
+++ b/server/wait-subscription-scan.ts
@@ -1,0 +1,159 @@
+// ---------------------------------------------------------------------------
+// 挂起 wake 订阅扫描（retain conversations with pending subagent wakes）
+// ---------------------------------------------------------------------------
+// 背景：pi-subagents 扩展在后台异步子代理运行结束后，通过持久化的
+// wait-subscription 记录唤醒父会话（pi.sendMessage({ triggerTurn: true })）。
+// 记录是独立的小 JSON 文件，存放在共享目录
+//   <tmp>/pi-subagents-<scope>/wait-subscriptions/<token>.json
+// 其中 scope 与 pi-subagents/src/shared/types.ts 的 resolveTempScopeId() 一致：
+//   PI_SUBAGENTS_TEMP_ROOT 环境变量优先，否则 uid-N / user-X / home-X / shared。
+// 记录的 sessionId 是会话 .jsonl 文件的绝对路径（AgentSession.sessionFile），
+// 记录自带 expiresAt（毫秒时间戳），因此任何基于它的保留策略都是自限的：
+// 记录过期后即不再触发保留，内存/运行时开销有硬上界。
+//
+// fail-open / fail-closed 决策：只有「能完整解析为合法 wait-subscription 记录、
+// sessionId 匹配且未过期」的文件才算证据（→ fail-closed 保留运行时）。
+// 损坏 JSON、格式不符、外部会话的记录一律视为「无证据」（→ fail-open 允许
+// 释放）：这些文件无法给出可信的过期时间，若 fail-closed 会造成运行时永久
+// 泄漏；而误释放的最坏后果只是本 bug 已知的行为（重开聊天时唤醒）。
+// ---------------------------------------------------------------------------
+// Scan for pending "wait subscription" records (pi-subagents). A pending record
+// means the conversation's session is owed a wake-up turn by a finished
+// background subagent run, so its runtime must be kept alive across project /
+// conversation switches. See the Chinese block above for the persistence layout
+// and the fail-open vs fail-closed rationale.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/** 与 pi-subagents WaitSubscriptionRecord 的必填字段保持一致（结构校验）。 */
+interface WaitSubscriptionRecord {
+	version: number;
+	token: string;
+	sessionId: string;
+	targetKind: "async" | "foreground";
+	runId: string;
+	requestedId: string;
+	createdAt: number;
+	expiresAt: number;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** 严格结构校验：任何字段缺失/类型不符都视为「外部格式」，不算证据。 */
+function parseRecord(value: unknown): WaitSubscriptionRecord | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const record = value as Partial<WaitSubscriptionRecord>;
+	if (record.version !== 1
+		|| typeof record.token !== "string"
+		|| !UUID_RE.test(record.token)
+		|| typeof record.sessionId !== "string"
+		|| (record.targetKind !== "async" && record.targetKind !== "foreground")
+		|| typeof record.runId !== "string"
+		|| typeof record.requestedId !== "string"
+		|| typeof record.createdAt !== "number"
+		|| typeof record.expiresAt !== "number") return undefined;
+	return record as WaitSubscriptionRecord;
+}
+
+function sanitizeTempScopeSegment(value: string): string {
+	const sanitized = value
+		.trim()
+		.replace(/[^A-Za-z0-9._-]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return sanitized || "unknown";
+}
+
+/**
+ * 复刻 pi-subagents 的临时目录 scope（resolveTempScopeId）：仅在本机
+ * 同 uid / 同用户的场景下运行，保持目录一致即可；不可得时退回 "shared"。
+ * Mirror of pi-subagents' temp-scope resolution so both sides agree on the
+ * shared wait-subscriptions directory without importing pi-subagents.
+ */
+export function resolveTempScopeId(env: NodeJS.ProcessEnv = process.env): string {
+	if (typeof process.getuid === "function") return `uid-${process.getuid()}`;
+	for (const key of ["USERNAME", "USER", "LOGNAME"] as const) {
+		const value = env[key];
+		if (value) return `user-${sanitizeTempScopeSegment(value)}`;
+	}
+	const homedir = env.USERPROFILE ?? env.HOME;
+	if (homedir) return `home-${sanitizeTempScopeSegment(homedir)}`;
+	return "shared";
+}
+
+/** wait-subscriptions 目录默认位置（与 pi-subagents 的推导一致）。 */
+export function resolveSubscriptionsDir(env: NodeJS.ProcessEnv = process.env): string {
+	const configured = env.PI_SUBAGENTS_TEMP_ROOT?.trim();
+	const root = configured
+		? path.resolve(configured)
+		: path.join(tmpdir(), `pi-subagents-${resolveTempScopeId(env)}`);
+	return path.join(path.dirname(path.join(root, "async-subagent-runs")), "wait-subscriptions");
+}
+
+export interface PendingWakeScanOptions {
+	/** 默认 resolveSubscriptionsDir()。测试可注入临时目录。 */
+	subscriptionsDir?: string;
+	/** 会话标识 = pi-subagents 记录中的 sessionId = session .jsonl 绝对路径。 */
+	sessionId?: string;
+	now?: () => number;
+}
+
+/**
+ * 磁盘扫描：该会话是否还有未过期的 wake 订阅记录。
+ * Does the session still have a non-expired wait-subscription record on disk?
+ * 任何 I/O / 解析错误都按「无证据」处理（见文件头 fail-open 说明）。
+ */
+export function hasPendingWaitSubscription(options: PendingWakeScanOptions): boolean {
+	const sessionId = options.sessionId;
+	if (!sessionId) return false;
+	const now = options.now ?? Date.now;
+	const dir = options.subscriptionsDir ?? resolveSubscriptionsDir();
+	let files: string[];
+	try {
+		files = readdirSync(dir).filter((file) => file.endsWith(".json"));
+	} catch {
+		return false; // 目录缺失 / 不可读 → 无证据
+	}
+	for (const file of files) {
+		let value: unknown;
+		try {
+			value = JSON.parse(readFileSync(path.join(dir, file), "utf-8"));
+		} catch {
+			continue; // 损坏 JSON → 无证据（fail-open）
+		}
+		const record = parseRecord(value);
+		if (!record) continue; // 外部格式 → 无证据
+		if (record.sessionId !== sessionId) continue; // 别的会话
+		if (record.expiresAt <= now()) continue; // 已过期 → 不再保留
+		return true;
+	}
+	return false;
+}
+
+/** displaceActive 决策的输入快照（纯数据，便于单测）。 */
+export interface DisplacementDecisionInput {
+	reviewing: boolean;
+	wizardRunning: boolean;
+	streaming: boolean;
+	openTerminals: number;
+	listed: boolean;
+	promptedSinceActive: boolean;
+	/** 磁盘扫描结果：存在未过期 wake 订阅。 */
+	hasPendingWake: boolean;
+}
+
+/**
+ * 纯函数版置换决策：true = 保留（不得 dispose），false = 调用方可释放。
+ * Pure decision core of displaceActive(): true = retain, false = may dispose.
+ * 顺序与 displaceActive 保持一致：review/wizard → streaming → terminals →
+ * pending wake → listed+continued（「打开后继续过」的会话也保留）。
+ */
+export function shouldRetainActive(input: DisplacementDecisionInput): boolean {
+	if (input.reviewing || input.wizardRunning) return true;
+	if (input.streaming) return true;
+	if (input.openTerminals > 0) return true;
+	if (input.hasPendingWake) return true;
+	if (input.listed && input.promptedSinceActive) return true;
+	return false;
+}

--- a/tests/unit/wait-subscription-scan.test.ts
+++ b/tests/unit/wait-subscription-scan.test.ts
@@ -1,0 +1,149 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+	hasPendingWaitSubscription,
+	shouldRetainActive,
+} from "../../server/wait-subscription-scan.js";
+
+const SESSION_FILE = "/root/.pi/agent/sessions/--proj--/2026-01-01T00-00-00Z_session.jsonl";
+const NOW = 1_000_000;
+const TOKEN = "0ffbdaf3-c196-4e88-8ae2-0674b2586335";
+
+function record(overrides: Record<string, unknown> = {}) {
+	return {
+		version: 1,
+		token: TOKEN,
+		sessionId: SESSION_FILE,
+		targetKind: "async",
+		runId: "run-1",
+		requestedId: "run-1",
+		createdAt: NOW - 1000,
+		expiresAt: NOW + 60_000,
+		...overrides,
+	};
+}
+
+const dirs: string[] = [];
+function makeDir(): string {
+	const dir = mkdtempSync(path.join(tmpdir(), "pi-web-ui-waitsub-"));
+	dirs.push(dir);
+	return dir;
+}
+afterAll(() => {
+	for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+});
+
+function writeRecord(dir: string, value: unknown, file = `${TOKEN}.json`): void {
+	writeFileSync(path.join(dir, file), typeof value === "string" ? value : JSON.stringify(value));
+}
+
+describe("hasPendingWaitSubscription", () => {
+	it("不存在目录 → 无证据", () => {
+		expect(hasPendingWaitSubscription({
+			subscriptionsDir: path.join(makeDir(), "missing", "wait-subscriptions"),
+			sessionId: SESSION_FILE,
+			now: () => NOW,
+		})).toBe(false);
+	});
+
+	it("空目录 → 无证据", () => {
+		expect(hasPendingWaitSubscription({
+			subscriptionsDir: makeDir(),
+			sessionId: SESSION_FILE,
+			now: () => NOW,
+		})).toBe(false);
+	});
+
+	it("匹配且未过期 → 有挂起订阅（保留会话）", () => {
+		const dir = makeDir();
+		writeRecord(dir, record());
+		expect(hasPendingWaitSubscription({
+			subscriptionsDir: dir,
+			sessionId: SESSION_FILE,
+			now: () => NOW,
+		})).toBe(true);
+	});
+
+	it("匹配但已过期 → 无挂起订阅", () => {
+		const dir = makeDir();
+		writeRecord(dir, record({ expiresAt: NOW - 1 }));
+		expect(hasPendingWaitSubscription({
+			subscriptionsDir: dir,
+			sessionId: SESSION_FILE,
+			now: () => NOW,
+		})).toBe(false);
+	});
+
+	it("其它会话的未过期记录 → 无挂起订阅", () => {
+		const dir = makeDir();
+		writeRecord(dir, record({ sessionId: "/other/session.jsonl" }));
+		expect(hasPendingWaitSubscription({
+			subscriptionsDir: dir,
+			sessionId: SESSION_FILE,
+			now: () => NOW,
+		})).toBe(false);
+	});
+
+	it("损坏 JSON → 视为无证据（fail-open）", () => {
+		const dir = makeDir();
+		writeRecord(dir, "{ not json !!!", "corrupt.json");
+		expect(hasPendingWaitSubscription({
+			subscriptionsDir: dir,
+			sessionId: SESSION_FILE,
+			now: () => NOW,
+		})).toBe(false);
+	});
+
+	it("格式不符（version 缺失等）→ 视为无证据", () => {
+		const dir = makeDir();
+		writeRecord(dir, { hello: "world" }, "foreign.json");
+		expect(hasPendingWaitSubscription({
+			subscriptionsDir: dir,
+			sessionId: SESSION_FILE,
+			now: () => NOW,
+		})).toBe(false);
+	});
+
+	it("非 .json 文件被忽略", () => {
+		const dir = makeDir();
+		writeRecord(dir, record(), "notes.txt");
+		expect(hasPendingWaitSubscription({
+			subscriptionsDir: dir,
+			sessionId: SESSION_FILE,
+			now: () => NOW,
+		})).toBe(false);
+	});
+});
+
+describe("shouldRetainActive（置换决策）", () => {
+	const base = {
+		reviewing: false,
+		wizardRunning: false,
+		streaming: false,
+		openTerminals: 0,
+		listed: false,
+		promptedSinceActive: false,
+		hasPendingWake: false,
+	};
+
+	it("默认可置换（返回 null）", () => {
+		expect(shouldRetainActive(base)).toBe(false);
+	});
+
+	it("reviewing / streaming / 终端打开 → 保留", () => {
+		expect(shouldRetainActive({ ...base, reviewing: true })).toBe(true);
+		expect(shouldRetainActive({ ...base, wizardRunning: true })).toBe(true);
+		expect(shouldRetainActive({ ...base, streaming: true })).toBe(true);
+		expect(shouldRetainActive({ ...base, openTerminals: 1 })).toBe(true);
+	});
+
+	it("listed + promptedSinceActive → 保留（原有行为）", () => {
+		expect(shouldRetainActive({ ...base, listed: true, promptedSinceActive: true })).toBe(true);
+	});
+
+	it("有未过期 wake 订阅 → 保留（本修复的核心行为）", () => {
+		expect(shouldRetainActive({ ...base, hasPendingWake: true })).toBe(true);
+	});
+});

--- a/tests/unit/wait-subscription-scan.test.ts
+++ b/tests/unit/wait-subscription-scan.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import {
 	hasPendingWaitSubscription,
+	resolveSubscriptionsDir,
+	resolveTempScopeId,
 	shouldRetainActive,
 } from "../../server/wait-subscription-scan.js";
 
@@ -145,5 +147,113 @@ describe("shouldRetainActive（置换决策）", () => {
 
 	it("有未过期 wake 订阅 → 保留（本修复的核心行为）", () => {
 		expect(shouldRetainActive({ ...base, hasPendingWake: true })).toBe(true);
+	});
+	it("thunk 只在到达 pending-wake 优先级时才求值（前置命中则不调用）", () => {
+		expect(shouldRetainActive({
+			...base,
+			streaming: true,
+			hasPendingWake: () => {
+				throw new Error("must not be evaluated");
+			},
+		})).toBe(true);
+		let calls = 0;
+		expect(shouldRetainActive({
+			...base,
+			hasPendingWake: () => {
+				calls += 1;
+				return true;
+			},
+		})).toBe(true);
+		expect(calls).toBe(1);
+	});
+});
+
+describe("resolveTempScopeId / resolveSubscriptionsDir", () => {
+	const cleanEnv = { PATH: "/usr/bin" } as unknown as NodeJS.ProcessEnv;
+
+	it("本平台默认走 uid-N 层", () => {
+		expect(resolveTempScopeId()).toMatch(/^uid-\d+$/);
+	});
+
+	it("无 uid 时用 USERNAME/USER/LOGNAME → user-X", () => {
+		expect(resolveTempScopeId({ ...cleanEnv, USER: "john doe" }, null)).toBe("user-john-doe");
+		expect(resolveTempScopeId({ ...cleanEnv, LOGNAME: "ops" }, null)).toBe("user-ops");
+	});
+
+	it("os.userInfo 层 → user-X（本机 username=root）", () => {
+		expect(resolveTempScopeId(cleanEnv, null)).toBe("user-root");
+	});
+
+	it("无用户名变量时用 HOME/USERPROFILE → home-X", () => {
+		expect(resolveTempScopeId({ ...cleanEnv, HOME: "/root" }, null, null)).toBe("home-root");
+	});
+
+	it("全部不可得 → shared", () => {
+		expect(resolveTempScopeId(cleanEnv, null, null, null)).toBe("shared");
+	});
+
+	it("resolveSubscriptionsDir：PI_SUBAGENTS_TEMP_ROOT 覆盖（含尾斜杠/相对路径）", () => {
+		expect(resolveSubscriptionsDir({ PI_SUBAGENTS_TEMP_ROOT: "/tmp/custom" }))
+			.toBe("/tmp/custom/wait-subscriptions");
+		expect(resolveSubscriptionsDir({ PI_SUBAGENTS_TEMP_ROOT: "/tmp/custom/" }))
+			.toBe("/tmp/custom/wait-subscriptions");
+		const resolved = resolveSubscriptionsDir({ PI_SUBAGENTS_TEMP_ROOT: "rel/root" });
+		expect(path.isAbsolute(resolved)).toBe(true);
+		expect(resolved.endsWith("wait-subscriptions")).toBe(true);
+	});
+
+	it("resolveSubscriptionsDir：默认推导 uid-N 目录", () => {
+		expect(resolveSubscriptionsDir(cleanEnv)).toBe(
+			path.join(tmpdir(), `pi-subagents-uid-${process.getuid()}`, "wait-subscriptions"),
+		);
+	});
+});
+
+describe("M1/M4/S2 边界与宿主对齐", () => {
+	it("expiresAt 为非有限数值（1e999 → Infinity）→ fail-open", () => {
+		const dir = makeDir();
+		writeFileSync(path.join(dir, `${TOKEN}.json`), JSON.stringify({
+			...record(),
+			expiresAt: JSON.parse("1e999"),
+		}));
+		expect(hasPendingWaitSubscription({
+			subscriptionsDir: dir,
+			sessionId: SESSION_FILE,
+			now: () => NOW,
+		})).toBe(false);
+	});
+
+	it("文件名与 token 不符（被重命名）→ fail-open", () => {
+		const dir = makeDir();
+		writeRecord(dir, record(), "renamed.json");
+		expect(hasPendingWaitSubscription({
+			subscriptionsDir: dir,
+			sessionId: SESSION_FILE,
+			now: () => NOW,
+		})).toBe(false);
+	});
+
+	it("非 ENOENT I/O 错误 warn 一次且仍 fail-open；ENOENT 静默", () => {
+		const warnings: string[] = [];
+		const warn = (message: string) => warnings.push(message);
+		// foo.json 是目录 → readFileSync 抛 EISDIR（非 ENOENT）
+		const dir = makeDir();
+		mkdirSync(path.join(dir, "foo.json"));
+		expect(hasPendingWaitSubscription({
+			subscriptionsDir: dir,
+			sessionId: SESSION_FILE,
+			now: () => NOW,
+			warn,
+		})).toBe(false);
+		expect(warnings).toHaveLength(1);
+		// 目录整体缺失 → ENOENT → 静默
+		const silent: string[] = [];
+		expect(hasPendingWaitSubscription({
+			subscriptionsDir: path.join(makeDir(), "nope"),
+			sessionId: SESSION_FILE,
+			now: () => NOW,
+			warn: (m) => silent.push(m),
+		})).toBe(false);
+		expect(silent).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
## Problem

Switching to another project/conversation **disposes an idle conversation's runtime** — `displaceActive()` (`server/agent-service.ts`) only retains conversations that are reviewing/wizard-running/streaming/have-open-terminals. A conversation that ended its turn while waiting on a [pi-subagents](https://github.com/xing-shuyin/pi-web-ui) **wait subscription** (the wake-up turn for a finished background async subagent run) is classified idle, so its runtime — including the pi-subagents extension host and its 1-second reconcile loop — is disposed.

The armed subscription survives on disk, but nothing reconciles it anymore. The session then **stalls until the user re-attaches that chat**, at which point the persisted record is rehydrated and fires immediately. Two symptoms:

1. **Indefinite stall** — orchestrator sessions waiting on background children freeze when the user switches projects.
2. **Misreported outcome** — if the record expires during the stall, the late reconcile reports `timed out` even when the targeted run actually **completed**.

### Verified reproduction (production instance)

From a real session (hawkeye project, all times UTC):

| Time | Event |
|---|---|
| Aug 27 18:57:39 | Orchestrator launches two background subagent children, arms a 30-min wait subscription, ends its turn |
| Aug 27 19:03:07 / 19:08:14 | Both children **complete** (~5.5 and ~10.5 min runtimes; outputs persisted) |
| Aug 27 19:08 → Aug 28 19:24 | **24.4 h of silence** — server up the whole time (uptime 33 days, other conversations served overnight) |
| Aug 28 19:24:21 | User re-opens the chat → wake fires **on that exact second** (server-side plugin logs confirm reattach time = wake time) |
| Aug 28 19:24:34 | Session resumes, reports the children as `timed out` although they finished 24 h earlier |

The same effect was reproduced casually afterwards: switch away mid-wait → come back → the "missed" wake fires on return.

## Fix

Retain a conversation across displacement when a **non-expired wait-subscription record exists on disk for its session** — i.e. a finished background run still owes it a wake-up turn.

- **New `server/wait-subscription-scan.ts`** — scans the shared pi-subagents directory (`PI_SUBAGENTS_TEMP_ROOT` or `<tmp>/pi-subagents-<scope>/wait-subscriptions/`, scope chain mirrored from pi-subagents' `resolveTempScopeId`), strictly schema-validates records (parity with pi-subagents' `parseRecord`, incl. UUID shape and finite numerics), and matches `sessionId` (the session `.jsonl` path, which equals `AgentSession.sessionFile` — same `SessionManager` on both sides since the extension host is created in-process).
- **`displaceActive()`** delegates to an exported pure `shouldRetainActive()` that preserves the existing check order and adds the pending-wake check; the disk scan is a lazy thunk resolved only at its precedence point, so common switches that retain earlier (streaming, terminals, …) never touch the filesystem.
- **Fail-open vs fail-closed**: only a parseable, session-matching, non-expired, correctly-named record retains the runtime (fail-closed). Corrupt JSON, foreign schemas, foreign sessions and I/O errors are "no evidence" → fail-open — worst case is the pre-existing bug behavior, never a permanently leaked runtime. Retention is self-limiting: records expire, so the invariant has a hard upper bound.
- pi-subagents itself is **not modified**.

## Testing

- 23 unit tests for the scanner + decision matrix (empty/missing dir, expired, foreign session, corrupt JSON, foreign schema, non-`.json` files, renamed-record parity, scope/dir resolution incl. `PI_SUBAGENTS_TEMP_ROOT` trailing-slash + relative paths, thunk-not-invoked-when-retained-earlier, and the regression case for this fix).
- Full suite: 165/165 passing (one pre-existing `terminal-key.test.ts` suite-load failure in a dev env without built `node-pty` — identical on a pristine checkout).
- `npm run build` clean (vite web + `tsc` server).
- The regression test was mutation-verified: removing the `hasPendingWake` retention line fails it.

Happy to adjust if you'd rather solve this at a different layer (e.g. server-level wake delivery independent of runtime lifetime) — this was chosen as the minimal, self-contained change on the pi-web-ui side.