### PR TITLE
feat(update-check): all-source update list — web UI + pi core + pi extensions

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -43,6 +43,12 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { BgServerTracker } from "./bg-servers.js";
+import {
+	checkAll as checkAllUpdates,
+	collectTargets,
+	compareVersions as compareSemver,
+	type UpdateItem,
+} from "./update-check.js";
 import { hasPendingWaitSubscription, shouldRetainActive } from "./wait-subscription-scan.js";
 import type { PluginAgentTool, PluginCommandDef, PluginToolEvent } from "./plugins.js";
 import { syncPluginToolsIntoSession } from "./plugins.js";
@@ -1711,14 +1717,7 @@ export class ClientSession {
 
 	/** Simple numeric semver compare: >0 means a newer than b. */
 	private static compareVersions(a: string, b: string): number {
-		const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
-		const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
-		for (let i = 0; i < 3; i++) {
-			const x = pa[i] ?? 0;
-			const y = pb[i] ?? 0;
-			if (x !== y) return x - y;
-		}
-		return 0;
+		return compareSemver(a, b);
 	}
 
 	/** Set by index.ts: called when /pi-web-ui:quit is invoked. */
@@ -1764,6 +1763,54 @@ export class ClientSession {
 				upToDate: false,
 				error: `检查更新失败：${(err as Error).message}`,
 			});
+		}
+	}
+
+	/** Cache window for the all-source check: 30 minutes. */
+	static UPDATE_ALL_CACHE_MS = 30 * 60_000;
+	private updatesAllCache: { at: number; items: UpdateItem[] } | null = null;
+
+	/**
+	 * All-source update check: pi-web-ui + the pi core + direct pi extensions
+	 * from the agent manifest (fallback: raw walk). Re-emits the cached list
+	 * within UPDATE_ALL_CACHE_MS; pass force=true (explicit refresh) to bypass.
+	 */
+	async checkUpdatesAll(force = false): Promise<void> {
+		if (
+			!force &&
+			this.updatesAllCache &&
+			Date.now() - this.updatesAllCache.at <
+				ClientSession.UPDATE_ALL_CACHE_MS
+		) {
+			this.emit({
+				type: "update_status_all",
+				items: this.updatesAllCache.items,
+			});
+			return;
+		}
+		try {
+			const targets = collectTargets(
+				this.agentDir,
+				ClientSession.currentAppVersion(),
+			);
+			const items = await checkAllUpdates(targets);
+			this.updatesAllCache = { at: Date.now(), items };
+			this.emit({ type: "update_status_all", items });
+		} catch (err) {
+			// checkAll degrades per-item; only local enumeration blowing up lands
+			// here — still report a usable (webui-only) error item.
+			const items: UpdateItem[] = [
+				{
+					name: "pi-web-ui",
+					kind: "webui",
+					current: ClientSession.currentAppVersion(),
+					latest: null,
+					latestPublishedAt: null,
+					upToDate: false,
+					error: `检查更新失败：${(err as Error).message}`,
+				},
+			];
+			this.emit({ type: "update_status_all", items });
 		}
 	}
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -660,6 +660,9 @@ wss.on("connection", (ws) => {
 			case "check_update":
 				void cs.checkUpdate();
 				break;
+			case "check_updates_all":
+				void cs.checkUpdatesAll(msg.force === true);
+				break;
 			case "dialog_response":
 				cs.resolveDialog(msg.id, msg.value);
 				break;

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -336,6 +336,7 @@ export type ClientMessage =
 	// -- self-update ----------------------------------------------------------
 	/** Check the npm registry for a newer pi-web-ui version. */
 	| { type: "check_update" }
+	| { type: "check_updates_all"; force?: true } // webui + direct pi extensions (manifest)
 	// -- pi agent setup ------------------------------------------------------
 	/** Auto-install the pi agent (mkdir config dir + npm i -g the CLI). */
 	| { type: "install_pi_agent" }
@@ -1054,6 +1055,21 @@ export type ServerMessage =
 			latestPublishedAt: string | null;
 			upToDate: boolean;
 			error?: string;
+	  }
+	/** Result of a check_updates_all run — one item per checked component
+	 *  (webui, the pi core, direct pi extensions). Failed lookups degrade
+	 *  per-item. */
+	| {
+			type: "update_status_all";
+			items: {
+				name: string;
+				kind: "webui" | "pi-core" | "package";
+				current: string;
+				latest: string | null;
+				latestPublishedAt?: string | null;
+				upToDate: boolean;
+				error?: string;
+			}[];
 	  }
 	// -- goal / review -------------------------------------------------------
 	/** Goal status pushed whenever it changes (set / review start-end / verdict).

--- a/server/update-check.ts
+++ b/server/update-check.ts
@@ -1,0 +1,334 @@
+/**
+ * All-source update check: pi-web-ui itself, the installed pi core
+ * (@earendil-works/pi-coding-agent — probed via `pi --version`, with a
+ * vendored-copy fallback), plus the DIRECT pi extensions declared in
+ * <agentDir>/npm/package.json (fallback: raw node_modules walk).
+ * Pure logic lives here so it can be unit-tested with an injected fetcher
+ * (and an injected pi-core probe); ClientSession only wires it to the wire
+ * protocol.
+ */
+import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PI_CORE_PACKAGE = "@earendil-works/pi-coding-agent";
+
+const REGISTRY = "https://registry.npmjs.org";
+const FETCH_TIMEOUT_MS = 8_000;
+/** Parallel registry lookups per batch. */
+const CONCURRENCY = 5;
+
+/** Simple numeric semver compare: >0 means a newer than b. */
+export function compareVersions(a: string, b: string): number {
+	const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
+	const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
+	for (let i = 0; i < 3; i++) {
+		const x = pa[i] ?? 0;
+		const y = pb[i] ?? 0;
+		if (x !== y) return x - y;
+	}
+	return 0;
+}
+
+/**
+ * Cache a zero-arg function's value for ttlMs. Plain value memoization: the
+ * pi probe returns null on failure instead of throwing, so errors thread
+ * through as ordinary values and there is nothing to rethrow.
+ */
+export function memoizeWithTtl<T>(fn: () => T, ttlMs: number): () => T {
+	let entry: { at: number; value: T } | null = null;
+	return () => {
+		const now = Date.now();
+		if (!entry || now - entry.at >= ttlMs) {
+			entry = { at: now, value: fn() };
+		}
+		return entry.value;
+	};
+}
+
+/**
+ * Parse `pi --version` stdout into a version string, or null. Two-stage:
+ * prefer a line that is exactly the version (optional leading "v", optional
+ * prerelease/build suffix) so a stdout preamble like "Update available:
+ * 0.85.0" cannot forge it; otherwise fall back to the first loose
+ * semver-looking token. The exact-line match keeps the FULL version incl.
+ * prerelease (0.85.0-beta.1 stays 0.85.0-beta.1).
+ */
+export function parsePiVersionOutput(stdout: string): string | null {
+	const exact = stdout.match(/^\s*v?(\d+\.\d+\.\d+(?:[-+][\w.]+)*)\s*$/m)?.[1];
+	if (exact) return exact;
+	return stdout.match(/\d+\.\d+\.\d+/)?.[0] ?? null;
+}
+
+export type UpdateItemKind = "webui" | "pi-core" | "package";
+
+export interface UpdateItem {
+	name: string;
+	kind: UpdateItemKind;
+	current: string;
+	latest: string | null;
+	latestPublishedAt?: string | null;
+	upToDate: boolean;
+	error?: string;
+}
+
+export interface LocalPackage {
+	name: string;
+	version: string;
+	kind: UpdateItemKind;
+}
+
+/**
+ * Enumerate installed pi packages for the "check all updates" list, matching
+ * what the TUI shows: the DIRECT dependencies declared in
+ * <agentDir>/npm/package.json, with each installed version resolved from
+ * node_modules/<name>/package.json (not the manifest range). Transitive deps
+ * are not listed.
+ *
+ * Fallback: when the manifest is missing/unreadable or declares no
+ * dependencies, fall back to the historical raw node_modules walk.
+ */
+export function listInstalledPackages(agentDir: string): LocalPackage[] {
+	const direct = readManifestDeps(agentDir);
+	if (direct) return direct;
+	return walkNodeModules(agentDir);
+}
+
+/** Direct deps from the npm manifest with installed versions, or null. */
+function readManifestDeps(agentDir: string): LocalPackage[] | null {
+	let manifest: { dependencies?: Record<string, string> } | null;
+	try {
+		manifest = JSON.parse(
+			readFileSync(join(agentDir, "npm", "package.json"), "utf8"),
+		) as { dependencies?: Record<string, string> } | null;
+		// Literal `null` parses fine but explodes on property access — treat as
+		// unreadable (fallback to the raw walk), per the documented contract.
+		if (!manifest || typeof manifest !== "object") return null;
+	} catch {
+		return null;
+	}
+	const deps = manifest.dependencies;
+	if (!deps || typeof deps !== "object" || Object.keys(deps).length === 0) {
+		return null;
+	}
+	const root = join(agentDir, "npm", "node_modules");
+	const out: LocalPackage[] = [];
+	for (const name of Object.keys(deps)) {
+		const item = readLocalPackage(join(root, ...name.split("/")));
+		// Broken/uninstalled entries are skipped (the registry never sees them).
+		if (item) out.push(item);
+	}
+	// Deterministic order (manifest key order is arbitrary).
+	return out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}
+
+/**
+ * Legacy fallback: raw walk of <agentDir>/npm/node_modules — top-level plain
+ * names plus one level inside @scope dirs. Skips .bin, dotfiles and anything
+ * without a readable package.json.
+ */
+function walkNodeModules(agentDir: string): LocalPackage[] {
+	const root = join(agentDir, "npm", "node_modules");
+	const out: LocalPackage[] = [];
+	let entries: string[];
+	try {
+		entries = readdirSync(root);
+	} catch {
+		return out;
+	}
+	for (const entry of entries) {
+		if (entry.startsWith(".") || entry === ".bin") continue;
+		if (entry.startsWith("@")) {
+			let scoped: string[];
+			try {
+				scoped = readdirSync(join(root, entry));
+			} catch {
+				continue;
+			}
+			for (const name of scoped) {
+				if (name.startsWith(".")) continue;
+				const item = readLocalPackage(join(root, entry, name));
+				if (item) out.push(item);
+			}
+		} else {
+			const item = readLocalPackage(join(root, entry));
+			if (item) out.push(item);
+		}
+	}
+	// Deterministic order (readdir order is FS-dependent).
+	return out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}
+
+function readLocalPackage(dir: string): LocalPackage | null {
+	try {
+		const pkg = JSON.parse(
+			readFileSync(join(dir, "package.json"), "utf8"),
+		) as { name?: string; version?: string };
+		if (!pkg.name || !pkg.version) return null;
+		return { name: pkg.name, version: pkg.version, kind: "package" };
+	} catch {
+		return null;
+	}
+}
+
+/** Uncached pi core probe (memoized machine-wide below). */
+function rawProbePiCore(): string | null {
+	try {
+		const res = spawnSync("pi", ["--version"], {
+			timeout: 5000,
+			stdio: "pipe",
+			shell: process.platform === "win32",
+		});
+		if (res.error || res.status !== 0) return null;
+		return parsePiVersionOutput(res.stdout?.toString() ?? "");
+	} catch {
+		return null;
+	}
+}
+
+/** How long a pi probe result stays hot (mirrors ClientSession.piCliProbe). */
+const PI_PROBE_TTL_MS = 10_000;
+
+/**
+ * Default pi core probe: run the globally installed `pi --version`, memoized
+ * machine-wide for PI_PROBE_TTL_MS so repeated collectTargets calls never
+ * re-block the event loop on a 5s spawnSync. Null on any failure or absence.
+ * Mirrors ClientSession.isPiCliInstalled() (same spawnSync shape; Windows
+ * resolves `pi` to a pi.cmd shim that only execs through a shell).
+ */
+export const defaultProbePiCore = memoizeWithTtl(
+	rawProbePiCore,
+	PI_PROBE_TTL_MS,
+);
+
+/**
+ * Fallback when the CLI probe yields nothing: the version of the vendored pi
+ * core copy in <agentDir>/npm/node_modules, or null if that is absent too.
+ */
+function readVendoredPiCore(agentDir: string): string | null {
+	try {
+		const pkg = JSON.parse(
+			readFileSync(
+				join(
+					agentDir,
+					"npm",
+					"node_modules",
+					...PI_CORE_PACKAGE.split("/"),
+					"package.json",
+				),
+				"utf8",
+			),
+		) as { name?: string; version?: string };
+		if (pkg.name !== PI_CORE_PACKAGE || !pkg.version) return null;
+		return pkg.version;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Build the full local target list: webui + the pi core + installed packages.
+ * The pi core version comes from the CLI probe (injectable for tests), falling
+ * back to the vendored copy under <agentDir>/npm/node_modules. Packages
+ * listing the core directly are filtered out so the pi-core row wins — never
+ * two rows for the same package.
+ */
+export function collectTargets(
+	agentDir: string,
+	webuiVersion: string,
+	probePiCore: () => string | null = defaultProbePiCore,
+): LocalPackage[] {
+	const targets: LocalPackage[] = [
+		{ name: "pi-web-ui", version: webuiVersion, kind: "webui" },
+	];
+	const coreVersion = probePiCore() ?? readVendoredPiCore(agentDir);
+	if (coreVersion) {
+		targets.push({
+			name: PI_CORE_PACKAGE,
+			version: coreVersion,
+			kind: "pi-core",
+		});
+	}
+	targets.push(
+		...listInstalledPackages(agentDir).filter(
+			(pkg) => pkg.name !== PI_CORE_PACKAGE,
+		),
+	);
+	return targets;
+}
+
+export type Fetcher = (
+	url: string,
+	init?: { signal?: AbortSignal },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+/** Default fetcher (real network). Tests inject a fake. */
+export const defaultFetcher: Fetcher = (url, init) =>
+	fetch(url, init) as unknown as ReturnType<Fetcher>;
+
+interface RegistryDoc {
+	"dist-tags"?: { latest?: string };
+	time?: Record<string, string>;
+}
+
+/** Look up one package's latest version + publish time in the npm registry. */
+export async function fetchLatest(
+	fetcher: Fetcher,
+	name: string,
+): Promise<{ latest: string | null; latestPublishedAt: string | null }> {
+	const res = await fetcher(`${REGISTRY}/${encodeURIComponent(name)}`, {
+		signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+	});
+	if (!res.ok) throw new Error(`HTTP ${res.status}`);
+	const data = (await res.json()) as RegistryDoc;
+	const latest = data["dist-tags"]?.latest ?? null;
+	return {
+		latest,
+		latestPublishedAt: latest && data.time ? (data.time[latest] ?? null) : null,
+	};
+}
+
+/**
+ * Check every target against the registry. One failed lookup degrades to an
+ * error item (upToDate: false) without failing the rest. Results keep the
+ * input order. Bounded concurrency (CONCURRENCY) keeps registry load polite.
+ */
+export async function checkAll(
+	targets: LocalPackage[],
+	fetcher: Fetcher = defaultFetcher,
+): Promise<UpdateItem[]> {
+	const results: UpdateItem[] = new Array(targets.length);
+	let cursor = 0;
+	async function worker() {
+		while (cursor < targets.length) {
+			const i = cursor++;
+			const t = targets[i]!;
+			try {
+				const { latest, latestPublishedAt } = await fetchLatest(fetcher, t.name);
+				results[i] = {
+					name: t.name,
+					kind: t.kind,
+					current: t.version,
+					latest,
+					latestPublishedAt,
+					upToDate:
+						latest === null || compareVersions(t.version, latest) >= 0,
+				};
+			} catch (err) {
+				results[i] = {
+					name: t.name,
+					kind: t.kind,
+					current: t.version,
+					latest: null,
+					latestPublishedAt: null,
+					upToDate: false,
+					error: `检查更新失败：${(err as Error).message}`,
+				};
+			}
+		}
+	}
+	await Promise.all(
+		Array.from({ length: Math.min(CONCURRENCY, targets.length) }, worker),
+	);
+	return results;
+}

--- a/tests/unit/update-check.test.ts
+++ b/tests/unit/update-check.test.ts
@@ -1,0 +1,375 @@
+/**
+ * All-source update check 单测：包枚举（含 scoped/.bin/坏 package.json）、
+ * 结果 shape、并发 checkAll 的优雅降级（单个失败不影响整体）、顺序保持。
+ * 全程注入 fake fetcher，零网络。
+ */
+import { describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	checkAll,
+	collectTargets,
+	compareVersions,
+	listInstalledPackages,
+	memoizeWithTtl,
+	parsePiVersionOutput,
+	type Fetcher,
+	type LocalPackage,
+} from "../../server/update-check.js";
+
+function makeFetcher(
+	latest: Record<string, string>,
+	fail: string[] = [],
+): { fetcher: Fetcher; calls: string[] } {
+	const calls: string[] = [];
+	const fetcher: Fetcher = async (url) => {
+		const name = decodeURIComponent(String(url).split("/").pop() ?? "");
+		calls.push(name);
+		if (fail.includes(name)) return { ok: false, status: 500, json: async () => ({}) };
+		return {
+			ok: true,
+			status: 200,
+			json: async () => ({
+				"dist-tags": { latest: latest[name] ?? null },
+				time: latest[name] ? { [latest[name]]: "2026-01-01T00:00:00Z" } : {},
+			}),
+		};
+	};
+	return { fetcher, calls };
+}
+
+describe("compareVersions", () => {
+	it("numeric segment compare", () => {
+		expect(compareVersions("1.2.3", "1.2.4")).toBeLessThan(0);
+		expect(compareVersions("1.10.0", "1.9.9")).toBeGreaterThan(0);
+		expect(compareVersions("0.48.0", "0.48.0")).toBe(0);
+		expect(compareVersions("1.2", "1.2.0")).toBe(0);
+	});
+});
+
+describe("parsePiVersionOutput", () => {
+	it("prefers an exact version line (leading v, prerelease kept)", () => {
+		expect(parsePiVersionOutput("0.84.4")).toBe("0.84.4");
+		expect(parsePiVersionOutput("v0.84.4")).toBe("0.84.4");
+		expect(parsePiVersionOutput("  0.85.0-beta.1  \n")).toBe("0.85.0-beta.1");
+		expect(parsePiVersionOutput("v0.85.0-beta.1+build.7\n")).toBe(
+			"0.85.0-beta.1+build.7",
+		);
+	});
+
+	it("exact line wins over a misleading preamble", () => {
+		expect(parsePiVersionOutput("Update available: 0.85.0\n0.84.4")).toBe(
+			"0.84.4",
+		);
+	});
+
+	it("falls back to the first loose token when no line is exact", () => {
+		expect(parsePiVersionOutput("pi version is 0.84.4 (built today)")).toBe(
+			"0.84.4",
+		);
+	});
+
+	it("garbage → null", () => {
+		expect(parsePiVersionOutput("")).toBeNull();
+		expect(parsePiVersionOutput("no version here")).toBeNull();
+	});
+});
+
+describe("memoizeWithTtl", () => {
+	it("calls through once within the TTL, again after expiry", () => {
+		vi.useFakeTimers();
+		try {
+			let n = 0;
+			const fn = vi.fn(() => ++n);
+			const memo = memoizeWithTtl(fn, 10_000);
+			expect(memo()).toBe(1);
+			expect(memo()).toBe(1);
+			expect(fn).toHaveBeenCalledTimes(1);
+			vi.advanceTimersByTime(10_000);
+			expect(memo()).toBe(2);
+			expect(fn).toHaveBeenCalledTimes(2);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("caches null results like any other value", () => {
+		vi.useFakeTimers();
+		try {
+			const fn = vi.fn((): string | null => null);
+			const memo = memoizeWithTtl(fn, 60_000);
+			expect(memo()).toBeNull();
+			expect(memo()).toBeNull();
+			expect(fn).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
+describe("listInstalledPackages", () => {
+	let dir: string;
+	it("enumerates plain + scoped, skips .bin/dotfiles/broken", () => {
+		dir = mkdtempSync(join(tmpdir(), "upd-check-"));
+		const root = join(dir, "npm", "node_modules");
+		const pkg = (d: string, name: string, version: string) => {
+			mkdirSync(d, { recursive: true });
+			writeFileSync(
+				join(d, "package.json"),
+				JSON.stringify({ name, version }),
+			);
+		};
+		pkg(join(root, "foo"), "foo", "1.0.0");
+		pkg(join(root, "@scope", "bar"), "@scope/bar", "2.3.4");
+		pkg(join(root, "@scope", "baz"), "@scope/baz", "0.1.0");
+		// noise
+		mkdirSync(join(root, ".bin"), { recursive: true });
+		mkdirSync(join(root, ".hidden"), { recursive: true });
+		mkdirSync(join(root, "@scope", ".staging"), { recursive: true });
+		mkdirSync(join(root, "broken"), { recursive: true });
+		writeFileSync(join(root, "broken", "package.json"), "{not json");
+		mkdirSync(join(root, "empty"), { recursive: true }); // no package.json
+
+		const items = listInstalledPackages(dir);
+		expect(items).toEqual([
+			{ name: "@scope/bar", version: "2.3.4", kind: "package" },
+			{ name: "@scope/baz", version: "0.1.0", kind: "package" },
+			{ name: "foo", version: "1.0.0", kind: "package" },
+		]);
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("returns [] for a missing agentDir", () => {
+		// Self-contained fixture — not coupled to the first test's directory.
+		const isolated = mkdtempSync(join(tmpdir(), "upd-check-empty-"));
+		try {
+			expect(listInstalledPackages(join(isolated, "nope"))).toEqual([]);
+		} finally {
+			rmSync(isolated, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("listInstalledPackages (manifest-driven)", () => {
+	const pkgJson = (d: string, body: unknown) => {
+		mkdirSync(d, { recursive: true });
+		writeFileSync(join(d, "package.json"), JSON.stringify(body));
+	};
+
+	it("lists direct deps with installed versions; transitive-only packages excluded", () => {
+		const dir = mkdtempSync(join(tmpdir(), "upd-manifest-"));
+		try {
+			pkgJson(join(dir, "npm"), {
+				dependencies: { foo: "^1.0.0", "@scope/bar": "~2.0.0" },
+			});
+			const root = join(dir, "npm", "node_modules");
+			pkgJson(join(root, "foo"), { name: "foo", version: "1.2.3" });
+			pkgJson(join(root, "@scope", "bar"), {
+				name: "@scope/bar",
+				version: "2.0.1",
+			});
+			// transitive dep: present in node_modules but not in the manifest
+			pkgJson(join(root, "transitive"), {
+				name: "transitive",
+				version: "0.5.0",
+			});
+
+			expect(listInstalledPackages(dir)).toEqual([
+				{ name: "@scope/bar", version: "2.0.1", kind: "package" },
+				{ name: "foo", version: "1.2.3", kind: "package" },
+			]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("falls back to the raw node_modules walk when the manifest is missing", () => {
+		const dir = mkdtempSync(join(tmpdir(), "upd-fallback-"));
+		try {
+			const root = join(dir, "npm", "node_modules");
+			pkgJson(join(root, "foo"), { name: "foo", version: "1.0.0" });
+			pkgJson(join(root, "extra"), { name: "extra", version: "2.0.0" });
+			// no <dir>/npm/package.json at all → old walk behavior
+			expect(listInstalledPackages(dir)).toEqual([
+				{ name: "extra", version: "2.0.0", kind: "package" },
+				{ name: "foo", version: "1.0.0", kind: "package" },
+			]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("skips manifest deps that are not installed (mixed case pins the no-fallback contract)", () => {
+		const dir = mkdtempSync(join(tmpdir(), "upd-skip-"));
+		try {
+			pkgJson(join(dir, "npm"), {
+				dependencies: { foo: "^1.0.0", ghost: "^1.0.0" },
+			});
+			// one installed sibling: a mutant that bails to the walk when ANY dep
+			// is uninstalled would surface walk-only entries — this pins it
+			pkgJson(join(dir, "npm", "node_modules", "foo"), {
+				name: "foo",
+				version: "1.0.0",
+			});
+			expect(listInstalledPackages(dir)).toEqual([
+				{ name: "foo", version: "1.0.0", kind: "package" },
+			]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("collectTargets", () => {
+	const pkgJson = (d: string, body: unknown) => {
+		mkdirSync(d, { recursive: true });
+		writeFileSync(join(d, "package.json"), JSON.stringify(body));
+	};
+	const makeAgentDir = (
+		manifest: Record<string, string> | null,
+		installed: Array<[rel: string, name: string, version: string]>,
+	) => {
+		const dir = mkdtempSync(join(tmpdir(), "upd-targets-"));
+		if (manifest) pkgJson(join(dir, "npm"), { dependencies: manifest });
+		for (const [rel, name, version] of installed)
+			pkgJson(join(dir, "npm", "node_modules", ...rel.split("/")), {
+				name,
+				version,
+			});
+		return dir;
+	};
+	const CORE = "@earendil-works/pi-coding-agent";
+
+	it("probe hit → one pi-core row, positioned webui < core < packages", () => {
+		const dir = makeAgentDir({ foo: "^1.0.0" }, [["foo", "foo", "1.0.0"]]);
+		try {
+			expect(collectTargets(dir, "0.48.0", () => "0.84.4")).toEqual([
+				{ name: "pi-web-ui", version: "0.48.0", kind: "webui" },
+				{ name: CORE, version: "0.84.4", kind: "pi-core" },
+				{ name: "foo", version: "1.0.0", kind: "package" },
+			]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("probe miss + no vendored copy → no pi-core row, rest unchanged", () => {
+		const dir = makeAgentDir({ foo: "^1.0.0" }, [["foo", "foo", "1.0.0"]]);
+		try {
+			expect(collectTargets(dir, "0.48.0", () => null)).toEqual([
+				{ name: "pi-web-ui", version: "0.48.0", kind: "webui" },
+				{ name: "foo", version: "1.0.0", kind: "package" },
+			]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("probe miss + vendored copy → pi-core row from the vendored version", () => {
+		const dir = makeAgentDir({ foo: "^1.0.0" }, [
+			["foo", "foo", "1.0.0"],
+			[CORE, CORE, "9.9.9"],
+		]);
+		try {
+			expect(collectTargets(dir, "0.48.0", () => null)).toEqual([
+				{ name: "pi-web-ui", version: "0.48.0", kind: "webui" },
+				{ name: CORE, version: "9.9.9", kind: "pi-core" },
+				{ name: "foo", version: "1.0.0", kind: "package" },
+			]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("probe wins over vendored copy; manifest row deduped to one pi-core row", () => {
+		const dir = makeAgentDir(
+			{ foo: "^1.0.0", [CORE]: "^0.84.2" },
+			[
+				["foo", "foo", "1.0.0"],
+				[CORE, CORE, "0.84.3"],
+			],
+		);
+		try {
+			const targets = collectTargets(dir, "0.48.0", () => "0.84.4");
+			expect(targets[0]).toEqual({
+				name: "pi-web-ui",
+				version: "0.48.0",
+				kind: "webui",
+			});
+			expect(targets.filter((t) => t.name === CORE)).toEqual([
+				{ name: CORE, version: "0.84.4", kind: "pi-core" },
+			]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("walk fallback (no manifest) still dedupes the core to one pi-core row", () => {
+		const dir = makeAgentDir(null, [
+			[CORE, CORE, "0.85.0"],
+			["plain", "plain", "1.0.0"],
+		]);
+		try {
+			// probe null → vendored 0.85.0 wins; the raw walk must not re-add CORE
+			expect(collectTargets(dir, "0.48.0", () => null)).toEqual([
+				{ name: "pi-web-ui", version: "0.48.0", kind: "webui" },
+				{ name: CORE, version: "0.85.0", kind: "pi-core" },
+				{ name: "plain", version: "1.0.0", kind: "package" },
+			]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("checkAll", () => {
+	it("shapes items, preserves order, degrades failures per-item", async () => {
+		const targets: LocalPackage[] = [
+			{ name: "pi-web-ui", version: "0.48.0", kind: "webui" },
+			{ name: "@earendil-works/pi-coding-agent", version: "1.0.0", kind: "pi-core" },
+			{ name: "foo", version: "1.0.0", kind: "package" },
+			{ name: "flaky", version: "2.0.0", kind: "package" },
+		];
+		const { fetcher } = makeFetcher(
+			{
+				"pi-web-ui": "0.49.0",
+				"@earendil-works/pi-coding-agent": "1.0.0",
+				foo: "0.9.0",
+			},
+			["flaky"],
+		);
+		const items = await checkAll(targets, fetcher);
+		expect(items.map((i) => i.name)).toEqual(targets.map((t) => t.name));
+		const [webui, core, foo, flaky] = items;
+		expect(webui).toMatchObject({
+			kind: "webui",
+			current: "0.48.0",
+			latest: "0.49.0",
+			upToDate: false,
+			latestPublishedAt: "2026-01-01T00:00:00Z",
+		});
+		expect(core!.upToDate).toBe(true);
+		expect(foo).toMatchObject({ upToDate: true, current: "1.0.0", latest: "0.9.0" });
+		expect(flaky).toMatchObject({
+			latest: null,
+			upToDate: false,
+		});
+		expect(flaky!.error).toContain("500");
+		// one failure never rejects the whole list
+		expect(items.every((i) => typeof i.current === "string")).toBe(true);
+	});
+
+	it("handles missing dist-tags / sparse docs", async () => {
+		const fetcher: Fetcher = async () => ({
+			ok: true,
+			status: 200,
+			json: async () => ({}),
+		});
+		const items = await checkAll(
+			[{ name: "ghost", version: "1.0.0", kind: "package" }],
+			fetcher,
+		);
+		expect(items[0]).toMatchObject({ latest: null, upToDate: true });
+	});
+});

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -143,6 +143,59 @@ export function TopBar({
 	};
 
 	// Shared by the desktop update dropdown and the mobile "⋯" panel.
+	const allUpdates = chat.updatesAll ?? [];
+	// Pure errors don't count as "updates" — they're shown as failed rows.
+	const updatesCount = allUpdates.filter((i) => !i.upToDate && !i.error).length;
+	const renderAllUpdatesBody = () => (
+		<div className="dd-updates-all">
+			<div className="dd-header">{t("updatesAllTitle")}</div>
+			{chat.updatesAll === null ? (
+				<div className="dd-note">{t("checkingUpdate")}</div>
+			) : allUpdates.length === 0 ? (
+				<div className="dd-note">{t("updatesAllUpToDate")}</div>
+			) : (
+				<ul className="dd-all-list">
+					{allUpdates.map((item) => (
+						<li
+							key={`${item.kind}:${item.name}`}
+							className={`dd-all-item${item.error ? " err" : item.upToDate ? "" : " warn"}`}
+						>
+							<span className="dd-all-name" title={item.name}>
+								{item.name}
+							</span>
+							<span className="dd-all-kind">
+								{item.kind === "webui"
+									? t("kindWebUi")
+									: item.kind === "pi-core"
+										? t("kindPiCore")
+										: t("kindPackage")}
+							</span>
+							<span className="dd-all-vers">
+								{item.error ? (
+									t("updateCheckFailed")
+								) : item.upToDate ? (
+									`v${item.current}`
+								) : (
+									<>
+										v{item.current} → v{item.latest}
+									</>
+								)}
+							</span>
+						</li>
+					))}
+				</ul>
+			)}
+			<div className="dd-actions">
+				<button
+					type="button"
+					className="dd-refresh"
+					onClick={() => send({ type: "check_updates_all", force: true })}
+				>
+					{t("updatesAllRefresh")}
+				</button>
+			</div>
+		</div>
+	);
 	const renderUpdateBody = () => (
 		<>
 			<div className="dd-update">
@@ -414,17 +467,26 @@ export function TopBar({
 											})}
 										/>
 									)}
+								{updatesCount > 0 && (
+									<span className="update-badge">
+										{t("updatesAllBadge", { n: updatesCount })}
+									</span>
+								)}
 							</>
 						}
 						open={updateOpen}
 						onOpenChange={(v) => {
 							setUpdateOpen(v);
-							if (v) send({ type: "check_update" });
+							if (v) {
+								send({ type: "check_update" });
+								send({ type: "check_updates_all" });
+							}
 						}}
 						fit
 					>
 						<div className="dd-header">{t("update")}</div>
 						{renderUpdateBody()}
+						{renderAllUpdatesBody()}
 					</Dropdown>
 
 					<a
@@ -465,7 +527,10 @@ export function TopBar({
 						open={moreOpen}
 						onOpenChange={(v) => {
 							setMoreOpen(v);
-							if (v) send({ type: "check_update" });
+							if (v) {
+								send({ type: "check_update" });
+								send({ type: "check_updates_all" });
+							}
 						}}
 					>
 						<div className="dd-header">{t("sound")}</div>
@@ -536,6 +601,7 @@ export function TopBar({
 						))}
 						<div className="dd-header">{t("update")}</div>
 						{renderUpdateBody()}
+						{renderAllUpdatesBody()}
 						<a
 							className="dd-refresh dd-more-link"
 							href="https://github.com/xing-shuyin/pi-web-ui"

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -183,6 +183,14 @@ const zh = {
 	updateTabTitle: "更新 pi-web-ui",
 	updateTerminalHint:
 		"点击后会在可见终端中运行 npm i -g pi-web-ui@latest；完成后重启服务生效（pi-web-ui server restart）。",
+	updatesAllTitle: "全部组件更新",
+	updatesAllBadge: "{n} 个更新",
+	updatesAllUpToDate: "全部组件均为最新",
+	kindWebUi: "Web 界面",
+	kindPiCore: "核心",
+	kindPackage: "组件",
+	updatesAllRefresh: "重新检查全部",
+	updateCheckFailed: "检查失败",
 
 	/* right panel */
 	rootDir: "根目录",
@@ -882,6 +890,14 @@ const en: Record<keyof typeof zh, string> = {
 	updateTabTitle: "Update pi-web-ui",
 	updateTerminalHint:
 		"Clicking runs npm i -g pi-web-ui@latest in a visible terminal; restart the service afterwards to take effect (pi-web-ui server restart).",
+	updatesAllTitle: "Component updates",
+	updatesAllBadge: "{n} updates",
+	updatesAllUpToDate: "All components up to date",
+	kindWebUi: "Web UI",
+	kindPiCore: "Core",
+	kindPackage: "Package",
+	updatesAllRefresh: "Re-check all",
+	updateCheckFailed: "Check failed",
 
 	/* right panel */
 	rootDir: "Root",

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7656,3 +7656,87 @@ span.msg-editor-hint svg {
 		font-size: 12px; /* avoid iOS auto-zoom on focus */
 	}
 }
+
+/* ------------------------------------------------- all-source update check */
+
+/* Amber counter badge on the update chip ("N updates" across all sources). */
+.update-badge {
+	display: inline-flex;
+	align-items: center;
+	padding: 1px 7px;
+	border-radius: 9px;
+	background: var(--amber);
+	color: #fff;
+	font-size: 10.5px;
+	font-weight: 700;
+	line-height: 1.5;
+	white-space: nowrap;
+}
+
+/* Per-component list inside the update dropdown (webui + core + packages). */
+.dd-updates-all {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 8px 10px 10px;
+	border-top: 1px solid var(--border-soft);
+	margin-top: 6px;
+}
+.dd-all-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	max-height: 240px;
+	overflow-y: auto;
+}
+.dd-all-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 4px 8px;
+	border-radius: 6px;
+	font-size: 12px;
+	color: var(--text-dim);
+}
+.dd-all-item.warn {
+	background: rgba(245, 158, 11, 0.08);
+	color: var(--amber);
+}
+.dd-all-item.err {
+	background: rgba(248, 113, 113, 0.08);
+	color: var(--red);
+}
+.dd-all-name {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-family: var(--mono);
+	color: var(--text);
+}
+.dd-all-item.warn .dd-all-name,
+.dd-all-item.err .dd-all-name {
+	color: inherit;
+}
+.dd-all-kind {
+	flex-shrink: 0;
+	font-size: 10.5px;
+	padding: 1px 6px;
+	border-radius: 8px;
+	background: var(--bg-elev1);
+	border: 1px solid var(--border-soft);
+}
+.dd-all-vers {
+	flex-shrink: 0;
+	font-family: var(--mono);
+	font-weight: 600;
+	color: var(--text);
+}
+.dd-all-item.warn .dd-all-vers,
+.dd-all-item.err .dd-all-vers {
+	color: inherit;
+}

--- a/web/src/use-chat.ts
+++ b/web/src/use-chat.ts
@@ -31,6 +31,17 @@ import { PROTOCOL_VERSION } from "./protocol-version";
 
 export type ConnStatus = "connecting" | "open" | "closed";
 
+/** One component in an all-source update check (update_status_all). */
+export interface UpdateAllItem {
+	name: string;
+	kind: "webui" | "pi-core" | "package";
+	current: string;
+	latest: string | null;
+	latestPublishedAt?: string | null;
+	upToDate: boolean;
+	error?: string;
+}
+
 export interface Notice {
 	id: number;
 	level: "info" | "warning" | "error";
@@ -94,6 +105,8 @@ export interface ChatState {
 		upToDate: boolean;
 		error?: string;
 	} | null;
+	/** All-source update check (webui + pi core + installed packages). */
+	updatesAll: UpdateAllItem[] | null;
 	/** Extension widgets (TUI overlays bridged to the web UI). */
 	widgets: { key: string; lines: string[] }[];
 	/** Extension footer statuses (setStatus bridge). */
@@ -221,6 +234,8 @@ type Action =
 				error?: string;
 			};
 	  }
+	| { type: "update_status_all"; items: UpdateAllItem[] }
+	| { type: "updates_check_started" }
 	| { type: "widgets"; widgets: { key: string; lines: string[] }[] }
 	| { type: "statuses"; statuses: { key: string; text: string | undefined }[] }
 	| {
@@ -523,6 +538,11 @@ function reducer(state: ChatState, action: Action): ChatState {
 			return { ...state, pathCompletions: action.completions };
 		case "update_status":
 			return { ...state, update: action.status };
+		case "update_status_all":
+			return { ...state, updatesAll: action.items };
+		case "updates_check_started":
+			// Forced re-check: clear stale rows so the "checking" state renders.
+			return { ...state, updatesAll: null };
 		case "widgets":
 			return { ...state, widgets: action.widgets };
 		case "statuses":
@@ -653,6 +673,7 @@ export function useChat() {
 		installResult: null,
 		pathCompletions: [],
 		update: null,
+		updatesAll: null,
 		widgets: [],
 		statuses: [],
 		dialog: null,
@@ -731,6 +752,11 @@ export function useChat() {
 	const send = useCallback((msg: ClientMessage) => {
 		const ws = wsRef.current;
 		if (ws && ws.readyState === WebSocket.OPEN) {
+			// Forced re-check: drop stale rows immediately so the "checking"
+			// state renders instead of the cached list.
+			if (msg.type === "check_updates_all" && msg.force === true) {
+				dispatch({ type: "updates_check_started" });
+			}
 			ws.send(JSON.stringify(msg));
 			return true;
 		}
@@ -795,6 +821,9 @@ export function useChat() {
 					);
 					ws.send(
 						JSON.stringify({ type: "check_update" } satisfies ClientMessage),
+					);
+					ws.send(
+						JSON.stringify({ type: "check_updates_all" } satisfies ClientMessage),
 					);
 					break;
 				case "snapshot":
@@ -931,6 +960,9 @@ export function useChat() {
 					break;
 				case "update_status":
 					dispatch({ type: "update_status", status: msg });
+					break;
+				case "update_status_all":
+					dispatch({ type: "update_status_all", items: msg.items });
 					break;
 				case "widgets":
 					dispatch({ type: "widgets", widgets: msg.widgets });


### PR DESCRIPTION
### Motivation

The web UI's update check currently covers pi-web-ui itself only (`checkUpdate` → `update_status`). Real-world setups run a dozen pi extensions from `<agentDir>/npm` — the web UI has no visibility into whether they (or the pi core CLI itself) are outdated, and no way to see it at a glance.

This PR extends the update check with an **all-components section** in the existing TopBar update dropdown (mirrored in the mobile "⋯" panel):

| Row | Version source |
|---|---|
| Web UI | existing `checkUpdate` flow (unchanged) |
| **pi core** (`@earendil-works/pi-coding-agent`) | `pi --version` probe — the binary that actually runs — with a vendored-copy fallback under `<agentDir>/npm/node_modules` |
| **pi extensions** | DIRECT dependencies of `<agentDir>/npm/package.json` (the same source of truth the pi TUI uses), each resolved from its installed `node_modules/<name>/package.json` |

Every row is checked against the npm registry (dist-tags.latest + publish time), with bounded concurrency (5) and per-item degradation — one failed lookup shows an error row instead of failing the whole list.

### Design notes

- **Kind-typed rows** (`webui` / `pi-core` / `package`) — wire protocol is purely additive: two new message types (`check_updates_all`, `update_status_all`); the existing singular check is untouched.
- **Server cache**: 30-minute TTL with an explicit forced refresh from the UI.
- **Probe hygiene**: the `pi --version` spawnSync is memoized machine-wide for 10 s (mirrors the existing `piCliProbe` pattern) so repeated checks never re-block the event loop; version parsing is two-stage (exact version line preferred, loose semver fallback) so a stdout preamble can never be mistaken for the current version.
- **Dedupe**: if a manifest ever lists the pi core directly, the `pi-core` row wins — never two rows for one package.
- **i18n**: zh + en for all new strings.

### Tests

19 unit tests (hermetic: temp-dir agent dirs, injected registry fetcher, injected probe): enumeration (manifest-driven with raw-walk fallback), pi-core probe/fallback/precedence/dedupe, registry check shaping and per-item error degradation, probe memoization TTL, version-parse edge cases (prefixed, prerelease, preamble, garbage).

### Scope

Server: new `server/update-check.ts` (pure, injectable logic), small wiring in `agent-service.ts` / `index.ts` / `protocol.ts`. Web: dropdown in `TopBar.tsx`, state in `use-chat.ts`, strings + styles. No existing behavior changes.

Happy to adjust UX (placement, styling, grouping) or scope — the enumeration logic is isolated in one module so it can be reused elsewhere (e.g. the settings panel) if preferred.

*Independent of #32 (scroll fix) — no shared files.*
