### PR TITLE
fix(terminal): send title in terminal_create so server doesn't overwr…

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -878,7 +878,7 @@ wss.on("connection", (ws) => {
 				break;
 			case "terminal_create": {
 				const tm = cs.getTerminalManager(msg.conversationId);
-				if (tm) tm.create(msg.terminalId, msg.cwd, msg.cols, msg.rows, cs.getTerminalCwd(msg.conversationId));
+				if (tm) tm.create(msg.terminalId, msg.cwd, msg.cols, msg.rows, cs.getTerminalCwd(msg.conversationId), msg.title);
 				break;
 			}
 			case "terminal_input":

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -252,6 +252,7 @@ export type ClientMessage =
 	| {
 			type: "terminal_create";
 			terminalId: string;
+			title?: string;
 			cwd: string;
 			cols: number;
 			rows: number;

--- a/web/src/components/TermXterm.tsx
+++ b/web/src/components/TermXterm.tsx
@@ -12,6 +12,8 @@ interface TermXtermProps {
 	command?: CommandDef;
 	/** Directory for a bare shell (from the snapshot at tab creation). */
 	cwd: string;
+	/** Display title (sent to server so the PTY metadata uses the correct locale). */
+	title?: string;
 	/** Whether this terminal is the visible one. */
 	active: boolean;
 	send: (msg: ClientMessage) => boolean;
@@ -33,6 +35,7 @@ export function TermXterm({
 	terminalId,
 	command,
 	cwd,
+	title,
 	active,
 	send,
 	register,
@@ -138,6 +141,7 @@ export function TermXterm({
 				send({
 					type: "terminal_create",
 					terminalId,
+					title,
 					conversationId,
 					cwd,
 					cols: term.cols,

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -439,6 +439,7 @@ export function TerminalPanel({ chat, send, terminal }: TerminalPanelProps) {
 							terminalId={t.id}
 							command={t.command}
 							cwd={t.cwd}
+							title={t.title}
 							active={t.id === activeId}
 							send={send}
 							register={terminal.register}


### PR DESCRIPTION
…ite with Chinese default

The terminal_create WebSocket message lacked a title field. The client correctly computed the localized title (e.g. 'Terminal 1' in English) but the server received no title, defaulted to the hardcoded Chinese '终端 N', and broadcast it back via terminal_list — overwriting the correct English title.

- server/protocol.ts: add optional title to terminal_create message type
- server/index.ts: pass msg.title to tm.create()
- web/src/components/TermXterm.tsx: accept title prop, send it
- web/src/components/TerminalPanel.tsx: forward t.title to TermXterm