### PR TITLE
Make WebUIContext class compatible with the way how SDK uses it (copy…

### DIFF
--- a/server/webui-context.ts
+++ b/server/webui-context.ts
@@ -153,15 +153,17 @@ export class WebUIContext {
 
 	// -- notifications --------------------------------------------------------
 
-	notify(message: string, type?: "info" | "warning" | "error"): void {
+	// Instance arrows so these survive the SDK's wrapUIPromptContext `{ ...ui }`
+	// (object spread copies own properties only, not class prototype methods).
+	notify: ExtensionUIContext["notify"] = (message, type) => {
 		this.emit({ type: "notice", level: type ?? "info", text: message });
-	}
+	};
 
 	// -- footer status (pi-lens "LSP Inactive", pi-cache-optimizer cache stats) --
 
 	private statuses = new Map<string, string>();
 
-	setStatus(key: string, text: string | undefined): void {
+	setStatus: ExtensionUIContext["setStatus"] = (key, text) => {
 		if (text === undefined || text === "") {
 			this.statuses.delete(key);
 		} else {
@@ -171,7 +173,7 @@ export class WebUIContext {
 			else this.statuses.set(key, clean);
 		}
 		this.pushStatuses();
-	}
+	};
 
 	private pushStatuses(): void {
 		this.emit({

--- a/tests/unit/webui-context.test.ts
+++ b/tests/unit/webui-context.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { WebUIContext } from "../../server/webui-context.js";
+import type { ServerMessage } from "../../server/protocol.js";
+
+/** Mimic pi SDK wrapUIPromptContext: `{ ...ui, select: wrapped }` copies own
+ *  properties only. Class prototype methods would vanish here. */
+function wrapLikeSdk(ui: WebUIContext) {
+	return {
+		...ui,
+		select: ui.select,
+	};
+}
+
+describe("WebUIContext SDK wrap", () => {
+	it("setStatus and notify remain functions after object spread", () => {
+		const ui = new WebUIContext(() => {});
+		const wrapped = wrapLikeSdk(ui);
+		expect(typeof wrapped.setStatus).toBe("function");
+		expect(typeof wrapped.notify).toBe("function");
+	});
+
+	it("spread copy still emits statuses and notice", () => {
+		const msgs: ServerMessage[] = [];
+		const ui = new WebUIContext((msg) => msgs.push(msg));
+		const wrapped = wrapLikeSdk(ui);
+
+		wrapped.setStatus("0-claude-max", "🧠 5h 19%");
+		wrapped.notify("hello", "info");
+
+		expect(msgs).toContainEqual({
+			type: "statuses",
+			statuses: [{ key: "0-claude-max", text: "🧠 5h 19%" }],
+		});
+		expect(msgs).toContainEqual({
+			type: "notice",
+			level: "info",
+			text: "hello",
+		});
+	});
+});


### PR DESCRIPTION
… by object spread and lose prototypes). Define `notify` and `setStatus` the same arrow function style as the `setWidget`. Add the test.

 **Change**
 `notify` and `setStatus` were class prototype methods. Pi’s SDK wraps the UI as { ...ui, select, confirm, ... }, and object spread only copies own properties. Those two methods disappeared, so `pi-claude-subscription-connector` crashed on every usage poll.

They are now instance arrows, same pattern as `setWidget` / `select`. After a { ...ui } wrap they stay functions and still emit statuses / notice to the browser.

Addressing https://github.com/xing-shuyin/pi-web-ui/issues/34