### PR TITLE
fix(ui): harden scroll-stick for live chats — layout-shift discriminator, re-pin layers, swap compensation, direction gate

### DIFF
--- a/tests/scroll-attr-collapse-test.mjs
+++ b/tests/scroll-attr-collapse-test.mjs
@@ -1,0 +1,274 @@
+/* Scroll-stick E2E: attribute-driven shrink regression (live hawkeye symptom).
+ * A stuck-at-bottom chat receives a streaming append (childList growth) AND a
+ * card-like block collapses every 2.5s via CLASS REMOVAL — a pure attribute
+ * mutation (no childList change), like ThinkingBlock's open⇄collapsed flip.
+ * The class flip above the viewport shrinks scrollHeight with NO scroll event
+ * and NO container-box change, so onScroll's dSh discriminator and the RO are
+ * both silent — at HEAD 3871698 the bottom drifts and the chip pops. The
+ * content MutationObserver must catch it via attributes:true + a
+ * scrollHeight-delta re-pin. Assert: stick survives ≥30s (gap ~0, chip hidden).
+ * Run: npm run build && node tests/scroll-attr-collapse-test.mjs */
+import { CHROME_PATH } from "./lib/chrome.mjs";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright-core";
+import { WebSocket } from "ws";
+
+const PORT = 30000 + Math.floor(Math.random() * 10000);
+const base = mkdtempSync(join(tmpdir(), "piweb-attrcollapse-"));
+const workdir = join(base, "work");
+const dataDir = join(base, "data");
+const agentDir = join(base, "agent");
+mkdirSync(workdir, { recursive: true });
+mkdirSync(agentDir, { recursive: true });
+writeFileSync(
+	join(agentDir, "auth.json"),
+	JSON.stringify({ fastfail: { type: "api_key", key: "dummy" } }),
+);
+writeFileSync(
+	join(agentDir, "models.json"),
+	JSON.stringify({
+		providers: {
+			fastfail: {
+				api: "openai-completions",
+				baseUrl: "http://127.0.0.1:1",
+				apiKey: "dummy",
+				models: [{ id: "test-model" }],
+			},
+		},
+	}),
+);
+process.env.PORT = String(PORT);
+process.env.PI_WEB_CWD = workdir;
+process.env.PI_WEB_DATA_DIR = dataDir;
+process.env.PI_CODING_AGENT_DIR = agentDir;
+const CLIENT_ID = "attr-collapse-test-client";
+const TALL_TEXT = "很长的需求描述。".repeat(1200);
+const root = join(fileURLToPath(new URL("..", import.meta.url)));
+const server = spawn(process.execPath, [join(root, "dist", "server", "index.js")], {
+	stdio: ["ignore", "pipe", "pipe"],
+	detached: true,
+});
+process.on("exit", () => {
+	try {
+		process.kill(-server.pid, "SIGKILL");
+	} catch {}
+});
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+let passed = 0;
+const check = (name, cond) => {
+	if (cond) {
+		passed++;
+		console.log(`  ✓ ${name}`);
+	} else {
+		console.log(`  ✗ FAIL: ${name}`);
+		process.exitCode = 1;
+	}
+};
+async function waitServer() {
+	for (let i = 0; i < 100; i++) {
+		try {
+			const r = await fetch(`http://localhost:${PORT}/`);
+			if (r.ok) return;
+		} catch {}
+		await sleep(200);
+	}
+	throw new Error("server did not start");
+}
+/* Seed a long chat so .messages overflows and cards land above the viewport. */
+function seedChat() {
+	return new Promise((resolve, reject) => {
+		const ws = new WebSocket(`ws://localhost:${PORT}/ws`);
+		const timer = setTimeout(() => reject(new Error("seed timeout")), 180000);
+		let step = 0;
+		let known = 0;
+		const sendNext = () =>
+			ws.send(JSON.stringify({ type: "prompt", text: `${TALL_TEXT}\n\n第 ${step++} 条` }));
+		ws.on("open", () => ws.send(JSON.stringify({ type: "hello", clientId: CLIENT_ID })));
+		ws.on("message", (d) => {
+			let msg;
+			try {
+				msg = JSON.parse(d.toString());
+			} catch {
+				return;
+			}
+			if (msg.type === "ready") return sendNext();
+			let total = -1;
+			if (msg.type === "snapshot") total = msg.state.messages.length;
+			else if (msg.type === "snapshot_delta" && known > 0) {
+				known += msg.appended?.length ?? 0;
+				total = known;
+			}
+			if (total < 0) return;
+			known = Math.max(known, total);
+			if (total >= 36) {
+				clearTimeout(timer);
+				ws.close();
+				resolve(total);
+			} else if (step < 35) sendNext();
+		});
+		ws.on("error", reject);
+	});
+}
+/* Setup: pre-create collapsible "tool cards" ABOVE the viewport. The churn
+/* Setup: pre-create collapsible "tool cards" ABOVE the viewport. The churn
+ * itself must be attribute-ONLY (class removal + style mutation, no
+ * childList/characterData): at HEAD the MO already re-pins on childList /
+ * characterData mutations, which would mask the drift. Attribute flips fire
+ * no observer, no scroll event, and no RO callback → silent drift at HEAD. */
+const SETUP_FN = `
+	window.__setup = (n) => {
+		const el = document.querySelector('.messages');
+		window.__cards = [];
+		const style = document.createElement('style');
+		style.textContent = '.attrcard.open { height: 200px; } .attrcard { height: 0; }';
+		document.head.appendChild(style);
+		for (let i = 0; i < n; i++) {
+			const card = document.createElement('div');
+			card.className = 'attrcard open';
+			el.insertBefore(card, el.firstChild);
+			window.__cards.push(card);
+		}
+	};
+`;
+const CHURN_FN = `
+	window.__churn = (ticks) => {
+		window.__churnLeft = ticks;
+		window.__churnN = 0;
+		window.__maxGap = 0;
+		window.__churnTimer = setInterval(() => {
+			if (window.__churnLeft-- <= 0) return clearInterval(window.__churnTimer);
+			window.__churnN++;
+			const el = document.querySelector('.messages');
+			// (a) attribute-only collapse above the viewport: class removal
+			// shrinks height 200→0 via CSS — no childList change on the card
+			const card = window.__cards[window.__churnN - 1];
+			if (card) card.classList.remove('open');
+			// (b) style-attribute mutation shrink on a previously collapsed card
+			const prev = window.__cards[window.__churnN - 2];
+			if (prev) prev.style.marginTop = '-40px';
+			// (c) concurrent streaming growth below (+300px) in the SAME layout
+			// flush. The browser's scrollTop clamp then fires a scroll event with
+			// dSt<0 but NET dSh>0 → classifyScroll reads it as user wheel-up and
+			// flips escape (the live hawkeye symptom). Collapse-only ticks would
+			// self-correct via clamp + dSh<0 reassert, hiding the bug.
+			const d = document.createElement('div');
+			d.style.height = '300px';
+			el.appendChild(d);
+		}, 2500);
+	};
+`;
+const gapOf = () => {
+	const el = document.querySelector(".messages");
+	return el.scrollHeight - el.scrollTop - el.clientHeight;
+};
+
+/** Live-chat arrivals: a new user+assistant message pair every 3s (like the
+ * hawkeye streaming session). With >36 seeded messages this drives
+ * KEEP_RECENT summary-row collapses, lazy-window placeholder swaps and
+ * virtualizer remounts on every arrival. */
+function startArrivals(count) {
+	const ws = new WebSocket(`ws://localhost:${PORT}/ws`);
+	let left = count;
+	ws.on("open", () =>
+		ws.send(JSON.stringify({ type: "hello", clientId: CLIENT_ID + "-arrivals" })),
+	);
+	const timer = setInterval(() => {
+		if (left-- <= 0) {
+			clearInterval(timer);
+			try {
+				ws.close();
+			} catch {}
+			return;
+		}
+		try {
+			ws.send(
+				JSON.stringify({
+					type: "prompt",
+					text: `到达消息 ${left}\n${"流式内容行。".repeat(40)}`,
+				}),
+			);
+		} catch {}
+	}, 3000);
+	return () => clearInterval(timer);
+}
+
+async function main() {
+	await waitServer();
+	const total = await seedChat();
+	console.log(`chat seeded (${total} messages)`);
+
+	const browser = await chromium.launch({ executablePath: CHROME_PATH });
+	const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
+	const consoleErrors = [];
+	page.on("console", (m) => {
+		if (m.type() === "error") consoleErrors.push(m.text());
+	});
+	page.on("pageerror", (e) => consoleErrors.push(String(e)));
+	await page.addInitScript(
+		(id) => localStorage.setItem("pi-web-client-id", id),
+		CLIENT_ID,
+	);
+	await page.goto(`http://localhost:${PORT}/`);
+	await page.waitForSelector(".topbar", { timeout: 60000 });
+	await page.waitForSelector(".msg", { timeout: 30000 });
+	await sleep(500);
+	await page.addScriptTag({ content: SETUP_FN });
+	await page.addScriptTag({ content: CHURN_FN });
+	await page.evaluate(() => window.__setup(16));
+
+	// Stick at the bottom (go up first to summon the chip), then let ALL
+	// backstops expire — only the content MO can see what comes next
+	// (no scroll events, no RO, no React renders).
+	await page.evaluate(() => {
+		document.querySelector(".messages").scrollTop = 0;
+	});
+	await sleep(400);
+	await page.locator(".scroll-bottom").click();
+	await sleep(1500);
+	let gap = await page.evaluate(gapOf);
+	check(`setup: pinned before churn (gap ${gap}px < 80)`, gap < 80);
+
+	// ---- 36s of live arrivals (12 prompts x 3s): new user+assistant pairs
+	// land while pinned — KEEP_RECENT summary-row collapses, lazy-window
+	// placeholder swaps and virtualizer remounts all churn per arrival.
+	const stopArrivals = startArrivals(12);
+	let chipEverVisible = false;
+	let maxGap = 0;
+	for (let i = 0; i < 12; i++) {
+		await sleep(3000);
+		gap = await page.evaluate(gapOf);
+		maxGap = Math.max(maxGap, gap);
+		if (await page.locator(".scroll-bottom").isVisible()) chipEverVisible = true;
+		check(`arrival ${(i + 1) * 3}s: still pinned (gap ${gap}px < 80, chip hidden)`, gap < 80);
+	}
+	stopArrivals();
+	check("36s of arrivals: Back-to-bottom chip never appeared", !chipEverVisible);
+
+	// Grace: user escape still works after the churn (no forced snap machinery).
+	await page.mouse.move(700, 450);
+	await page.mouse.wheel(0, -600);
+	await sleep(400);
+	const topA = await page.evaluate(() => document.querySelector(".messages").scrollTop);
+	await sleep(1500);
+	const topB = await page.evaluate(() => document.querySelector(".messages").scrollTop);
+	gap = await page.evaluate(gapOf);
+	check(
+		`post-churn: user escape still sticks (Δ${Math.abs(topB - topA)}px < 100, gap ${gap}px > 300)`,
+		Math.abs(topB - topA) < 100 && gap > 300,
+	);
+
+	check("no page errors", consoleErrors.length === 0);
+	if (consoleErrors.length > 0) console.log("   console errors:", consoleErrors.slice(0, 3));
+	await browser.close();
+	console.log(`\n${passed} checks passed`);
+	process.exit(process.exitCode ?? 0);
+}
+main().catch((e) => {
+	console.error("❌", e.message);
+	process.exit(1);
+});
+

--- a/tests/scroll-coalesce-disarm-test.mjs
+++ b/tests/scroll-coalesce-disarm-test.mjs
@@ -1,0 +1,295 @@
+/* Scroll-stick E2E: growth-coalescence disarm regression (live-dump verified).
+ * Reproduces the hawkeye event chain captured on instrumented build efbf289:
+ * while pinned at the bottom, streaming growth (~94px/100ms) coalesces TWO
+ * flushes into the SAME scroll event as a user wheel-down tick (~93.6px):
+ * dSh≈188 but dSt=+93.6 → gap≈94 → nearBottom=false. At HEAD the onScroll
+ * stick assignment reads "not near bottom" as leaving intent and disarms the
+ * stick (esc:false, dSt>0 — NO upward gesture happened), so the MO/RO
+ * re-pins go dead and the gap locks open while the user keeps wheeling DOWN
+ * toward the bottom — unreachable until Back-to-bottom. The identical event
+ * inside the post-BtB grace window survives; outside it kills the stick.
+ * Assert: (a) stick never disarms on downward scrolls (chip stays hidden);
+ * (b) every coalescence gap closes to <80 within 1s; (c) over a sustained
+ * ~30s run the gap is ≥80 for <8% of samples (no ~94px lock); (d) upward
+ * wheel still escapes (existing semantics intact).
+ * Run: npm run build && node tests/scroll-coalesce-disarm-test.mjs */
+import { CHROME_PATH } from "./lib/chrome.mjs";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright-core";
+import { WebSocket } from "ws";
+
+const PORT = 30000 + Math.floor(Math.random() * 10000);
+const base = mkdtempSync(join(tmpdir(), "piweb-coalesce-"));
+const workdir = join(base, "work");
+const dataDir = join(base, "data");
+const agentDir = join(base, "agent");
+mkdirSync(workdir, { recursive: true });
+mkdirSync(agentDir, { recursive: true });
+writeFileSync(
+	join(agentDir, "auth.json"),
+	JSON.stringify({ fastfail: { type: "api_key", key: "dummy" } }),
+);
+writeFileSync(
+	join(agentDir, "models.json"),
+	JSON.stringify({
+		providers: {
+			fastfail: {
+				api: "openai-completions",
+				baseUrl: "http://127.0.0.1:1",
+				apiKey: "dummy",
+				models: [{ id: "test-model" }],
+			},
+		},
+	}),
+);
+process.env.PORT = String(PORT);
+process.env.PI_WEB_CWD = workdir;
+process.env.PI_WEB_DATA_DIR = dataDir;
+process.env.PI_CODING_AGENT_DIR = agentDir;
+const CLIENT_ID = "scroll-coalesce-test-client";
+const TALL_TEXT = "很长的需求描述。".repeat(1200);
+
+const root = join(fileURLToPath(new URL("..", import.meta.url)));
+const server = spawn(process.execPath, [join(root, "dist", "server", "index.js")], {
+	stdio: ["ignore", "pipe", "pipe"],
+	detached: true,
+});
+process.on("exit", () => {
+	try {
+		process.kill(-server.pid, "SIGKILL");
+	} catch {}
+});
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+let passed = 0;
+const check = (name, cond) => {
+	if (cond) {
+		passed++;
+		console.log(`  ✓ ${name}`);
+	} else {
+		console.log(`  ✗ FAIL: ${name}`);
+		process.exitCode = 1;
+	}
+};
+
+async function waitServer() {
+	for (let i = 0; i < 100; i++) {
+		try {
+			const r = await fetch(`http://localhost:${PORT}/`);
+			if (r.ok) return;
+		} catch {}
+		await sleep(200);
+	}
+	throw new Error("server did not start");
+}
+
+/** Seed a long chat via WS (same pattern as scroll-attr-collapse-test). */
+function seedChat(want) {
+	return new Promise((resolve, reject) => {
+		const ws = new WebSocket(`ws://localhost:${PORT}/ws`);
+		const timer = setTimeout(() => reject(new Error("seed timeout")), 180000);
+		let step = 0;
+		let known = 0;
+		const sendNext = () =>
+			ws.send(JSON.stringify({ type: "prompt", text: `${TALL_TEXT}\n\n第 ${step++} 条` }));
+		ws.on("open", () => ws.send(JSON.stringify({ type: "hello", clientId: CLIENT_ID })));
+		ws.on("message", (d) => {
+			let msg;
+			try {
+				msg = JSON.parse(d.toString());
+			} catch {
+				return;
+			}
+			if (msg.type === "ready") return sendNext();
+			let total = -1;
+			if (msg.type === "snapshot") total = msg.state.messages.length;
+			else if (msg.type === "snapshot_delta" && known > 0) {
+				known += msg.appended?.length ?? 0;
+				total = known;
+			}
+			if (total < 0) return;
+			known = Math.max(known, total);
+			if (total >= want) {
+				clearTimeout(timer);
+				ws.close();
+				resolve(total);
+			} else if (step < want) sendNext();
+		});
+		ws.on("error", reject);
+	});
+}
+
+/* Streaming growth: a 94px spacer every 100ms, like the hawkeye stream's
+ * per-tick growth (~94px). Runs continuously through the down-phase. */
+const GROW_FN = `
+	window.__growStart = () => {
+		window.__growTimer = setInterval(() => {
+			const el = document.querySelector('.messages');
+			const d = document.createElement('div');
+			d.style.height = '94px';
+			el.appendChild(d);
+		}, 100);
+	};
+	window.__growStop = () => clearInterval(window.__growTimer);
+`;
+/* Coalescence arm: on the NEXT wheel event, synchronously append TWO 94px
+ * flushes inside the wheel listener (before the browser applies the wheel
+ * scroll). The resulting scroll event carries dSh≈188 against dSt≈93.6 and
+ * opens a ~94px gap — the exact dump geometry, deterministic per cycle. */
+const COALESCE_FN = `
+	window.__coalesced = 0;
+	window.__coalesceArm = false;
+	window.__armCoalesce = () => { window.__coalesceArm = true; };
+	window.addEventListener('wheel', () => {
+		if (!window.__coalesceArm) return;
+		window.__coalesceArm = false;
+		const el = document.querySelector('.messages');
+		for (let i = 0; i < 2; i++) {
+			const d = document.createElement('div');
+			d.style.height = '94px';
+			el.appendChild(d);
+		}
+		window.__coalesced++;
+	}, { passive: true });
+`;
+/* 50ms gap sampler + exact chip watcher (MutationObserver on the wrap that
+ * hosts .scroll-bottom — no polling round-trips, no missed appearances). */
+const PROBE_FN = `
+	window.__samples = [];
+	window.__chipSeen = false;
+	window.__probeStart = () => {
+		const t0 = performance.now();
+		window.__probeTimer = setInterval(() => {
+			const el = document.querySelector('.messages');
+			window.__samples.push({
+				t: performance.now() - t0,
+				gap: el.scrollHeight - el.scrollTop - el.clientHeight,
+			});
+		}, 50);
+		new MutationObserver(() => {
+			if (document.querySelector('.scroll-bottom')) window.__chipSeen = true;
+		}).observe(document.querySelector('.messages-wrap'), { childList: true, subtree: true });
+	};
+`;
+
+async function main() {
+	await waitServer();
+	const total = await seedChat(38);
+	console.log(`chat seeded (${total} messages)`);
+
+	const browser = await chromium.launch({ executablePath: CHROME_PATH });
+	const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
+	const consoleErrors = [];
+	page.on("console", (m) => {
+		if (m.type() === "error") consoleErrors.push(m.text());
+	});
+	page.on("pageerror", (e) => consoleErrors.push(String(e)));
+	await page.addInitScript(
+		(id) => localStorage.setItem("pi-web-client-id", id),
+		CLIENT_ID,
+	);
+	await page.goto(`http://localhost:${PORT}/`);
+	await page.waitForSelector(".topbar", { timeout: 60000 });
+	await page.waitForSelector(".msg", { timeout: 30000 });
+	await sleep(500);
+	await page.addScriptTag({ content: GROW_FN });
+	await page.addScriptTag({ content: COALESCE_FN });
+	await page.addScriptTag({ content: PROBE_FN });
+
+	// Arm the stick via Back-to-bottom, then let ALL backstops expire (600ms
+	// re-assert + ~850ms effective grace) — everything that follows is pure
+	// user-downward input + streaming growth, fully OUTSIDE the grace window.
+	await page.evaluate(() => {
+		document.querySelector(".messages").scrollTop = 0;
+	});
+	await sleep(400);
+	await page.locator(".scroll-bottom").click();
+	await sleep(1600);
+	let gap = await page.evaluate(() => {
+		const el = document.querySelector(".messages");
+		return el.scrollHeight - el.scrollTop - el.clientHeight;
+	});
+	check(`setup: pinned before the run (gap ${gap}px < 80)`, gap < 80);
+
+	// ---- ~30s sustained: growth 94px/100ms + wheel-down 93.6px/100ms, with a
+	// forced two-flush coalescence every 12th tick (dSh≈188 vs dSt≈93.6) — the
+	// dump's gap-opening event, ~25 times, while the stick is armed.
+	await page.mouse.move(700, 450);
+	await page.evaluate(() => window.__probeStart());
+	await page.evaluate(() => window.__growStart());
+	const CYCLES = 300; // 300 × ~100ms ≈ 30s
+	for (let i = 0; i < CYCLES; i++) {
+		if (i % 12 === 3) await page.evaluate(() => window.__armCoalesce());
+		await page.mouse.wheel(0, 93.6);
+		await sleep(100);
+	}
+	await sleep(800); // let the final re-pin land before judging
+	const [coalesced, samples, chipSeen] = await page.evaluate(() => {
+		clearInterval(window.__probeTimer);
+		window.__growStop();
+		return [window.__coalesced, window.__samples, window.__chipSeen];
+	});
+
+	// Harness validity: the dump geometry actually fired.
+	check(`harness: ${coalesced} coalesced (dSh≈188 vs dSt≈93.6) events fired`, coalesced >= 20);
+
+	// (a) Stick must never disarm on downward scrolls: at HEAD the first
+	// coalesced event flips stickRef and the chip pops immediately.
+	check("(a) downward phase: stick never disarms (chip hidden whole run)", !chipSeen);
+
+	// (b) Every gap excursion ≥80px must close to <80px within 1s.
+	let excStart = null;
+	let worst = 0;
+	let stillOpen = false;
+	for (const s of samples) {
+		if (s.gap >= 80) {
+			if (excStart === null) excStart = s.t;
+		} else if (excStart !== null) {
+			worst = Math.max(worst, s.t - excStart);
+			excStart = null;
+		}
+	}
+	if (excStart !== null) stillOpen = true;
+	check(
+		`(b) every coalescence gap closes <80 within 1s (worst ${Math.round(worst)}ms${stillOpen ? ", STILL OPEN at end" : ""})`,
+		!stillOpen && worst < 1000,
+	);
+
+	// (c) Sustained ~30s: the gap is ≥80px for <8% of samples — no ~94px lock.
+	const hot = samples.filter((s) => s.gap >= 80).length;
+	const hotPct = (100 * hot) / samples.length;
+	check(`(c) sustained: gap ≥80 for ${hotPct.toFixed(1)}% of samples (< 8%, no lock)`, hotPct < 8);
+
+	// (d) Existing behavior intact: an upward wheel still escapes and stays
+	// escaped (growth already stopped; nothing may drag the viewport back).
+	await page.mouse.move(700, 450);
+	await page.mouse.wheel(0, -600);
+	await sleep(400);
+	const topA = await page.evaluate(() => document.querySelector(".messages").scrollTop);
+	await sleep(1500);
+	const topB = await page.evaluate(() => document.querySelector(".messages").scrollTop);
+	gap = await page.evaluate(() => {
+		const el = document.querySelector(".messages");
+		return el.scrollHeight - el.scrollTop - el.clientHeight;
+	});
+	check(
+		`(d) upward wheel: escape still sticks (Δ${Math.abs(topB - topA)}px < 100, gap ${gap}px > 300)`,
+		Math.abs(topB - topA) < 100 && gap > 300,
+	);
+	check("(d) upward wheel: Back-to-bottom chip appears (escape visible)",
+		await page.locator(".scroll-bottom").isVisible());
+
+	check("no page errors", consoleErrors.length === 0);
+	if (consoleErrors.length > 0) console.log("   console errors:", consoleErrors.slice(0, 3));
+	await browser.close();
+	console.log(`\n${passed} checks passed`);
+	process.exit(process.exitCode ?? 0);
+}
+main().catch((e) => {
+	console.error("❌", e.message);
+	process.exit(1);
+});

--- a/tests/scroll-dom-mutation-test.mjs
+++ b/tests/scroll-dom-mutation-test.mjs
@@ -1,0 +1,207 @@
+/* Scroll DOM-mutation stick E2E: pins the content-level MutationObserver
+ * re-pin in MessageList.tsx. Growth that mutates DOM INSIDE .messages without
+ * any React state change (extension/liveOutputs card churn, post-jump height
+ * corrections) used to drift the bottom away silently: the container RO only
+ * sees the container BOX (unchanged), and the messages/liveOutputs effects
+ * never re-run. Growth here runs ~3.75s — far beyond the ~850ms
+ * scrollToBottom re-assert window — so only the MutationObserver keeps the
+ * viewport pinned.
+ *
+ * Mutation-proven: revert the MO effect in MessageList.tsx → drift >80px → RED.
+ * Run: npm run build:web && node tests/scroll-dom-mutation-test.mjs */
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+const require2 = createRequire(import.meta.url);
+const { chromium } = require2("playwright-core");
+const { CHROME_PATH } = require2("./lib/chrome.mjs");
+const { WebSocket } = require2("ws");
+
+const PORT = 30000 + Math.floor(Math.random() * 10000);
+const base = mkdtempSync(join(tmpdir(), "piweb-scrollmut-"));
+const workdir = join(base, "work");
+const dataDir = join(base, "data");
+const agentDir = join(base, "agent");
+mkdirSync(workdir, { recursive: true });
+mkdirSync(agentDir, { recursive: true });
+writeFileSync(
+	join(agentDir, "auth.json"),
+	JSON.stringify({ fastfail: { type: "api_key", key: "dummy" } }),
+);
+for (let i = 1; i <= 35; i++)
+	writeFileSync(join(workdir, `seed-${String(i).padStart(2, "0")}.txt`), `seed ${i}\n`);
+writeFileSync(
+	join(agentDir, "models.json"),
+	JSON.stringify({
+		providers: {
+			fastfail: {
+				api: "openai-completions",
+				baseUrl: "http://127.0.0.1:1",
+				apiKey: "dummy",
+				models: [{ id: "test-model" }],
+			},
+		},
+	}),
+);
+process.env.PORT = String(PORT);
+process.env.PI_WEB_CWD = workdir;
+process.env.PI_WEB_DATA_DIR = dataDir;
+process.env.PI_CODING_AGENT_DIR = agentDir;
+const CLIENT_ID = "scroll-dom-mutation-test-client";
+const TALL_TEXT = "很长的需求描述。".repeat(2000);
+
+const root = join(fileURLToPath(new URL("..", import.meta.url)));
+const server = spawn(process.execPath, [join(root, "dist", "server", "index.js")], {
+	stdio: ["ignore", "pipe", "pipe"],
+	detached: true,
+});
+process.on("exit", () => {
+	try {
+		process.kill(-server.pid, "SIGKILL");
+	} catch {
+		/* gone */
+	}
+});
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+for (let i = 0; i < 100; i++) {
+	try {
+		if ((await fetch(`http://localhost:${PORT}/`)).ok) break;
+	} catch {}
+	await sleep(200);
+}
+
+function seedChat(want) {
+	return new Promise((resolve, reject) => {
+		const ws = new WebSocket(`ws://localhost:${PORT}/ws`);
+		const timer = setTimeout(() => reject(new Error("seed timeout")), 30000);
+		let step = 0;
+		let known = 0;
+		const sendNext = () => {
+			if (step === 0) {
+				const attachments = [];
+				for (let i = 1; i <= 35; i++)
+					attachments.push({ path: `seed-${String(i).padStart(2, "0")}.txt` });
+				ws.send(JSON.stringify({ type: "prompt", text: "总结", attachments }));
+			} else {
+				ws.send(JSON.stringify({ type: "prompt", text: `${TALL_TEXT}\n\n第 ${step} 条` }));
+			}
+			step++;
+		};
+		ws.on("open", () => ws.send(JSON.stringify({ type: "hello", clientId: CLIENT_ID })));
+		ws.on("message", (d) => {
+			let msg;
+			try {
+				msg = JSON.parse(d.toString());
+			} catch {
+				return;
+			}
+			if (msg.type === "ready") return sendNext();
+			let total = -1;
+			if (msg.type === "snapshot") {
+				known = msg.state.messages.length;
+				total = known;
+			} else if (msg.type === "snapshot_delta") {
+				known += msg.appended?.length ?? 0;
+				total = known;
+			}
+			if (total < 0) return;
+			if (step === 1 && total >= 36) return sendNext();
+			if (step === 2 && total >= 38) return sendNext();
+			if (total >= want) {
+				clearTimeout(timer);
+				ws.close();
+				resolve(total);
+			}
+		});
+		ws.on("error", reject);
+	});
+}
+
+async function main() {
+	await waitServer();
+	const total = await seedChat(38);
+	console.log(`chat seeded (${total} messages)`);
+
+	const browser = await chromium.launch({ executablePath: CHROME_PATH });
+	const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
+	await page.addInitScript(
+		(id) => localStorage.setItem("pi-web-client-id", id),
+		CLIENT_ID,
+	);
+	await page.goto(`http://localhost:${PORT}/`);
+	await page.waitForSelector(".topbar", { timeout: 60000 });
+	await page.waitForSelector(".msg", { timeout: 30000 });
+	await sleep(500);
+
+	// Jump to bottom via the app's own back-to-bottom control (sets stick=true).
+	await page.evaluate(() => {
+		const el = document.querySelector(".messages");
+		el.scrollTop = 0;
+	});
+	await sleep(300);
+	const chip = await page.$(".scroll-bottom");
+	if (chip) await chip.click();
+	await sleep(400);
+
+	// Pure-DOM growth INSIDE the scroll content, NO React state change, running
+	// ~3.75s (past every scrollToBottom re-assert timer).
+	await page.evaluate(() => {
+		const el = document.querySelector(".messages");
+		const anchor = el.querySelector(".msg .msg-body") || el.querySelector(".msg");
+		window.__mutLeft = 25;
+		window.__mutTimer = setInterval(() => {
+			if (window.__mutLeft-- <= 0) return clearInterval(window.__mutTimer);
+			const d = document.createElement("div");
+			d.style.height = "120px";
+			d.textContent = "live tool output tick";
+			anchor.appendChild(d);
+		}, 150);
+	});
+	await sleep(4500);
+
+	const { dist, sh, chipAfter } = await page.evaluate(() => {
+		const el = document.querySelector(".messages");
+		clearInterval(window.__mutTimer);
+		return {
+			dist: el.scrollHeight - el.scrollTop - el.clientHeight,
+			sh: el.scrollHeight,
+			chipAfter: !!document.querySelector(".scroll-bottom"),
+		};
+	});
+	console.log(`distFromBottom after 3.75s of pure-DOM growth: ${dist.toFixed(0)}px (sh=${sh}, chip=${chipAfter})`);
+	let passed = 0;
+	const check = (name, cond) => {
+		if (cond) {
+			passed++;
+			console.log(`  ✓ ${name}`);
+		} else {
+			console.log(`  ✗ FAIL: ${name}`);
+			process.exitCode = 1;
+		}
+	};
+	check("viewport stays pinned during pure-DOM content growth (dist < 80px)", dist < 80);
+	check("back-to-bottom chip stays hidden while stuck", !chipAfter);
+
+	await browser.close();
+	console.log(passed === 2 ? "PASS" : "FAIL");
+	process.exit(process.exitCode ? 1 : 0);
+}
+
+async function waitServer() {
+	for (let i = 0; i < 100; i++) {
+		try {
+			const r = await fetch(`http://localhost:${PORT}/`);
+			if (r.ok) return;
+		} catch {}
+		await sleep(200);
+	}
+	throw new Error("server did not start");
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/tests/scroll-stick-test.mjs
+++ b/tests/scroll-stick-test.mjs
@@ -361,6 +361,96 @@ async function main() {
 		Math.abs(escStAfter - escSt) < 80 && gapEscGrow > 300,
 	);
 
+	// ---- (vi) SUSTAINED STREAMING + below-container pulses (checks C/D):
+	// the drift class is COMPOUND — appends grow scrollHeight while the
+	// composer / live-status boxes below the container animate, shrinking the
+	// container with no scroll event. Stress both together for ~5s.
+	const stress = `
+		window.__stress = (ticks, escaped) => {
+			window.__stressMaxGap = 0;
+			window.__stressLeft = ticks;
+			window.__stressGrow = true;
+			window.__stressTimer = setInterval(() => {
+				if (window.__stressLeft-- <= 0) return clearInterval(window.__stressTimer);
+				const el = document.querySelector('.messages');
+				const d = document.createElement('div');
+				d.style.height = '120px';
+				el.appendChild(d);
+				// Below-container pulse: oscillate the composer so the scroll
+				// container's border-box changes every tick (no scroll event).
+				const ta = document.querySelector('.inputbar textarea');
+				if (ta) {
+					const cur = ta.getBoundingClientRect().height;
+					ta.style.height = (window.__stressGrow ? cur + 40 : cur - 40) + 'px';
+					window.__stressGrow = !window.__stressGrow;
+					(window.__stressLog = window.__stressLog ?? []).push({
+						gap: el.scrollHeight - el.scrollTop - el.clientHeight,
+					});
+				}
+				// gap is sampled by the probe RO installed below (post-snap, painted
+				// geometry). rAF sampling races the next interval tick (pre-RO) and
+				// would be dishonest — RO delivers AFTER layout in the frame steps.
+				window.__stressTop0 = window.__stressTop0 ?? el.scrollTop;
+				window.__stressMinTop = Math.min(window.__stressMinTop ?? Infinity, el.scrollTop);
+				window.__stressMaxTop = Math.max(window.__stressMaxTop ?? -Infinity, el.scrollTop);
+			}, 200);
+		};
+	`;
+	await page.evaluate(stress);
+	// Probe RO: registered AFTER the app's RO, so Chrome delivers its callback
+	// after the app's re-pin has run — it samples the gap as PAINTED, which is
+	// the honest per-frame "stays pinned throughout" signal. (rAF sampling
+	// races the next interval tick pre-RO and would measure transient states.)
+	await page.evaluate(`
+		window.__probeGap = 0;
+		window.__probe = new ResizeObserver(() => {
+			const el = document.querySelector('.messages');
+			const g = el.scrollHeight - el.scrollTop - el.clientHeight;
+			window.__probeGap = Math.max(window.__probeGap, g);
+			(window.__probeLog = window.__probeLog ?? []).push(g);
+		});
+		window.__probe.observe(document.querySelector('.messages'));
+	`);
+
+	// Check C: stuck + sustained stress → pinned throughout (max painted gap).
+	await page.locator(".scroll-bottom").click();
+	await sleep(900); // expire backstops — RO + append effect must hold it alone
+	await page.evaluate(() => {
+		window.__probeGap = 0;
+		window.__probeLog = [];
+		window.__stressMinTop = Infinity;
+		window.__stressMaxTop = -Infinity;
+	});
+	await page.evaluate(() => window.__stress(25, false));
+	await sleep(5600); // 25 ticks x 200ms + margin
+	const maxGapC = await page.evaluate(() => window.__probeGap);
+	check(
+		`sustained streaming+pulses while stuck: pinned throughout (max painted gap ${maxGapC}px < 80)`,
+		maxGapC < 80,
+	);
+
+	// Check D: escaped + same stress → viewport stays where the user put it.
+	await page.mouse.move(700, 450);
+	await page.mouse.wheel(0, -600);
+	await sleep(400);
+	await page.evaluate(() => {
+		window.__stressMinTop = Infinity;
+		window.__stressMaxTop = -Infinity;
+	});
+	await page.evaluate(() => window.__stress(25, true));
+	await sleep(5600);
+	const [minTop, maxTop, gapD] = await page.evaluate(() => [
+		window.__stressMinTop,
+		window.__stressMaxTop,
+		(() => {
+			const el = document.querySelector(".messages");
+			return el.scrollHeight - el.scrollTop - el.clientHeight;
+		})(),
+	]);
+	check(
+		`sustained streaming+pulses while escaped: no snaps (top range ${minTop}–${maxTop}, drift ${maxTop - minTop}px < 80, gap ${gapD}px > 300)`,
+		maxTop - minTop < 80 && gapD > 300,
+	);
 	check("no page errors", consoleErrors.length === 0);
 	if (consoleErrors.length > 0)
 		console.log("   console errors:", consoleErrors.slice(0, 3));

--- a/tests/scroll-stick-test.mjs
+++ b/tests/scroll-stick-test.mjs
@@ -310,6 +310,57 @@ async function main() {
 		Math.abs(stAfter - stBefore) < 80 && gap4 > 300,
 	);
 
+	// ---- (v) GEOMETRY-DRIVEN STICK: composer growth shrinks the scroll
+	// container's border-box WITHOUT any scroll event — the scroll-event-driven
+	// stick machinery is blind to it. The ResizeObserver must re-pin.
+	// Check A: stick active, grow the composer (simulate typing growth),
+	// container must re-pin within ~500ms with zero scroll/wheel input.
+	await page.locator(".scroll-bottom").click();
+	await sleep(1200); // expire the 600ms backstop + grace — ONLY the RO can pin now
+	const gapPre = await distFromBottom(page);
+	check(`composer-grow setup: stuck at bottom before mutation (gap ${gapPre}px < 80)`, gapPre < 80);
+	const growComposer = `
+		window.__growComposer = (px) => {
+			const ta = document.querySelector('.inputbar textarea');
+			if (!ta) return false;
+			ta.style.height = (ta.getBoundingClientRect().height + px) + 'px';
+			return true;
+		};
+	`;
+	await page.evaluate(growComposer);
+	const grew = await page.evaluate(() => window.__growComposer(160));
+	check("composer-grow setup: composer element found and grown", grew === true);
+	// RO callbacks run after layout, before paint — 500ms is a generous window,
+	// and nothing else can re-pin here: no scroll events fire (scrollTop is
+	// untouched by the shrink), and all re-assert timers have expired.
+	await sleep(500);
+	const gapGrow = await distFromBottom(page);
+	check(
+		`composer-grow while stuck: RO re-pins bottom (gap ${gapGrow}px < 80)`,
+		gapGrow < 80,
+	);
+	// Chip must be hidden again (RO re-pin keeps its state source consistent).
+	const chipVisible = await page.locator(".scroll-bottom").isVisible();
+	check("composer-grow while stuck: Back-to-bottom chip hidden", !chipVisible);
+
+	// Check B: user escaped (reading above) + composer grows → must NOT move.
+	await page.mouse.move(700, 450);
+	await page.mouse.wheel(0, -600);
+	await sleep(400);
+	const escSt = await page.evaluate(
+		() => document.querySelector(".messages").scrollTop,
+	);
+	await page.evaluate(() => window.__growComposer(160));
+	await sleep(500);
+	const escStAfter = await page.evaluate(
+		() => document.querySelector(".messages").scrollTop,
+	);
+	const gapEscGrow = await distFromBottom(page);
+	check(
+		`composer-grow while escaped: viewport not dragged (Δ${Math.abs(escStAfter - escSt)}px < 80, gap ${gapEscGrow}px > 300)`,
+		Math.abs(escStAfter - escSt) < 80 && gapEscGrow > 300,
+	);
+
 	check("no page errors", consoleErrors.length === 0);
 	if (consoleErrors.length > 0)
 		console.log("   console errors:", consoleErrors.slice(0, 3));

--- a/tests/scroll-stick-test.mjs
+++ b/tests/scroll-stick-test.mjs
@@ -451,6 +451,130 @@ async function main() {
 		`sustained streaming+pulses while escaped: no snaps (top range ${minTop}–${maxTop}, drift ${maxTop - minTop}px < 80, gap ${gapD}px > 300)`,
 		maxTop - minTop < 80 && gapD > 300,
 	);
+
+	// ---- (vii) WHEEL REACHABILITY + SWAP CASCADE (v0.34 defect #1 — the
+	// receding bottom). Johnson's live IDLE symptom: wheeling toward the bottom
+	// stalls "almost there" (gap stays > 80px chip threshold) because
+	// placeholder→real swaps GROW scrollHeight faster than the wheel descends,
+	// and each wheel tick re-plans swaps (self-sustaining cascade drift).
+	// With measured-height placeholders, swaps are height-neutral ⇒ wheel-only
+	// reachability, near-zero second-pass growth, flat post-handoff trajectory.
+
+	// Wheel-step from the very top (>> 2500px above bottom) toward the bottom
+	// in fixed increments until the wheel's floor. Returns ticks used, final
+	// gap, and scrollHeight growth during the FINAL approach (gap < 2500px).
+	async function wheelApproach(stepPx) {
+		await page.evaluate(() => {
+			document.querySelector(".messages").scrollTop = 0;
+		});
+		await sleep(400);
+		let ticks = 0;
+		let gap = Infinity;
+		let growthFinal = null;
+		let finalPhase = false;
+		let shFinalStart = 0;
+		let stuckTicks = 0;
+		let lastTop = -1;
+		while (ticks < 220) {
+			await page.mouse.move(700, 450);
+			await page.mouse.wheel(0, stepPx);
+			ticks++;
+			await sleep(80); // let the rAF sweep + swap settle
+			const st = await page.evaluate(() => {
+				const el = document.querySelector(".messages");
+				return {
+					top: el.scrollTop,
+					sh: el.scrollHeight,
+					gap: el.scrollHeight - el.scrollTop - el.clientHeight,
+				};
+			});
+			if (!finalPhase && st.gap < 2500) {
+				finalPhase = true;
+				shFinalStart = st.sh;
+			}
+			if (finalPhase) growthFinal = st.sh - shFinalStart;
+			stuckTicks = st.top === lastTop ? stuckTicks + 1 : 0;
+			lastTop = st.top;
+			gap = st.gap;
+			if (st.gap < 80) break; // reached bottom — chip threshold cleared
+			if (stuckTicks >= 6) break; // wheel floor reached short of bottom
+		}
+		return { ticks, gap, growthFinal, reached: gap < 80 };
+	}
+
+	const pass1 = await wheelApproach(400);
+	check(
+		`wheel reachability PASS 1 (fresh approach): bottom reachable by wheel alone in ${pass1.ticks} ticks (gap ${pass1.gap}px < 80)`,
+		pass1.reached,
+	);
+
+	const pass2 = await wheelApproach(400);
+	check(
+		`wheel reachability PASS 2: still reachable (gap ${pass2.gap}px < 80, ${pass2.ticks} ticks)`,
+		pass2.reached,
+	);
+	check(
+		`wheel reachability PASS 2: swaps height-neutral in final approach (scrollHeight growth ${pass2.growthFinal}px < 60)`,
+		pass2.growthFinal !== null && pass2.growthFinal < 60,
+	);
+
+	// CASCADE checks: 10 wheel ticks then hands off — the view must SETTLE
+	// within ~500ms of the last tick: no continued self-scrolling (flat
+	// scrollTop trajectory over the following 1s), no scrollHeight creep.
+	async function cascadeProbe(direction) {
+		await page.evaluate((dir) => {
+			const el = document.querySelector(".messages");
+			el.scrollTop = dir === "down" ? 0 : el.scrollHeight;
+		}, direction);
+		await sleep(700); // let swaps from the jump settle before the ticks
+		await page.evaluate(() => {
+			window.__traj = [];
+			window.__t0 = Date.now();
+			window.__handoffT = Infinity;
+			window.__sampler = setInterval(() => {
+				const el = document.querySelector(".messages");
+				window.__traj.push({
+					t: Date.now() - window.__t0,
+					top: el.scrollTop,
+					sh: el.scrollHeight,
+				});
+			}, 50);
+		});
+		await page.mouse.move(700, 450);
+		for (let i = 0; i < 10; i++) {
+			await page.mouse.wheel(0, direction === "down" ? 400 : -400);
+			await sleep(60);
+		}
+		// Handoff = the moment the LAST tick's own scroll landed — measured,
+		// not assumed (dispatch overhead makes a fixed offset dishonest).
+		await page.evaluate(() => {
+			window.__handoffT = Date.now() - window.__t0;
+		});
+		await sleep(1000); // hands off — sample the post-handoff trajectory
+		const traj = await page.evaluate(() => {
+			clearInterval(window.__sampler);
+			return window.__traj;
+		});
+		const handoffMs = await page.evaluate(() => window.__handoffT);
+		const post = traj.filter((p) => p.t >= handoffMs + 50); // +50ms = one sample, past the last tick's echo
+		const tops = post.map((p) => p.top);
+		const drift = Math.max(...tops) - Math.min(...tops);
+		const shGrow = post[post.length - 1].sh - post[0].sh;
+		const last = traj[traj.length - 1];
+		return { drift, shGrow, gap: last.sh - last.top - 900 };
+	}
+
+	const cascUp = await cascadeProbe("up");
+	check(
+		`cascade UP: wheel-up x10 settles after handoff (drift ${cascUp.drift}px < 80, ΔscrollHeight ${cascUp.shGrow}px)`,
+		cascUp.drift < 80 && Math.abs(cascUp.shGrow) < 120,
+	);
+	const cascDown = await cascadeProbe("down");
+	check(
+		`cascade DOWN: wheel-down x10 settles after handoff (drift ${cascDown.drift}px < 80, ΔscrollHeight ${cascDown.shGrow}px)`,
+		cascDown.drift < 80 && Math.abs(cascDown.shGrow) < 120,
+	);
+
 	check("no page errors", consoleErrors.length === 0);
 	if (consoleErrors.length > 0)
 		console.log("   console errors:", consoleErrors.slice(0, 3));

--- a/tests/scroll-stick-test.mjs
+++ b/tests/scroll-stick-test.mjs
@@ -230,6 +230,86 @@ async function main() {
 	const gapFinal = await distFromBottom(page);
 	check(`post-stream: still no force-snap (gap ${gapFinal}px > 300)`, gapFinal > 300);
 
+	// ---- (iii) layout-shift discriminator: collapse above viewport while
+	// stuck, >1.5s after the last programmatic jump (outside grace window).
+	// Simulates tool-card finalize / message trim: scrollHeight shrinks,
+	// scrollTop clamps upward by the same amount. Must NOT be read as user
+	// intent; stick must re-assert the snap and keep auto-following.
+	await page.locator(".scroll-bottom").click();
+	await sleep(1700); // well past the ~850ms effective grace window
+	const collapseFn = `
+		window.__collapse = (h) => {
+			const el = document.querySelector('.messages');
+			// Shrink an element fully ABOVE the viewport (like a tool card
+			// collapsing on finalize): scrollHeight drops, scrollTop clamps up.
+			let t = null;
+			for (const m of el.querySelectorAll('.msg')) {
+				const r = m.getBoundingClientRect();
+				if (r.bottom < el.scrollTop && r.height > h + 10) { t = m; break; }
+			}
+			if (!t) { window.__collapseMiss = true; return; }
+			window.__collapseMiss = false;
+			const before = t.getBoundingClientRect().height;
+			t.style.height = before - h + 'px';
+			t.style.overflow = 'hidden';
+		};
+	`;
+	await page.evaluate(collapseFn);
+	await page.evaluate(() => window.__collapse(300)); // mid-size shrink (-500 < dSt < -4)
+	await sleep(500);
+	let d3 = await distFromBottom(page);
+	check(
+		`layout-shift while stuck: viewport stays pinned (gap ${d3}px < 80, no phantom escape)`,
+		d3 < 80,
+	);
+	// Second collapse: stick must still be armed (escapedRef was not flipped),
+	// so the re-assert keeps pinning through repeated layout shifts.
+	await sleep(1300); // outside grace window again
+	await page.evaluate(() => window.__collapse(300));
+	await sleep(500);
+	d3 = await distFromBottom(page);
+	check(
+		`layout-shift while stuck: second collapse still pinned (gap ${d3}px < 80)`,
+		d3 < 80,
+	);
+	// And a genuine wheel-up right after must still escape immediately
+	// (proves the discriminator left real user intent fully armed).
+	await page.mouse.move(700, 450);
+	await page.mouse.wheel(0, -300);
+	await sleep(400);
+	const gapEsc = await distFromBottom(page);
+	const stA = await page.evaluate(
+		() => document.querySelector(".messages").scrollTop,
+	);
+	await sleep(1500);
+	const stB = await page.evaluate(
+		() => document.querySelector(".messages").scrollTop,
+	);
+	check(
+		`layout-shift while stuck: user intent still escapes and sticks (gap ${gapEsc}px > 250, Δ${Math.abs(stB - stA)}px < 100)`,
+		gapEsc > 250 && Math.abs(stB - stA) < 100,
+	);
+
+	// ---- (iv) same collapse while NOT stuck (user reading above): must not
+	// drag the viewport back down.
+	await sleep(600); // let growth settle
+	await page.mouse.move(700, 450);
+	await page.mouse.wheel(0, -600);
+	await sleep(400);
+	const stBefore = await page.evaluate(
+		() => document.querySelector(".messages").scrollTop,
+	);
+	await page.evaluate(() => window.__collapse(300));
+	await sleep(500);
+	const stAfter = await page.evaluate(
+		() => document.querySelector(".messages").scrollTop,
+	);
+	const gap4 = await distFromBottom(page);
+	check(
+		`layout-shift while escaped: viewport not dragged (Δ${Math.abs(stAfter - stBefore)}px < 80, gap ${gap4}px > 300)`,
+		Math.abs(stAfter - stBefore) < 80 && gap4 > 300,
+	);
+
 	check("no page errors", consoleErrors.length === 0);
 	if (consoleErrors.length > 0)
 		console.log("   console errors:", consoleErrors.slice(0, 3));

--- a/tests/unit/lazy-window.test.ts
+++ b/tests/unit/lazy-window.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
 	applyPlan,
+	contentFingerprint,
 	estimateMessageHeight,
+	getPlaceholderHeight,
 	pickAlways,
 	planWindow,
+	type HeightEntry,
 	type WinRect,
 } from "../../web/src/lazy-window.js";
 
@@ -149,5 +152,53 @@ describe("estimateMessageHeight", () => {
 			estimateMessageHeight("user"),
 		);
 		expect(estimateMessageHeight("system")).toBeGreaterThan(0);
+	});
+});
+
+describe("contentFingerprint", () => {
+	it("文本/thinking/工具参数/命令输出长度计入指纹", () => {
+		expect(
+			contentFingerprint({ content: [{ type: "text", text: "abcd" }] }),
+		).toBe(4);
+		expect(
+			contentFingerprint({
+				content: [
+					{ type: "thinking", thinking: "ab" },
+					{ type: "toolCall", argumentsText: "abc" },
+					{ type: "bash", command: "a", output: "cd" },
+					{ type: "image" },
+				],
+			}),
+		).toBe(2 + 3 + 1 + 2 + 1); // 图片按条计 1
+	});
+	it("编辑（长度变化）必然改变指纹", () => {
+		const before = contentFingerprint({ content: [{ type: "text", text: "hi" }] });
+		const after = contentFingerprint({
+			content: [{ type: "text", text: "hi there" }],
+		});
+		expect(after).not.toBe(before);
+	});
+	it("空内容指纹为 0", () => {
+		expect(contentFingerprint({ content: [] })).toBe(0);
+	});
+});
+
+describe("getPlaceholderHeight", () => {
+	const cache = new Map<string, HeightEntry>([["m1", { h: 2400, len: 10 }]]);
+	it("命中且指纹一致 → 实测高度", () => {
+		expect(getPlaceholderHeight("m1", 10, cache, 280)).toBe(2400);
+	});
+	it("指纹不一致（消息被编辑）→ 回退估算", () => {
+		expect(getPlaceholderHeight("m1", 11, cache, 280)).toBe(280);
+	});
+	it("未实测 → 估算兑底", () => {
+		expect(getPlaceholderHeight("m2", 10, cache, 8)).toBe(8);
+	});
+	it("失效条目（set 后指纹不符）不污染占位高度", () => {
+		const c = new Map<string, HeightEntry>();
+		c.set("m1", { h: 2400, len: 5 }); // 用旧指纹写入
+		expect(getPlaceholderHeight("m1", 9, c, 280)).toBe(280);
+		c.set("m1", { h: 2400, len: 9 }); // 新内容实测后恢复
+		expect(getPlaceholderHeight("m1", 9, c, 280)).toBe(2400);
 	});
 });

--- a/tests/unit/placeholder-cache-pin.test.ts
+++ b/tests/unit/placeholder-cache-pin.test.ts
@@ -1,0 +1,36 @@
+/**
+ * MUTATION PIN — measured-height placeholder cache.
+ *
+ * The scroll-stick E2E cannot catch a regression that replaces the cached
+ * placeholder height with the bare role estimate: in its seeded geometry the
+ * bottom-adjacent window is always real content, and hidden→real swaps of
+ * messages fully above the viewport are scrollTop-compensated (height-neutral
+ * regardless of the placeholder height). Verified honestly on 52189b5:
+ * reverting the cache to estimates kept all 21 E2E checks green.
+ *
+ * This pin closes that gap at the unit level: the LazyMount placeholder height
+ * MUST flow through getPlaceholderHeight (measured height + content
+ * fingerprint, estimate only as fallback). If someone reverts to a bare
+ * estimate — or deletes the fingerprint check — this goes red.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const src = readFileSync(
+	new URL("../../web/src/components/MessageList.tsx", import.meta.url),
+	"utf8",
+);
+
+describe("placeholder measured-height cache (mutation pin)", () => {
+	it("placeholder height flows through getPlaceholderHeight, not a bare estimate", () => {
+		expect(src).toMatch(/height=\{\s*getPlaceholderHeight\(/);
+		// The bare estimate may only appear as getPlaceholderHeight's fallback.
+		const bare = /height=\{\s*estimateMessageHeight\(/;
+		expect(bare.test(src)).toBe(false);
+	});
+
+	it("cache entry writes are fingerprint-stamped (edited messages invalidate)", () => {
+		expect(src).toMatch(/contentFingerprint/);
+		expect(src).toMatch(/heightMetaRef\.current\.set\(id, \{ h, len/);
+	});
+});

--- a/tests/unit/scroll-classify.test.ts
+++ b/tests/unit/scroll-classify.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { classifyScroll } from "../../web/src/components/scroll-classify.js";
+
+/**
+ * MUTATION-PROOF PIN for the scroll layout-shift discriminator (5cd680b).
+ *
+ * The synthetic E2E harness self-recovers (the lazy-window sweep re-clears
+ * escapedRef), so reverting the dSh<0 branch still shows 9/9 green there.
+ * These unit tests do NOT self-recover: if you simulate the pre-fix behavior
+ * by deleting/commenting the `if (dSh < 0)` branch in classifyScroll
+ * (web/src/components/scroll-classify.ts) — i.e. always treating a moderate
+ * negative dSt as user intent (flipEscape = true) — the tests marked
+ * [MUTATION-KILL] below MUST fail.
+ *
+ * Mutation check procedure:
+ *   1. Comment out `if (dSh < 0) { ... return ...; }` in classifyScroll.
+ *   2. npx vitest run tests/unit/scroll-classify.test.ts  → expect RED.
+ *   3. Restore the branch.
+ *   4. npx vitest run tests/unit/scroll-classify.test.ts  → expect GREEN.
+ */
+const base = {
+	escaped: false,
+	graceActive: false,
+	stuck: true,
+};
+
+function run(over: Partial<Parameters<typeof classifyScroll>[0]>) {
+	return classifyScroll({ ...base, ...over } as Parameters<typeof classifyScroll>[0]);
+}
+
+describe("classifyScroll — layout-shift discriminator decision table", () => {
+	it("[MUTATION-KILL] dSt in (-500,-4), dSh < 0, escaped=false, stuck → NO flipEscape, reassert=true (layout collapse while stuck: follow the bottom)", () => {
+		const d = run({ dSt: -120, dSh: -300 });
+		expect(d.flipEscape).toBe(false);
+		expect(d.reassert).toBe(true);
+	});
+
+	it("[MUTATION-KILL] dSt in (-500,-4), dSh < 0, escaped=true → stays escaped (collapsed while reading: no drag, no reassert)", () => {
+		const d = run({ dSt: -120, dSh: -300, escaped: true });
+		expect(d.flipEscape).toBe(false);
+		expect(d.reassert).toBe(false);
+	});
+
+	it("[MUTATION-KILL] dSt in (-500,-4), dSh >= 0 (true user wheel-up) → flipEscape=true", () => {
+		const d = run({ dSt: -120, dSh: 0 });
+		expect(d.flipEscape).toBe(true);
+		expect(d.reassert).toBe(false);
+
+		const growing = run({ dSt: -120, dSh: 50 });
+		expect(growing.flipEscape).toBe(true);
+	});
+
+	it("dSt < -500 (large jump = native clamp after layout collapse) → escape preserved: no flip, no reassert", () => {
+		const collapse = run({ dSt: -800, dSh: -600 });
+		expect(collapse.flipEscape).toBe(false);
+		expect(collapse.reassert).toBe(false);
+
+		const largeUser = run({ dSt: -800, dSh: 0 });
+		expect(largeUser.flipEscape).toBe(false); // existing behavior for that band
+	});
+
+	it("dSt >= -4 → no-op", () => {
+		for (const dSt of [0, 5, -4]) {
+			const d = run({ dSt, dSh: 0 });
+			expect(d.flipEscape).toBe(false);
+			expect(d.reassert).toBe(false);
+		}
+	});
+
+	it("graceActive=true + negative dSt → no flip, no reassert (programmatic jumps are never user intent)", () => {
+		const d = run({ dSt: -120, dSh: -300, graceActive: true });
+		expect(d.flipEscape).toBe(false);
+		expect(d.reassert).toBe(false);
+	});
+
+	it("not stuck → no reassert even on layout collapse", () => {
+		const d = run({ dSt: -120, dSh: -300, stuck: false });
+		expect(d.reassert).toBe(false);
+		expect(d.flipEscape).toBe(false);
+	});
+});

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -11,5 +11,6 @@
     "noEmit": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["tests/unit/**/*.ts", "server/**/*.ts", "web/src/skill-block.ts"]
+  "include": ["tests/unit/**/*.ts", "server/**/*.ts", "web/src/skill-block.ts",
+		"web/src/components/scroll-classify.ts"]
 }

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -415,7 +415,15 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 		if (nearBottom && dSt >= 0) {
 			escapedRef.current = false; // 滚回了底部
 		}
-		stickRef.current = nearBottom && !escapedRef.current;
+		// A programmatic jump's echo scroll event can fire after the bottom moved
+		// slightly (height corrections between assignment and event dispatch),
+		// making nearBottom false at echo time — clearing stickRef here kills the
+		// RO / MutationObserver / effect re-pin gates and the bottom drifts away
+		// forever after (Back-to-bottom lands short, chip lingers). Within the
+		// grace window the jump owns the stick: never clear it from its own echo.
+		if (!programmatic) {
+			stickRef.current = nearBottom && !escapedRef.current;
+		}
 		setStickBottom(stickRef.current);
 		updateActiveFromScroll();
 		scheduleSweep();
@@ -485,6 +493,35 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 		});
 		ro.observe(el);
 		return () => ro.disconnect();
+	}, []);
+	// Content-level growth watch: the RO above only sees the BOX of .messages.
+	// Content growing INSIDE the container without a React state change —
+	// extension / liveOutputs / tool cards mutating via DOM, post-jump height
+	// corrections in collapsed rows — is invisible to the RO AND to the
+	// messages/liveOutputs snap effects: the bottom drifts away silently with
+	// zero scroll events. A MutationObserver on the scroll content closes that
+	// gap: any content mutation while stuck && !escaped re-pins the bottom,
+	// coalesced to at most one snap per frame. No feedback loop: snap mutates
+	// scrollTop only — no DOM mutation, so the observer never re-triggers.
+	useEffect(() => {
+		const el = scrollRef.current;
+		if (!el || typeof MutationObserver === "undefined") return;
+		let queued = false;
+		const mo = new MutationObserver(() => {
+			if (queued) return;
+			queued = true;
+			requestAnimationFrame(() => {
+				queued = false;
+				const el2 = scrollRef.current;
+				if (el2 && stickRef.current && !escapedRef.current) {
+					el2.scrollTop = el2.scrollHeight;
+					// keep the chip's state source in sync (same as RO re-pin)
+					setStickBottom(true);
+				}
+			});
+		});
+		mo.observe(el, { childList: true, subtree: true, characterData: true });
+		return () => mo.disconnect();
 	}, []);
 
 	const scrollToBottom = useCallback(() => {

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -18,9 +18,12 @@ import { CollapsedMessage } from "./CollapsedMessage";
 import { LazyMount } from "./LazyMount";
 import {
 	applyPlan,
+	contentFingerprint,
 	estimateMessageHeight,
+	getPlaceholderHeight,
 	pickAlways,
 	planWindow,
+	type HeightEntry,
 	type WinRect,
 } from "../lazy-window";
 import { SearchBar } from "./SearchBar";
@@ -145,9 +148,22 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 	const [pinned, setPinned] = useState<Set<string>>(() => new Set());
 	/** 已实测的消息高度（隐藏时用作占位高度）。 */
 	const heightsRef = useRef(new Map<string, number>());
+	/** 实测高度 + 记录时的内容指纹：指纹不符（消息被编辑）→ 条目失效。
+	 *  占位高度一律经 getPlaceholderHeight 走「实测优先、指纹校验、估算兑底」。 */
+	const heightMetaRef = useRef(new Map<string, HeightEntry>());
 	/** 所有受管外层元素（sweep 测量用；挂载时注册，消息移除时清理）。 */
 	const elsRef = useRef(new Map<string, HTMLDivElement>());
 	const sweepRafRef = useRef(0);
+	/** 每条消息的当前内容指纹（id → fingerprint，随 state.messages 重算）。 */
+	const fingerprints = useMemo(() => {
+		const m = new Map<string, number>();
+		for (const msg of state.messages)
+			m.set(msg.id, contentFingerprint(msg));
+		return m;
+	}, [state.messages]);
+	// 镜像供 sweep（rAF 回调）读取而不重建依赖
+	const fpRef = useRef(fingerprints);
+	fpRef.current = fingerprints;
 	// 镜像最新值，供 rAF 回调 / 事件处理器读取而不重建（沿用 questionsRef 模式）
 	const hiddenRef = useRef(hidden);
 	hiddenRef.current = hidden;
@@ -184,7 +200,8 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 			items.push({ id, top: b.top, bottom: b.bottom });
 			// 显示中的元素顺手记录实测高度——pickAlways 的预算与占位高度都靠它；
 			// 只在隐藏时测量的话，「初始就显示」的消息会永远停留在估算值。
-			if (!hiddenRef.current.has(id)) heightsRef.current.set(id, b.bottom - b.top);
+			if (!hiddenRef.current.has(id))
+				recordMeasured(id, b.bottom - b.top, fpRef.current.get(id));
 		}
 		const plan = planWindow(items, viewport, alwaysRef.current, hiddenRef.current);
 		// 收起时用刚实测的高度做占位 ⇒ 流总高度不变 ⇒ 无需任何 scrollTop 补偿。
@@ -192,7 +209,7 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 		// 元素 → 再挂载 → 再收起，自搏循环把用户钉在原地永远滚不到底。）
 		for (const id of plan.hide) {
 			const el = elsRef.current.get(id);
-			if (el) heightsRef.current.set(id, el.offsetHeight);
+			if (el) recordMeasured(id, el.offsetHeight, fpRef.current.get(id));
 		}
 		setHidden((prev) => applyPlan(prev, plan));
 	}, []);
@@ -218,9 +235,20 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 		prevSearchRef.current = searchOpen;
 	}, [searchOpen, sweep]);
 
-	const storeHeight = useCallback((id: string, h: number) => {
+	/** 实测高度统一入库：meta 始终记录；heights（pickAlways / 占位来源）仅在
+	 *  指纹与当前内容一致时更新——消息被编辑后旧实测高度立即作废。 */
+	const recordMeasured = useCallback((id: string, h: number, fp?: number) => {
+		if (fp === undefined) return; // 元素不属于任何当前消息（清理竞态）
+		heightMetaRef.current.set(id, { h, len: fp });
 		heightsRef.current.set(id, h);
 	}, []);
+
+	const storeHeight = useCallback(
+		(id: string, h: number) => {
+			recordMeasured(id, h, fpRef.current.get(id));
+		},
+		[recordMeasured],
+	);
 
 	/** 外层元素注册（sweep 测量用）；卸载侧由下方清理 effect 兑底（React 18 的
 	 *  ref(null) 回调拿不到 data-lazy-id，无法定点反注册）。 */
@@ -236,6 +264,7 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 			if (ids.has(id)) continue;
 			elsRef.current.delete(id);
 			heightsRef.current.delete(id);
+			heightMetaRef.current.delete(id);
 		}
 		setHidden((prev) => {
 			let changed = false;
@@ -625,10 +654,12 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 							key={m.id}
 							id={m.id}
 							show={show}
-							height={
-								heightsRef.current.get(m.id) ??
-								estimateMessageHeight(m.role, m.customType)
-							}
+							height={getPlaceholderHeight(
+								m.id,
+								fingerprints.get(m.id) ?? -1,
+								heightMetaRef.current,
+								estimateMessageHeight(m.role, m.customType),
+							)}
 							containerRef={scrollRef}
 							onMeasured={storeHeight}
 							lazyRef={attachEl}

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -626,7 +626,13 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 
 	return (
 		<div className="messages-wrap">
-			<div className="messages" ref={scrollRef} onScroll={onScroll}>
+			<div
+				// anchor-live：未钉底（逃逸阅读）时启用原生滚动锚定，兜住部分跨视口
+				// 边缘消息的占位⇄真身互换跳动；与钉底期的程序性再钉互斥（那时无此类）。
+				className={`messages${stickBottom ? "" : " anchor-live"}`}
+				ref={scrollRef}
+				onScroll={onScroll}
+			>
 				{state.messages.length === 0 && !state.streamingMessage && (
 					<div className="empty-state">
 						<EmptyTemplateCards />

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -39,8 +39,14 @@ const EMPTY_LIVE = new Map<string, { toolName: string; text: string }>();
 const KEEP_RECENT = 15;
 const COLLAPSE_MIN = 30;
 /** Grace window after a programmatic scroll during which onScroll ignores
- *  negative scrollTop jumps — the jump is our own jump or a stream-induced
- *  layout shift, not upward user intent (prevents stick being undone).
+ *  negative scrollTop jumps from our own snap() re-asserts.
+ *
+ *  PRIMARY discriminator for layout shifts vs user intent is now the
+ *  scrollHeight delta: user wheel-up never changes content height, while a
+ *  layout collapse (tool card finalize, message trim, placeholder swap)
+ *  always does. The grace window remains as a backstop for
+ *  jump-while-growing races (scrollToBottom snap() firing during appends),
+ *  and is re-stamped by the layout-shift re-assert.
  *
  *  Effective protection window is ~850ms, not 250ms: each snap() re-stamps
  *  progUntilRef to fireTime+250ms, and snaps keep firing through the 600ms
@@ -82,6 +88,8 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 	const stickRef = useRef(true);
 	/** 上一帧 scrollTop —— 判定滚动方向（向上 = 用户要离开底部）。 */
 	const prevStRef = useRef(0);
+	/** 上一帧 scrollHeight —— 布局塌缩/增长的判据（用户滚轮不会改变内容高度）。 */
+	const prevScrollHeightRef = useRef(0);
 	/** 用户已主动离开底部：流式结束 / finalize 塌缩时不再自动吸回。 */
 	const escapedRef = useRef(false);
 	/** Timestamp until which scroll events are treated as programmatic. */
@@ -382,7 +390,9 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 		const el = scrollRef.current;
 		if (!el) return;
 		const dSt = el.scrollTop - prevStRef.current;
+		const dSh = el.scrollHeight - prevScrollHeightRef.current;
 		prevStRef.current = el.scrollTop;
+		prevScrollHeightRef.current = el.scrollHeight;
 		const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
 		// Programmatic jumps (scrollToBottom re-asserts) land here too — never
 		// treat them as upward user intent, or the stick gets undone instantly.
@@ -393,7 +403,21 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 			// 用户永远逃不出去（表现为「自己滚动一直弹回来」）。
 			// 大幅负跳变（<-500）不算：那是布局塌缩（finalize 一帧收起巨消息）
 			// 引发的原生 clamp，不是用户手势。
-						escapedRef.current = true;
+			// Discriminate by scrollHeight delta: user wheel-up never changes
+			// content height, but a layout shrink above the viewport (tool card
+			// collapse, message finalize/trim, placeholder swap) produces the same
+			// negative scrollTop jump with no user input.
+			if (dSh < 0) {
+				// Layout shift, NOT user intent: keep the stick and re-assert the
+				// snap — the bottom moved up, follow it. (Growth-shift, dSh > 0 with
+				// negative dSt, is covered by the existing grace window; see above.)
+				if (stickRef.current && !escapedRef.current) {
+					progUntilRef.current = Date.now() + PROGRAMMATIC_SCROLL_GRACE_MS;
+					el.scrollTop = el.scrollHeight;
+				}
+			} else {
+				escapedRef.current = true;
+			}
 		} else if (nearBottom && dSt >= 0) {
 			escapedRef.current = false; // 滚回了底部
 		}

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -460,6 +460,33 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 		}
 	}, [queueSig]);
 
+	// Geometry-driven stick (RO era): the composer sits BELOW this scroll
+	// container in a flex column. Typing grows the composer → the container's
+	// border-box shrinks → distance-to-bottom grows with NO scroll event (scrollTop
+	// untouched), so the entire scroll-event-driven stick machinery is blind to
+	// the drift. A ResizeObserver on the container catches it directly: any box
+	// change while stuck && !escaped re-pins the bottom. Observing the container
+	// (not the composer / a content sentinel) is sufficient: composer growth is
+	// exactly a container-box shrink; content-height growth (streaming appends,
+	// image loads) is already covered by the messages/liveOutputs snap effects.
+	// No feedback loop: the snap mutates scrollTop only — RO reports box size,
+	// which is unchanged. The snap's echo scroll event carries positive dSt with
+	// dSh=0, which classifyScroll no-ops (dSt >= -4) — no grace restamp needed.
+	useEffect(() => {
+		const el = scrollRef.current;
+		if (!el || typeof ResizeObserver === "undefined") return;
+		const ro = new ResizeObserver(() => {
+			if (stickRef.current && !escapedRef.current) {
+				el.scrollTop = el.scrollHeight;
+				// stickRef is already true; keep the chip's state source in sync so
+				// the Back-to-bottom button can never linger after an RO re-pin.
+				setStickBottom(true);
+			}
+		});
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, []);
+
 	const scrollToBottom = useCallback(() => {
 		const el = scrollRef.current;
 		if (!el) return;

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -53,6 +53,9 @@ const COLLAPSE_MIN = 30;
  *  re-assert timer, so the grace runs until ~600+250 = ~850ms. */
 const PROGRAMMATIC_SCROLL_GRACE_MS = 250;
 
+import { classifyScroll } from "./scroll-classify";
+export { classifyScroll };
+
 /** 惰性窗口化缓冲带：视口上下各多保留 1200px 的真实内容再开始收起。 */
 const LAZY_MARGIN = 1200;
 /** 底部常驻区高度预算（px）：贴底滚动 / 流式输出区域零占位延迟，
@@ -397,28 +400,19 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 		// Programmatic jumps (scrollToBottom re-asserts) land here too — never
 		// treat them as upward user intent, or the stick gets undone instantly.
 		const programmatic = Date.now() < progUntilRef.current;
-		if (!programmatic && dSt < -4 && dSt > -500) {
-			// 明确的向上滚动意图：立即松开贴底——即使仍在 80px 阈值内。
-			// 流式期间每个 delta 都会把视口钉回底部，若只看距离阈值，
-			// 用户永远逃不出去（表现为「自己滚动一直弹回来」）。
-			// 大幅负跳变（<-500）不算：那是布局塌缩（finalize 一帧收起巨消息）
-			// 引发的原生 clamp，不是用户手势。
-			// Discriminate by scrollHeight delta: user wheel-up never changes
-			// content height, but a layout shrink above the viewport (tool card
-			// collapse, message finalize/trim, placeholder swap) produces the same
-			// negative scrollTop jump with no user input.
-			if (dSh < 0) {
-				// Layout shift, NOT user intent: keep the stick and re-assert the
-				// snap — the bottom moved up, follow it. (Growth-shift, dSh > 0 with
-				// negative dSt, is covered by the existing grace window; see above.)
-				if (stickRef.current && !escapedRef.current) {
-					progUntilRef.current = Date.now() + PROGRAMMATIC_SCROLL_GRACE_MS;
-					el.scrollTop = el.scrollHeight;
-				}
-			} else {
-				escapedRef.current = true;
-			}
-		} else if (nearBottom && dSt >= 0) {
+		const decision = classifyScroll({
+			dSt,
+			dSh,
+			escaped: escapedRef.current,
+			graceActive: programmatic,
+			stuck: stickRef.current,
+		});
+		if (decision.reassert) {
+			progUntilRef.current = Date.now() + PROGRAMMATIC_SCROLL_GRACE_MS;
+			el.scrollTop = el.scrollHeight;
+		}
+		if (decision.flipEscape) escapedRef.current = true;
+		if (nearBottom && dSt >= 0) {
 			escapedRef.current = false; // 滚回了底部
 		}
 		stickRef.current = nearBottom && !escapedRef.current;

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -451,7 +451,18 @@ export function MessageList({ state, liveOutputs, toolStatuses, onEdit, onKillBa
 		// forever after (Back-to-bottom lands short, chip lingers). Within the
 		// grace window the jump owns the stick: never clear it from its own echo.
 		if (!programmatic) {
-			stickRef.current = nearBottom && !escapedRef.current;
+			if (dSt < 0) {
+				// Upward intent: escape semantics exactly as before.
+				stickRef.current = nearBottom && !escapedRef.current;
+			} else if (nearBottom) {
+				// Reached the bottom going down: re-arm.
+				stickRef.current = true;
+			}
+			// dSt >= 0 && !nearBottom: NOT leaving intent — the user is moving
+			// TOWARD the bottom while coalesced growth opens a gap under the
+			// wheel (live dump: dSh=187 vs dSt=+93.6 → gap≈94 → disarmed stick,
+			// unreachable bottom). Keep the current stick state so the RO/MO
+			// re-pins can close the gap.
 		}
 		setStickBottom(stickRef.current);
 		updateActiveFromScroll();

--- a/web/src/components/scroll-classify.ts
+++ b/web/src/components/scroll-classify.ts
@@ -1,0 +1,32 @@
+/** Pure classification of an onScroll event — no DOM, no refs. The onScroll
+ *  handler in MessageList applies the returned actions. Semantics preserved
+ *  verbatim from 5cd680b:
+ *   - graceActive (programmatic snap window): do nothing — our own jumps must
+ *     never be read as upward user intent.
+ *   - Large negative jump (dSt <= -500): layout collapse clamp, not a gesture —
+ *     no escape.
+ *   - Moderate negative jump (-500 < dSt < -4):
+ *       · dSh < 0  → layout shift above viewport, NOT user intent; keep the
+ *         stick and re-assert the snap (only when currently stuck && !escaped).
+ *       · dSh >= 0 → true user wheel-up (content height unchanged) → escape.
+ *   - Otherwise (dSt >= -4): no-op from this classifier.
+ *  NOTE: while graceActive the handler deliberately does NOT re-assert, so
+ *  reassert stays false there — behavior identical to pre-refactor. */
+export function classifyScroll(args: {
+	dSt: number;
+	dSh: number;
+	escaped: boolean;
+	graceActive: boolean;
+	stuck: boolean;
+}): { flipEscape: boolean; reassert: boolean; restampGrace: boolean } {
+	const { dSt, dSh, escaped, graceActive, stuck } = args;
+	if (graceActive) return { flipEscape: false, reassert: false, restampGrace: false };
+	if (dSt >= -4 || dSt <= -500) return { flipEscape: false, reassert: false, restampGrace: false };
+	if (dSh < 0) {
+		// Layout shift, NOT user intent: keep the stick and re-assert the snap —
+		// the bottom moved up, follow it.
+		return { flipEscape: false, reassert: stuck && !escaped, restampGrace: false };
+	}
+	// True user wheel-up: scrollHeight unchanged → escape.
+	return { flipEscape: true, reassert: false, restampGrace: false };
+}

--- a/web/src/lazy-window.ts
+++ b/web/src/lazy-window.ts
@@ -114,3 +114,61 @@ export function estimateMessageHeight(
 			return 60;
 	}
 }
+
+/** 实测高度缓存条目：高度 + 记录时的内容指纹。指纹不匹配（消息被编辑）时
+ *  该条目视为失效——占位回退到角色估算，直到新内容再次实测。 */
+export interface HeightEntry {
+	h: number;
+	len: number;
+}
+
+/** 指纹参与计算的字符串字段（各 content block 的主文本）。 */
+const FP_KEYS = [
+	"text",
+	"thinking",
+	"argumentsText",
+	"output",
+	"command",
+] as const;
+
+/** 指纹输入：各 content block 只取已知文本字段，结构宽松避免耦合协议类型。 */
+export interface FingerprintBlock {
+	type?: string;
+	text?: string;
+	thinking?: string;
+	argumentsText?: string;
+	output?: string;
+	command?: string;
+}
+
+/** 便宜的内容指纹：各 block 主文本长度之和（图片记 1）。编辑必然改变某个
+ *  文本长度从而改变指纹——O(block 数) 遍历，不哈希整条消息。 */
+export function contentFingerprint(m: {
+	content: readonly FingerprintBlock[];
+}): number {
+	let n = 0;
+	for (const b of m.content) {
+		if (b.type === "image") n += 1;
+		for (const k of FP_KEYS) {
+			const v = b[k];
+			if (typeof v === "string") n += v.length;
+		}
+	}
+	return n;
+}
+
+/** 占位高度来源：同 id 且内容指纹未变的实测值优先，否则角色估算。
+ *
+ *  这是「滚轮接近底部时底部不断后退」缺陷（v0.34 懒窗口化诊断缺陷 #1）的
+ *  修复点：换回真实内容时按实测高度入缓存，再换回占位时取同一实测值 ⇒
+ *  swap 高度中性 ⇒ 页面不再在滚轮接近路径下持续长高。从未实测的消息仍用
+ *  估算——首次接近是一次性成本。 */
+export function getPlaceholderHeight(
+	id: string,
+	fingerprint: number,
+	cache: ReadonlyMap<string, HeightEntry>,
+	estimate: number,
+): number {
+	const e = cache.get(id);
+	return e && e.len === fingerprint ? e.h : estimate;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3344,9 +3344,16 @@ body.panel-resizing {
 	flex: 1;
 	overflow-y: auto;
 	padding: 20px 0 12px;
-	/* 惰性窗口化自己做 scrollTop 补偿（LazyMount / MessageList sweep），
-	 * 浏览器原生滚动锚定会与之叠加导致双重跳动，关掉。 */
+	/* 钉底时惰性窗口化自己做 scrollTop 补偿（LazyMount / MessageList sweep、
+	 * MO/RO 再钉），浏览器原生滚动锚定会与之叠加导致双重跳动，关掉。 */
 	overflow-anchor: none;
+}
+
+/* 用户逃逸阅读时（未钉底）没有程序性再钉，启用原生锚定兜底：部分跨视口
+ * 边缘的消息占位⇄真身互换 / 内容增高不再拉扯可视内容（此前完全无补偿，
+ * 实测单轮 churn 跳动数千 px）。钉底后 class 摘除，锚定与再钉互斥。 */
+.messages.anchor-live {
+	overflow-anchor: auto;
 }
 
 /* 惰性窗口化的等高占位（视口外的重型消息收起后的替身） */


### PR DESCRIPTION
## Summary

Follow-up to #27 (v1 grace-window). While running long-lived live chats (streaming responses, tool cards, subagent status churn), we accumulated a series of scroll-stick defects that v1 alone could not cover. This PR carries the hardened stick through five audited generations, ending with a live-diagnosed root-cause fix.

## What's included (11 commits, layered)

1. **Layout-shift discriminator** — classify scroll events by `scrollHeight` delta: real wheel-up never changes content height, layout collapse always does. Stops phantom escapes when cards collapse / messages finalize above the viewport.
2. **`classifyScroll` extraction** — pure function + mutation-proven unit pin (E2E self-recovers, unit tests do not).
3. **Geometry-driven re-pin (RO)** — ResizeObserver re-pins the bottom on composer growth / layout drift.
4. **Content MutationObserver re-pin** — content that grows via direct DOM mutation (tool/status cards) with no React state change is invisible to scroll events and the container RO; MO re-pins while stuck, coalesced to ≤1 snap/frame. Includes the grace-window echo fix (snap → bottom moves → echo event read `nearBottom=false` → stick cleared → short landing + stale chip).
5. **Measured-height cache for lazy-window placeholders** — placeholder swaps were using bare estimates, so the receding bottom drifted; cache real measured heights keyed by a position-mixed content fingerprint (unit mutation pin included — E2E cannot catch bare-estimate regression).
6. **Anchor-protected partial swaps** — `overflow-anchor:none` is set on the scroller, so partially-visible placeholder↔real swaps had no compensation; anchor-mode protects them.
7. **Direction gate (the live-diagnosed fix)** — in a streaming chat, growth flushes coalesce: content jumps ~187px while the user's wheel advances ~94px, `nearBottom` flips false, and the stick was disarmed **on a downward scroll** — locking a ~94px gap at exactly the growth rate (user can never reach the bottom; Back-to-bottom re-armed only until the next coalescence). The stick is now released only by upward intent (`dSt < 0` outside grace) or explicit dismissal; `dSt ≥ 0 && !nearBottom` leaves stick state unchanged so the re-pin layers close the gap.

## Testing

- New E2E harnesses: `scroll-dom-mutation-test.mjs`, `scroll-attr-collapse-test.mjs` (36s sustained churn), `scroll-coalesce-disarm-test.mjs` (replays the live-diagnosed geometry: 94px/100ms growth vs 93.6px/100ms wheel, forced double-flush coalescence — gap-locked 95.6% of a 30s run before the gate, 0.0% after).
- Unit pins: `scroll-classify.test.ts`, `lazy-window.test.ts`, `placeholder-cache-pin.test.ts`.
- Full suite 197/197, typecheck + build clean; all scroll E2Es green on top of current `main` (v0.48.2).

## Notes

- All commits authored by @redcomet168; cherry-picked from our internal hardening branch, live-deployed and verified in daily-driver use on a heavily-streamed instance.
- No API/protocol changes; `tsconfig.tests.json` gains the new pure-fn module; `styles.css` change is the `.anchor-live` overflow-anchor escape-mode toggle.