### PR TITLE
fix(server): deleting the current chat auto-switches to the next-latest chat (or a new blank one) before rm

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -2698,7 +2698,16 @@ export class ClientSession {
 		await this.pushProjects();
 	}
 
-	/** Permanently delete a persisted session transcript file (history list ✕). */
+	/** Permanently delete a persisted session transcript file (history list ✕).
+	 *
+	 * Deleting the ACTIVE conversation's own transcript is allowed: the session
+	 * first switches away to the next-latest persisted chat (or a fresh blank
+	 * chat when no other history exists). If the displacement could not release
+	 * the file (streaming / open terminals / pending wake subscription /
+	 * conversation cap), the deletion is aborted with a notice instead of
+	 * yanking the file out of a live runtime. Background conversations still
+	 * block deletion outright.
+	 */
 	async deleteSession(path: string): Promise<void> {
 		try {
 			const abs = resolve(path);
@@ -2713,13 +2722,41 @@ export class ClientSession {
 				});
 				return;
 			}
-			// Refuse to pull the file out from under a live conversation.
-			for (const conv of this.convs.values()) {
-				if (conv.session.sessionFile === abs) {
+			// A live conversation may hold the target transcript. A BACKGROUND
+			// conversation must still block deletion outright, but when the ACTIVE
+			// conversation holds it the request can be satisfied by switching away
+			// first (next-latest history chat, or a fresh blank one) and letting
+			// the displacement drop the old runtime.
+			const holdsTarget = (conv: Conversation): boolean => {
+				const file = conv.session.sessionFile;
+				return file !== undefined && resolve(file) === abs;
+			};
+			const holder = [...this.convs.values()].find(holdsTarget);
+			if (holder && holder.id !== this.activeId) {
+				this.emit({
+					type: "notice",
+					level: "warning",
+					text: "该对话正在后台运行，请先停止或关闭该对话再删除",
+				});
+				return;
+			}
+			if (holder) {
+				// Same source the history panel uses (refreshSessions): newest first.
+				const infos = await SessionManager.list(this.cwd);
+				const next = infos
+					.filter((s) => resolve(s.path) !== abs)
+					.sort((a, b) => b.modified.getTime() - a.modified.getTime())[0];
+				if (next) await this.switchSession(next.path);
+				else await this.newChat();
+				// displaceActive() may have RETAINED the old conversation as a
+				// background run (streaming, open terminals, pending wake
+				// subscription, conversation cap) — in every such case the file is
+				// still held, so abort instead of yanking it from a live runtime.
+				if ([...this.convs.values()].some(holdsTarget)) {
 					this.emit({
 						type: "notice",
 						level: "warning",
-						text: "该对话正在使用中，请先切换到其他对话再删除",
+						text: "对话仍在后台运行，已停止删除；请等待其结束后再删除",
 					});
 					return;
 				}

--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -2752,11 +2752,24 @@ export class ClientSession {
 				// background run (streaming, open terminals, pending wake
 				// subscription, conversation cap) — in every such case the file is
 				// still held, so abort instead of yanking it from a live runtime.
-				if ([...this.convs.values()].some(holdsTarget)) {
+				// Only a conversation that is genuinely still running in the
+				// background (streaming / listed) keeps the "wait for it" notice;
+				// a retained-but-idle hold means the switch itself failed (cap,
+				// quiesce, runtime creation) — say that instead.
+				const stillHeld = [...this.convs.values()].find(holdsTarget);
+				if (stillHeld) {
+					let stillRunning = stillHeld.listed;
+					try {
+						stillRunning = stillHeld.session.isStreaming || stillRunning;
+					} catch {
+						// session being replaced — keep the listed-flag fallback
+					}
 					this.emit({
 						type: "notice",
 						level: "warning",
-						text: "对话仍在后台运行，已停止删除；请等待其结束后再删除",
+						text: stillRunning
+							? "对话仍在后台运行，已停止删除；请等待其结束后再删除"
+							: "未能切换到其他对话，已取消删除本次操作",
 					});
 					return;
 				}

--- a/tests/left-panel-delete-test.mjs
+++ b/tests/left-panel-delete-test.mjs
@@ -2,8 +2,11 @@
  * 左栏删除功能协议冒烟（零 token）：
  *   - delete_session：删除 <agentDir>/sessions/ 下的会话文件（磁盘验证 + sessions 列表刷新）
  *   - delete_session 越界路径（会话目录之外）：报错且不动文件
+ *   - delete_session 删除“当前对话”：自动切换到次新历史会话（无历史时新建空白对话）后删除
+ *   - delete_session 删除“唯一的会话”（当前对话持有）：自动新建空白对话后删除，服务不崩
+ *   - delete_session 删除“后台对话占用的会话”（未过期 pi-subagents wake 订阅保留）：拒绝且文件保留
  *   - remove_project：把工作区从最近项目列表移出（projects 消息不再包含）
- * 自起编译后的 server（隔离端口 8967 + 临时 data-dir + 临时 agent-dir），自行清理。
+ * 自起编译后的 server（隔离端口 8967/8968 + 临时 data-dir + 临时 agent-dir），自行清理。
  */
 import { portUp } from "./lib/port-utils.mjs";
 import { fileURLToPath } from "node:url";
@@ -40,9 +43,9 @@ const dataDir = mkdtempSync(join(tmpdir(), "pi-web-lp-del-data-"));
 const agentDir = join(baseTmp, "agent");
 
 // 种两个会话文件（workDir 一条 + otherDir 一条），格式与 pi CLI/TUI 相同
-function seedSession(dirName, id, cwd, text) {
+function seedSession(dirName, id, cwd, text, tsMs = 1722700801000, dirRoot = agentDir) {
 	const safePath = `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
-	const dir = join(agentDir, "sessions", dirName ?? safePath);
+	const dir = join(dirRoot, "sessions", dirName ?? safePath);
 	mkdirSync(dir, { recursive: true });
 	const file = join(dir, `2026-08-04T00-00-00-000Z_${id}.jsonl`);
 	writeFileSync(
@@ -63,7 +66,7 @@ function seedSession(dirName, id, cwd, text) {
 				message: {
 					role: "user",
 					content: [{ type: "text", text }],
-					timestamp: 1722700801000,
+					timestamp: tsMs,
 				},
 			}),
 		].join("\n") + "\n",
@@ -74,34 +77,35 @@ const sess1 = seedSession(null, "del-target", workDir, "要删除的对话");
 const sess2 = seedSession(null, "del-keep", workDir, "要保留的对话");
 const sessOther = seedSession(null, "del-other", otherDir, "另一个项目的对话");
 
-let server = null;
+const servers = [];
 
-async function startServer() {
-	server = spawn("node", ["dist/server/index.js"], {
+async function startServer(env = {
+	PORT: String(PORT),
+	PI_WEB_DATA_DIR: dataDir,
+	PI_CODING_AGENT_DIR: agentDir,
+	PI_WEB_CWD: workDir,
+}) {
+	const proc = spawn("node", ["dist/server/index.js"], {
 		cwd: REPO_ROOT,
-		env: {
-			...process.env,
-			PORT: String(PORT),
-			PI_WEB_DATA_DIR: dataDir,
-			PI_CODING_AGENT_DIR: agentDir,
-			PI_WEB_CWD: workDir,
-		},
+		env: { ...process.env, ...env },
 		stdio: "ignore",
 	});
+	servers.push(proc);
+	const port = Number(env.PORT);
 	for (let i = 0; i < 40; i++) {
 		await sleep(250);
 		try {
-			if (await portUp(PORT)) return;
+			if (await portUp(port)) return;
 		} catch {
 			// not up yet
 		}
 	}
-	throw new Error("server did not start");
+	throw new Error(`server did not start on ${port}`);
 }
 
-function connect() {
+function connect(url = URL) {
 	return new Promise((resolve, reject) => {
-		const ws = new WebSocket(URL);
+		const ws = new WebSocket(url);
 		const inbox = [];
 		const waiters = [];
 		const api = {
@@ -215,13 +219,155 @@ async function run() {
 	c2.ws.close();
 }
 
+/**
+ * 删除“当前对话”的自动切走行为（独立第二套环境，避免干扰上面的既有用例）：
+ *   A) 当前对话持有目标文件 + 存在更早历史 → 自动切到次新会话，再删文件；
+ *   B) 当前对话持有唯一的会话文件 → 自动新建空白对话，再删文件，服务不崩；
+ *   C) 后台对话（未过期 pi-subagents wake 订阅保留）持有目标文件 → 拒绝删除。
+ */
+async function runCurrentSessionCases() {
+	const base2 = mkdtempSync(join(tmpdir(), "pi-web-lp-del-cur-"));
+	const workDir2 = join(base2, "proj");
+	const dataDir2 = mkdtempSync(join(tmpdir(), "pi-web-lp-del-cur-data-"));
+	const agentDir2 = join(base2, "agent");
+	// PI_SUBAGENTS_TEMP_ROOT：让 wake 订阅扫描落在本测试可控的目录里
+	const subRoot = join(base2, "pi-subagents-root");
+	mkdirSync(workDir2, { recursive: true });
+
+	// 先种旧会话再种新会话：mtime 与消息时间戳一致地让“最新”= cur-target（continueRecent 取最新）
+	const sessOld = seedSession(null, "cur-fallback", workDir2, "旧的保留对话", 1722700801000, agentDir2);
+	await sleep(10);
+	const sessActive = seedSession(null, "cur-target", workDir2, "要删除的当前对话", 1722700802000, agentDir2);
+
+	await startServer({
+		PORT: String(PORT + 1),
+		PI_WEB_DATA_DIR: dataDir2,
+		PI_CODING_AGENT_DIR: agentDir2,
+		PI_WEB_CWD: workDir2,
+		PI_SUBAGENTS_TEMP_ROOT: subRoot,
+	});
+	const URL2 = `ws://localhost:${PORT + 1}/ws`;
+	const c = await connect(URL2);
+	const stateMsg = (m) =>
+		(m.type === "snapshot" || m.type === "snapshot_delta") && m.state &&
+		typeof m.state === "object";
+
+	// A) 启动即恢复最近会话：活跃对话持有 cur-target
+	const init = await c.next(
+		(m) => stateMsg(m) && m.state.sessionFile,
+		"初始 snapshot（含 sessionFile）",
+	);
+	check("启动恢复最近会话（当前对话持有 cur-target）", init.state.sessionFile === sessActive, init.state.sessionFile);
+	const convId1 = init.state.conversationId;
+
+	c.send({ type: "delete_session", path: sessActive });
+	const switched = await c.next(
+		(m) => stateMsg(m) && m.state.sessionFile === sessOld,
+		"自动切换到次新会话",
+	);
+	check("删除当前对话后自动切换到次新会话", switched.state.sessionFile === sessOld);
+	check("切换产生了新的活跃对话", switched.state.conversationId !== convId1, `${convId1} → ${switched.state.conversationId}`);
+	const convId2 = switched.state.conversationId;
+	await c.next(
+		(m) => m.type === "conversations" && m.activeId === convId2,
+		"conversations（activeId=新对话）",
+	);
+	await c.next(
+		(m) => m.type === "sessions" && !(m.sessions ?? []).some((x) => x.path === sessActive),
+		"sessions（不含被删项）",
+	);
+	check("被删的当前会话文件已从磁盘消失", !existsSync(sessActive), sessActive);
+
+	// B) 当前对话持有唯一的会话文件 → 自动新建空白对话
+	// 收件箱里滞留着删除前时代的旧状态消息（60ms 防抖快照），必须先清空，
+	// 否则下面的“conversationId 变化”断言会匹配到旧消息。
+	for (;;) {
+		try {
+			await c.next(() => true, "drain", 1);
+		} catch {
+			break;
+		}
+	}
+	c.send({ type: "delete_session", path: sessOld });
+	const blank = await c.next(
+		(m) =>
+			stateMsg(m) &&
+			m.state.conversationId !== convId2 &&
+			m.state.sessionFile !== sessOld,
+		"自动新建空白对话",
+	);
+	check("唯一会话被删后自动新建空白对话", blank.state.conversationId !== convId2, blank.state.conversationId);
+	check("旧会话文件从磁盘消失", !existsSync(sessOld), sessOld);
+	// 删除管线的收尾（rm 后的 sessions 刷新）也到达 —— 证明整条链路跑完、服务未崩
+	await c.next(
+		(m) => m.type === "sessions" && !(m.sessions ?? []).some((x) => x.path === sessOld),
+		"sessions（B 删后刷新）",
+	);
+
+	// C) 后台对话持有目标文件 → 拒绝删除（wake 订阅让切走时保留运行时）
+	const sessBg = seedSession(null, "cur-bg", workDir2, "后台占用的对话", 1722700803000, agentDir2);
+	const sessAfter = seedSession(null, "cur-after", workDir2, "切换目标对话", 1722700804000, agentDir2);
+	const subDir = join(subRoot, "wait-subscriptions");
+	mkdirSync(subDir, { recursive: true });
+	const bgToken = "3f2b8c64-1a2b-4c3d-9e4f-5a6b7c8d9e0f";
+	writeFileSync(join(subDir, `${bgToken}.json`), JSON.stringify({
+		version: 1,
+		token: bgToken,
+		sessionId: sessBg, // 会话 .jsonl 绝对路径（与 conv.session.sessionFile 一致）
+		targetKind: "async",
+		runId: "run-del-test",
+		requestedId: "req-del-test",
+		createdAt: Date.now(),
+		expiresAt: Date.now() + 10 * 60_000,
+	}));
+
+	c.send({ type: "switch_session", path: sessBg });
+	const onBg = await c.next(
+		(m) => stateMsg(m) && m.state.sessionFile === sessBg,
+		"切到后台目标会话",
+	);
+	const bgConvId = onBg.state.conversationId;
+	c.send({ type: "switch_session", path: sessAfter });
+	await c.next(
+		(m) => stateMsg(m) && m.state.sessionFile === sessAfter,
+		"切走（后台保留）",
+	);
+	const convsC = await c.next(
+		(m) =>
+			m.type === "conversations" &&
+			(m.conversations ?? []).some((x) => x.id === bgConvId),
+		"conversations（后台对话在运行列表）",
+	);
+	check(
+		"切走后原对话保留为后台运行",
+		(convsC.conversations ?? []).some((x) => x.id === bgConvId),
+		bgConvId,
+	);
+
+	c.send({ type: "delete_session", path: sessBg });
+	const nC = await c.next(
+		(m) =>
+			m.type === "notice" &&
+			m.level === "warning" &&
+			m.text === "该对话正在后台运行，请先停止或关闭该对话再删除",
+		"后台占用拒绝删除提示",
+	);
+	check("后台对话占用的会话拒绝删除", typeof nC.text === "string" && nC.text.includes("后台运行"), nC.text);
+	check("后台会话文件仍在磁盘", existsSync(sessBg), sessBg);
+
+	c.ws.close();
+}
+
 try {
 	await run();
+	await runCurrentSessionCases();
 } catch (err) {
 	console.error("FATAL:", err?.message ?? err);
 	failures++;
 } finally {
-	if (server?.pid) process.kill(server.pid, "SIGTERM");
+	for (const s of servers) {
+		if (s?.pid) process.kill(s.pid, "SIGTERM");
+	}
 	await sleep(500);
 }
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Problem

Clicking ✕ on the **current** chat in the history list always fails with 「该对话正在使用中，请先切换到其他对话再删除」. The guard is correct — unlinking a transcript under a live conversation runtime orphans it — but it forces a manual two-step (switch away, then delete) for the most common case.

## Changes

`deleteSession()` now distinguishes who holds the target file:

- **Background conversation** → still refuses outright, with clearer wording (「该对话正在后台运行，请先停止或关闭该对话再删除」).
- **Active conversation** → satisfies the request:
  1. Picks the next-latest persisted session from the same source the panel uses (`SessionManager.list(this.cwd)`, `modified` desc, excluding the target) and `switchSession()`s to it — or `newChat()` when no other history exists.
  2. Re-checks that no runtime still holds the file. `displaceActive()` may legitimately retain the old conversation (streaming, open terminals, pending pi-subagents wait subscription, conversation-cap refusal, quiesce) — in every such case deletion aborts with an accurate notice instead of yanking the file from a live runtime. The notice now differentiates "genuinely still running in background" from "switch silently failed" (quiesce/cap), avoiding a misleading double warning.
  3. Only then `rmSync` + `refreshSessions`, exactly as before.
- Bonus hardening: the holder comparison now `resolve()`s both sides; the old raw `sessionFile === abs` compare could miss a non-normalized path and rm under a live runtime.

## Testing

- `tests/left-panel-delete-test.mjs` +3 integration cases (isolated second server, seeded unexpired wake subscription via `PI_SUBAGENTS_TEMP_ROOT`):
  - delete current chat → auto-switches to next-latest, file removed from disk, sessions list refreshed
  - delete the only session in history → fresh blank chat becomes active, service unharmed
  - background-retained chat → refused, file intact
- `npm run typecheck` (3 tsconfigs), `npm run check:protocol`, `node tests/left-panel-delete-test.mjs` (19/19), `npm run test:unit` (26 files / 233 tests) — all green.
- Also verified live against a production install (v0.52.0 build).

## Notes for reviewers

- The await-free re-check→`rmSync` span is atomic w.r.t. the event loop, so no conversation already in the map can take the file between check and unlink.
- Pre-existing (unchanged here): the holder scan is per-`ClientSession`, and an in-flight `openedRuntime` during a concurrent `switch_session` is invisible to the scan — same exposure as before this change.