### PR TITLE
fix: detect configured models from pi runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2991,9 +2991,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3155,9 +3152,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3172,9 +3166,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3189,9 +3180,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3206,9 +3194,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3223,9 +3208,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3240,9 +3222,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3257,9 +3236,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3274,9 +3250,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3291,9 +3264,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3308,9 +3278,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3325,9 +3292,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3342,9 +3306,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3359,9 +3320,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -1597,29 +1597,16 @@ export class ClientSession {
 	}
 
 	/**
-	 * Whether the pi agent config looks ready: the agent dir exists and
-	 * auth.json has at least one provider credential. Cached for 2s.
+	 * Whether the pi agent has at least one usable model. ModelRuntime's
+	 * available snapshot already accounts for models.json, auth.json, env-var
+	 * credentials, OAuth, and runtime API-key overrides. Cached for 2s because
+	 * this is called while building frequent snapshots.
 	 */
 	isPiConfigured(): boolean {
 		const now = Date.now();
 		const cached = this.piCheckCache;
 		if (cached && now - cached.at < 2000) return cached.configured;
-		let configured = false;
-		try {
-			const authPath = join(this.agentDir, "auth.json");
-			if (existsSync(authPath)) {
-				const data = JSON.parse(readFileSync(authPath, "utf8")) as Record<
-					string,
-					unknown
-				>;
-				configured =
-					typeof data === "object" &&
-					data !== null &&
-					Object.keys(data).length > 0;
-			}
-		} catch {
-			configured = false;
-		}
+		const configured = (this.sharedModelRuntime?.getAvailableSnapshot().length ?? 0) > 0;
 		this.piCheckCache = { at: now, configured };
 		return configured;
 	}

--- a/server/model-admin.ts
+++ b/server/model-admin.ts
@@ -857,6 +857,7 @@ static async probeModelsEndpoint(
 				// auth.json is optional; models.json can still use its own apiKey.
 			}
 			await this.host.modelRuntime().refresh();
+			this.host.invalidatePiConfig();
 			await this.listModelsConfig();
 			await this.host.pushModels();
 			this.host.emit({
@@ -892,6 +893,7 @@ static async probeModelsEndpoint(
 				JSON.stringify({ providers }, null, 2) + "\n",
 			);
 			await this.host.modelRuntime().refresh();
+			this.host.invalidatePiConfig();
 			await this.listModelsConfig();
 			await this.host.pushModels();
 			this.host.emit({

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -116,9 +116,9 @@ export interface UiState {
 	/** Monotonic snapshot sequence — clients can use it to drop stale snapshots. */
 	version: number;
 	/**
-	 * Whether the pi agent config looks ready (agentDir + auth.json with at
-	 * least one provider credential). False → the client should offer the
-	 * one-time setup flow.
+	 * Whether the pi agent has at least one usable model. The SDK resolves
+	 * models.json together with auth.json, environment credentials, OAuth, and
+	 * runtime API-key overrides. False → offer the one-time setup flow.
 	 */
 	piConfigured: boolean;
 	/**


### PR DESCRIPTION
## Summary

- Use pi SDK's `getAvailableSnapshot()` to determine whether pi is configured
- Recognize custom providers from `models.json`
- Invalidate the pi configuration cache after saving or deleting model config
- Preserve support for auth.json, environment credentials, OAuth, and runtime API keys

## Tests

- `npm run typecheck`
- `npm test -- --run`