### PR TITLE
fix(server): scan flat pi 0.84.x session layout via explicit sessions root

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -587,6 +587,19 @@ function collectSessionAnchors(
 	return anchors;
 }
 
+/**
+ * pi 0.84.x 的会话存储是扁平布局：主 transcript jsonl 直接位于 sessions 根目录
+ * 顶层（`<root>/<timestamp>_<uuid>.jsonl`），所属 cwd 是文件内字段；sessions 根
+ * 由 PI_CODING_AGENT_SESSION_DIR 决定，未设时为 <agentDir>/sessions。
+ * 而 SDK 无参的 SessionManager.list()/listAll() 仍走旧版
+ * `<agentDir>/sessions/--<cwd>--/` 子目录布局（新版 pi 下基本为空），
+ * 导致历史对话/项目推导列不到终端 pi 的真实会话。
+ * 这里解析与 pi CLI/TUI 相同的 sessions 根，供调用点显式传入。
+ */
+export function piSessionsRoot(): string {
+	return process.env.PI_CODING_AGENT_SESSION_DIR ?? join(getAgentDir(), "sessions");
+}
+
 export class ClientSession {
 	readonly clientId: string;
 	/** Set by AgentService.attach: reflects the SERVICE-wide quiesce flag
@@ -2910,7 +2923,7 @@ export class ClientSession {
 		if (c && c.cwd === this.cwd && now - c.at < ClientSession.SESSION_INFO_CACHE_TTL) {
 			return c.infos;
 		}
-		const infos = await SessionManager.list(this.cwd);
+		const infos = await SessionManager.list(this.cwd, piSessionsRoot());
 		this.sessionInfosCache = { cwd: this.cwd, infos, at: now };
 		return infos;
 	}
@@ -3008,7 +3021,7 @@ export class ClientSession {
 			}
 			if (holder) {
 				// Same source the history panel uses (refreshSessions): newest first.
-				const infos = await SessionManager.list(this.cwd);
+				const infos = await SessionManager.list(this.cwd, piSessionsRoot());
 				const next = infos
 					.filter((s) => resolve(s.path) !== abs)
 					.sort((a, b) => b.modified.getTime() - a.modified.getTime())[0];
@@ -3270,7 +3283,7 @@ export class ClientSession {
 			);
 			const map = new Map<string, number>();
 			for (const p of saved.projects) map.set(p.path, p.lastUsed);
-			const all = await SessionManager.listAll();
+			const all = await SessionManager.listAll(piSessionsRoot());
 			for (const s of all) {
 				if (s.cwd) {
 					const t = s.modified.getTime();

--- a/tests/unit/pi-sessions-root.test.ts
+++ b/tests/unit/pi-sessions-root.test.ts
@@ -1,0 +1,37 @@
+/**
+ * piSessionsRoot 单元测试（零 token、零 server）。
+ *
+ * 背景：pi 0.84.x 会话为 sessions 根顶层的扁平 jsonl，而 SDK 无参
+ * list()/listAll() 仍扫旧版 --<cwd>-- 子目录 → 历史对话列不到终端会话。
+ * 修复要求 sessions 根解析：
+ *   1. 设了 PI_CODING_AGENT_SESSION_DIR → 原样使用（XDG 布局用户）；
+ *   2. 未设 → 回退 <agentDir>/sessions（默认布局）；
+ *   3. 两种分支都不携带 --<cwd>-- 后缀（显式传给 SDK 后由文件内 cwd 字段过滤）。
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { piSessionsRoot } from "../../server/agent-service.js";
+
+const original = process.env.PI_CODING_AGENT_SESSION_DIR;
+afterEach(() => {
+	if (original === undefined) delete process.env.PI_CODING_AGENT_SESSION_DIR;
+	else process.env.PI_CODING_AGENT_SESSION_DIR = original;
+});
+
+describe("piSessionsRoot", () => {
+	it("prefers PI_CODING_AGENT_SESSION_DIR when set", () => {
+		process.env.PI_CODING_AGENT_SESSION_DIR = "/tmp/custom-sessions";
+		expect(piSessionsRoot()).toBe("/tmp/custom-sessions");
+	});
+
+	it("falls back to <agentDir>/sessions when unset", () => {
+		delete process.env.PI_CODING_AGENT_SESSION_DIR;
+		expect(piSessionsRoot()).toBe(join(getAgentDir(), "sessions"));
+	});
+
+	it("never carries the legacy per-cwd suffix", () => {
+		process.env.PI_CODING_AGENT_SESSION_DIR = "/tmp/custom-sessions";
+		expect(piSessionsRoot()).not.toMatch(/--/);
+	});
+});


### PR DESCRIPTION
## Problem

The history panel (「历史对话」) and the recent-project derivation never show sessions created by the pi CLI/TUI — `/resume` refresh returns an empty list even though transcripts exist on disk.

## Root cause

pi 0.84.x changed the session storage layout to **flat**: each transcript is a `<root>/<timestamp>_<uuid>.jsonl` file directly under the sessions root, and the owning `cwd` is a field *inside* the file. The sessions root itself is controlled by `PI_CODING_AGENT_SESSION_DIR` (default `<agentDir>/sessions`).

The SDK's no-arg `SessionManager.list(cwd)` / `SessionManager.listAll()` still target the **legacy** `<agentDir>/sessions/--<cwd>--/` subdirectory layout, which is empty on modern pi installs — so every enumeration call site in `agent-service.ts` returned 0 sessions. The pi CLI itself calls `SessionManager.list(cwd, sessionDir)` with an explicit sessions root (top-level scan + per-file `cwd` filtering), which is the working posture.

## Fix

Add `piSessionsRoot()` — honors `PI_CODING_AGENT_SESSION_DIR`, falls back to `<agentDir>/sessions` — and pass it explicitly at the three enumeration call sites:

- `loadSessionInfos()` → `SessionManager.list(this.cwd, piSessionsRoot())`
- delete-then-pick-next listing → same
- `pushProjects()` → `SessionManager.listAll(piSessionsRoot())` (the explicit-string branch scans top-level jsonl)

`SessionManager.continueRecent(cwd)` in `ClientSession.create()` is intentionally left alone — it seeds the *first conversation's* runtime and switching it to the flat root would make every new web chat resume the latest terminal session instead of starting fresh.

## Verification

- New unit tests `tests/unit/pi-sessions-root.test.ts` (3 cases: env set / fallback / no legacy suffix)
- Full suite: **249/249 passed**; `npm run typecheck` clean (server + web + tests)
- Local end-to-end on a pi 0.84.x install: history listing goes from **0 → 6** sessions for the home cwd; `listAll` from 0 → **22 sessions across 9 cwds**

---

**中文摘要**：pi 0.84.x 会话改为扁平布局（主 jsonl 位于 sessions 根顶层、cwd 是文件内字段），而 SDK 无参 `list()/listAll()` 仍扫旧版 `--<cwd>--/` 子目录（新版下为空），导致 web 历史对话列不到任何终端会话。本 PR 新增 `piSessionsRoot()`（识别 `PI_CODING_AGENT_SESSION_DIR`，回退 `<agentDir>/sessions`）并在三处枚举调用显式传入，与 pi CLI 的调用姿势一致；`continueRecent` 种子会话有意不动（否则 web 新建对话会接管终端最近会话）。含 3 个单测，全套 249/249 绿、typecheck 干净；本地实测列表 0→6（当前 cwd）/ 0→22（全库）。
