### PR TITLE
Retain displaced conversations with active pi-subagents async work

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -2845,12 +2845,17 @@ export class ClientSession {
 		// still owes this conversation a wake-up turn.
 		// 还要检查 pi-subagents 的 active-run marker：后台子代理 / 工作流仍在
 		// 运行（queued/running）时释放运行时会杀死扩展宿主，所有进行中的
-		// 异步运行被中止。保留同样自限：运行终态即删 marker，且 24h mtime
-		// 过期视为 crash 孤儿。
+		// 异步运行被中止。探针是全局粒度（跨会话）：session 级保留需逐 marker
+		// 读 <runId>/status.json（queued 运行可能瞬时缺失），故接受更粗的全局
+		// 探针。保留同样自限：运行终态即删 marker，且 24h mtime 过期视为
+		// crash 孤儿。
 		// And retain while pi-subagents has live async work (active-run markers):
 		// disposing the runtime would kill the extension host and abort every
-		// in-flight background run. Self-limiting: markers are removed on
-		// terminal states and expire after 24h.
+		// in-flight background run. The probe is GLOBAL (cross-session):
+		// session-scoped retention would require reading <runId>/status.json per
+		// marker (transiently absent for queued runs), so we accept the coarser
+		// global probe. Self-limiting: markers are removed on terminal states and
+		// expire after 24h.
 		const retained = shouldRetainActive({
 			reviewing: conv.goal.reviewing,
 			wizardRunning: conv.wizardRunning,

--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -50,7 +50,7 @@ import {
 	compareVersions as compareSemver,
 	type UpdateItem,
 } from "./update-check.js";
-import { hasPendingWaitSubscription, shouldRetainActive } from "./wait-subscription-scan.js";
+import { hasActiveSubagentRuns, hasPendingWaitSubscription, shouldRetainActive } from "./wait-subscription-scan.js";
 import type { PluginAgentTool, PluginCommandDef, PluginToolEvent } from "./plugins.js";
 import { syncPluginToolsIntoSession } from "./plugins.js";
 import { SettingsService } from "./settings-service.js";
@@ -2843,6 +2843,14 @@ export class ClientSession {
 		// Also retain when a non-expired pi-subagents wait-subscription record
 		// exists on disk for this session: a finished background subagent run
 		// still owes this conversation a wake-up turn.
+		// 还要检查 pi-subagents 的 active-run marker：后台子代理 / 工作流仍在
+		// 运行（queued/running）时释放运行时会杀死扩展宿主，所有进行中的
+		// 异步运行被中止。保留同样自限：运行终态即删 marker，且 24h mtime
+		// 过期视为 crash 孤儿。
+		// And retain while pi-subagents has live async work (active-run markers):
+		// disposing the runtime would kill the extension host and abort every
+		// in-flight background run. Self-limiting: markers are removed on
+		// terminal states and expire after 24h.
 		const retained = shouldRetainActive({
 			reviewing: conv.goal.reviewing,
 			wizardRunning: conv.wizardRunning,
@@ -2851,6 +2859,7 @@ export class ClientSession {
 			listed: conv.listed,
 			promptedSinceActive: conv.promptedSinceActive,
 			hasPendingWake: () => hasPendingWaitSubscription({ sessionId: conv.session.sessionFile }),
+			hasActiveSubagentWork: () => hasActiveSubagentRuns(),
 		});
 		if (retained) {
 			conv.listed = true;

--- a/server/wait-subscription-scan.ts
+++ b/server/wait-subscription-scan.ts
@@ -25,7 +25,7 @@
 // conversation switches. See the Chinese block above for the persistence layout
 // and the fail-open vs fail-closed rationale.
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir, tmpdir, userInfo } from "node:os";
 import path from "node:path";
 
@@ -121,6 +121,18 @@ export function resolveSubscriptionsDir(env: NodeJS.ProcessEnv = process.env): s
 	return path.join(path.dirname(path.join(root, "async-subagent-runs")), "wait-subscriptions");
 }
 
+/**
+ * async-subagent-runs 目录默认位置（与 pi-subagents ASYNC_DIR 推导一致）。
+ * Default async-runs dir: same temp root as wait-subscriptions.
+ */
+export function resolveAsyncRunsDir(env: NodeJS.ProcessEnv = process.env): string {
+	const configured = env.PI_SUBAGENTS_TEMP_ROOT?.trim();
+	const root = configured
+		? path.resolve(configured)
+		: path.join(tmpdir(), `pi-subagents-${resolveTempScopeId(env)}`);
+	return path.join(root, "async-subagent-runs");
+}
+
 export interface PendingWakeScanOptions {
 	/** 默认 resolveSubscriptionsDir()。测试可注入临时目录。 */
 	subscriptionsDir?: string;
@@ -177,6 +189,84 @@ export function hasPendingWaitSubscription(options: PendingWakeScanOptions): boo
 	return false;
 }
 
+export interface ActiveSubagentScanOptions {
+	/** 默认 resolveAsyncRunsDir()。测试可注入临时目录。 */
+	asyncRunsDir?: string;
+	now?: () => number;
+	/** I/O 警告出口（测试可静音）。默认 console.warn。 */
+	warn?: (message: string, error: unknown) => void;
+}
+
+/** 与 pi-subagents 的 DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS 对齐：24h。 */
+export const STALE_ACTIVE_RUN_MARKER_MS = 24 * 60 * 60 * 1000;
+
+/** 与 pi-subagents 的 isActiveAsyncState 对齐（active-run-index.ts:42）。 */
+function isActiveAsyncState(state: string): boolean {
+	return state === "queued" || state === "running";
+}
+
+/**
+ * 磁盘扫描：pi-subagents 是否还有未失效的后台异步运行（active-run marker）。
+ * Does pi-subagents have any live async subagent run (active-run marker on disk)?
+ *
+ * 布局：`<async-runs-root>/.active-runs/<runId>`（marker 文件名为 async 目录
+ * basename，即 runId）。pi-subagents 0.64.0 的 marker 是空文件（状态在写入
+ * 时判定：只有 queued/running 才创建 marker，终态会删除）；若 marker 带有
+ * JSON 内容且含字符串 state 字段，则按 isActiveAsyncState 判定。
+ * Marker mtime 超过 24h（STALE_ACTIVE_RUN_MARKER_MS，与上游
+ * DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS 一致）视为 crash 孤儿 → 无证据。
+ *
+ * 作用域权衡：marker 只记录 runId，无法从会话 .jsonl 路径可靠映射回所属
+ * 会话，因此这是「任意未失效 active marker」的全局探针（跨会话粒度）。
+ * 保留是自限的（24h staleness + 上游终态即删 marker），全局安全，只是更粗。
+ * The probe is intentionally GLOBAL (any unexpired active marker), not
+ * session-scoped: markers carry only run ids, which cannot be mapped back to
+ * a conversation session file. Retention is self-limiting via the 24h
+ * staleness cap, so the coarser scope is safe.
+ *
+ * fail-open 语义与 hasPendingWaitSubscription 一致：任何 I/O / 解析错误
+ * （目录缺失、损坏 JSON）都按「无证据」处理；ENOENT 静默，其它错误
+ * console.warn 一次。
+ */
+export function hasActiveSubagentRuns(options: ActiveSubagentScanOptions = {}): boolean {
+	const now = options.now ?? Date.now;
+	const warn = options.warn ?? ((message: string, error: unknown) => console.warn(message, error));
+	const isNotFound = (error: unknown): boolean =>
+		typeof error === "object" && error !== null && "code" in error
+		&& (error as NodeJS.ErrnoException).code === "ENOENT";
+	const dir = path.join(options.asyncRunsDir ?? resolveAsyncRunsDir(), ".active-runs");
+	let markers: string[];
+	try {
+		markers = readdirSync(dir).filter((file) => file !== "." && file !== "..");
+	} catch (error) {
+		if (!isNotFound(error)) warn(`Failed to scan active-run markers in '${dir}':`, error);
+		return false; // 目录缺失 / 不可读 → 无证据
+	}
+	for (const marker of markers) {
+		const markerPath = path.join(dir, marker);
+		try {
+			// 先查 mtime：超过 24h 的 marker 是 crash 孤儿（上游同样按 mtime 清理），
+			// 不构成保留证据，也无需再读内容。
+			const age = now() - statSync(markerPath).mtimeMs;
+			if (age > STALE_ACTIVE_RUN_MARKER_MS) continue;
+			const content = readFileSync(markerPath, "utf-8").trim();
+			if (content === "") return true; // 上游 0.64.0 写入的就是空 marker
+			let value: unknown;
+			try {
+				value = JSON.parse(content);
+			} catch {
+				continue; // 损坏 JSON → 无证据（fail-open）
+			}
+			const state = (value as { state?: unknown })?.state;
+			if (typeof state === "string" && isActiveAsyncState(state)) return true;
+		} catch (error) {
+			if (!isNotFound(error)) warn(`Failed to read active-run marker '${markerPath}':`, error);
+			continue; // 单个 marker 读取失败 → 无证据（fail-open），继续看下一个
+		}
+	}
+	return false;
+}
+
 /** displaceActive 决策的输入快照（纯数据，便于单测）。 */
 export interface DisplacementDecisionInput {
 	reviewing: boolean;
@@ -192,13 +282,23 @@ export interface DisplacementDecisionInput {
 	 * invoked at this precedence point, after the cheaper checks pass.
 	 */
 	hasPendingWake: boolean | (() => boolean);
+	/**
+	 * 磁盘扫描结果：存在未失效的 pi-subagents 后台异步运行（active-run
+	 * marker）。可传 thunk 延迟求值 —— 只在前面的保留条件都不命中时才会被
+	 * 调用，避免每次置换都做同步磁盘 I/O。
+	 * Live async subagent work on disk; pass a thunk to defer the disk scan.
+	 */
+	hasActiveSubagentWork: boolean | (() => boolean);
 }
 
 /**
  * 纯函数版置换决策：true = 保留（不得 dispose），false = 调用方可释放。
  * Pure decision core of displaceActive(): true = retain, false = may dispose.
  * 顺序与 displaceActive 保持一致：review/wizard → streaming → terminals →
- * pending wake → listed+continued（「打开后继续过」的会话也保留）。
+ * pending wake → active subagent runs → listed+continued（「打开后继续过」
+ * 的会话也保留）。
+ * Order: review/wizard → streaming → terminals → pending wake → live async
+ * subagent runs → listed+continued.
  */
 export function shouldRetainActive(input: DisplacementDecisionInput): boolean {
 	if (input.reviewing || input.wizardRunning) return true;
@@ -208,6 +308,10 @@ export function shouldRetainActive(input: DisplacementDecisionInput): boolean {
 		? input.hasPendingWake()
 		: input.hasPendingWake;
 	if (hasPendingWake) return true;
+	const hasActiveSubagentWork = typeof input.hasActiveSubagentWork === "function"
+		? input.hasActiveSubagentWork()
+		: input.hasActiveSubagentWork;
+	if (hasActiveSubagentWork) return true;
 	if (input.listed && input.promptedSinceActive) return true;
 	return false;
 }

--- a/server/wait-subscription-scan.ts
+++ b/server/wait-subscription-scan.ts
@@ -216,13 +216,17 @@ function isActiveAsyncState(state: string): boolean {
  * Marker mtime 超过 24h（STALE_ACTIVE_RUN_MARKER_MS，与上游
  * DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS 一致）视为 crash 孤儿 → 无证据。
  *
- * 作用域权衡：marker 只记录 runId，无法从会话 .jsonl 路径可靠映射回所属
- * 会话，因此这是「任意未失效 active marker」的全局探针（跨会话粒度）。
- * 保留是自限的（24h staleness + 上游终态即删 marker），全局安全，只是更粗。
+ * 作用域权衡：marker 名即 async run 目录 basename，session 级保留需要逐
+ * marker 读取 <async-runs-root>/<runId>/status.json（内含 sessionFile/
+ * sessionId），但 queued 运行的 status.json 可能瞬时缺失，因此接受更粗
+ * 的全局探针（任意未失效 active marker）。保留是自限的（24h staleness
+ * + 上游终态即删 marker），全局安全，只是更粗。
  * The probe is intentionally GLOBAL (any unexpired active marker), not
- * session-scoped: markers carry only run ids, which cannot be mapped back to
- * a conversation session file. Retention is self-limiting via the 24h
- * staleness cap, so the coarser scope is safe.
+ * session-scoped: session-scoped retention would require reading
+ * <runId>/status.json per marker (the marker name is the async run dir
+ * basename; status.json carries sessionFile/sessionId), which may be
+ * transiently absent for queued runs. We accept the coarser global probe as
+ * self-limiting (24h staleness cap + terminal-state marker deletion).
  *
  * fail-open 语义与 hasPendingWaitSubscription 一致：任何 I/O / 解析错误
  * （目录缺失、损坏 JSON）都按「无证据」处理；ENOENT 静默，其它错误
@@ -237,7 +241,9 @@ export function hasActiveSubagentRuns(options: ActiveSubagentScanOptions = {}): 
 	const dir = path.join(options.asyncRunsDir ?? resolveAsyncRunsDir(), ".active-runs");
 	let markers: string[];
 	try {
-		markers = readdirSync(dir).filter((file) => file !== "." && file !== "..");
+		markers = readdirSync(dir, { withFileTypes: true })
+			.filter((entry) => entry.isFile())
+			.map((entry) => entry.name); // 仅文件：跳过永久子目录（如 tool-calls/）
 	} catch (error) {
 		if (!isNotFound(error)) warn(`Failed to scan active-run markers in '${dir}':`, error);
 		return false; // 目录缺失 / 不可读 → 无证据

--- a/tests/unit/wait-subscription-scan.test.ts
+++ b/tests/unit/wait-subscription-scan.test.ts
@@ -9,6 +9,7 @@ import {
 	resolveSubscriptionsDir,
 	resolveTempScopeId,
 	shouldRetainActive,
+	STALE_ACTIVE_RUN_MARKER_MS,
 } from "../../server/wait-subscription-scan.js";
 
 const SESSION_FILE = "/root/.pi/agent/sessions/--proj--/2026-01-01T00-00-00Z_session.jsonl";
@@ -240,6 +241,9 @@ describe("hasActiveSubagentRuns", () => {
 		// 23h 前的 marker 仍算活跃（边界）。
 		writeMarker(root, "run-2", "", NOW - 23 * 60 * 60 * 1000);
 		expect(hasActiveSubagentRuns({ asyncRunsDir: root, now: () => NOW })).toBe(true);
+		// 精确 24h 边界：age === STALE_ACTIVE_RUN_MARKER_MS 仍算 ACTIVE（age > 才过期）。
+		writeMarker(root, "run-3", "", NOW - STALE_ACTIVE_RUN_MARKER_MS);
+		expect(hasActiveSubagentRuns({ asyncRunsDir: root, now: () => NOW })).toBe(true);
 	});
 
 	it("损坏 JSON marker → 无证据（fail-open）", () => {
@@ -263,16 +267,30 @@ describe("hasActiveSubagentRuns", () => {
 		expect(hasActiveSubagentRuns({ asyncRunsDir: root, now: () => NOW })).toBe(true);
 	});
 
-	it("marker 是目录（EISDIR，非 ENOENT）→ warn 且 fail-open", () => {
+	it("永久子目录 tool-calls/ 被静默跳过（withFileTypes 仅取文件）", () => {
 		const warnings: string[] = [];
 		const root = makeRunsRoot();
-		mkdirSync(path.join(markerDir(root), "run-1"));
+		// 上游 TOOL_CALL_INDEX_DIR 在 .active-runs 下永久存在，不能当作 marker。
+		mkdirSync(path.join(markerDir(root), "tool-calls"));
+		writeMarker(root, "run-1", "");
+		expect(hasActiveSubagentRuns({
+			asyncRunsDir: root,
+			now: () => NOW,
+			warn: (m) => warnings.push(m),
+		})).toBe(true);
+		expect(warnings).toHaveLength(0);
+	});
+
+	it("仅 tool-calls/ 子目录、无 marker → 无活跃运行，零 warn", () => {
+		const warnings: string[] = [];
+		const root = makeRunsRoot();
+		mkdirSync(path.join(markerDir(root), "tool-calls"));
 		expect(hasActiveSubagentRuns({
 			asyncRunsDir: root,
 			now: () => NOW,
 			warn: (m) => warnings.push(m),
 		})).toBe(false);
-		expect(warnings).toHaveLength(1);
+		expect(warnings).toHaveLength(0);
 	});
 
 	it("resolveAsyncRunsDir：PI_SUBAGENTS_TEMP_ROOT 覆盖 / 默认推导", () => {

--- a/tests/unit/wait-subscription-scan.test.ts
+++ b/tests/unit/wait-subscription-scan.test.ts
@@ -1,9 +1,11 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir, userInfo } from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import {
+	hasActiveSubagentRuns,
 	hasPendingWaitSubscription,
+	resolveAsyncRunsDir,
 	resolveSubscriptionsDir,
 	resolveTempScopeId,
 	shouldRetainActive,
@@ -128,6 +130,7 @@ describe("shouldRetainActive（置换决策）", () => {
 		listed: false,
 		promptedSinceActive: false,
 		hasPendingWake: false,
+		hasActiveSubagentWork: false,
 	};
 
 	it("默认可置换（返回 null）", () => {
@@ -165,6 +168,120 @@ describe("shouldRetainActive（置换决策）", () => {
 			},
 		})).toBe(true);
 		expect(calls).toBe(1);
+	});
+	it("有活跃子代理运行 → 保留（在 pending-wake 之后、listed+prompted 之前）", () => {
+		expect(shouldRetainActive({ ...base, hasActiveSubagentWork: true })).toBe(true);
+	});
+	it("hasActiveSubagentWork thunk 只在到达该优先级时才求值", () => {
+		expect(shouldRetainActive({
+			...base,
+			hasPendingWake: true,
+			hasActiveSubagentWork: () => {
+				throw new Error("must not be evaluated");
+			},
+		})).toBe(true);
+	});
+});
+
+describe("hasActiveSubagentRuns", () => {
+	function makeRunsRoot(): string {
+		const root = makeDir();
+		mkdirSync(path.join(root, "async-subagent-runs"));
+		return path.join(root, "async-subagent-runs");
+	}
+	function markerDir(runsRoot: string): string {
+		const dir = path.join(runsRoot, ".active-runs");
+		mkdirSync(dir, { recursive: true });
+		return dir;
+	}
+	function writeMarker(runsRoot: string, name: string, content: string | unknown, mtimeMs = NOW): void {
+		const dir = markerDir(runsRoot);
+		const file = path.join(dir, name);
+		writeFileSync(file, typeof content === "string" ? content : JSON.stringify(content));
+		// 固定 mtime 以便用注入的 now 精确测试 24h staleness。
+		utimesSync(file, new Date(mtimeMs), new Date(mtimeMs));
+	}
+
+	it("目录不存在 → 无证据（fail-open，静默）", () => {
+		const warnings: string[] = [];
+		expect(hasActiveSubagentRuns({
+			asyncRunsDir: path.join(makeDir(), "missing-runs"),
+			now: () => NOW,
+			warn: (m) => warnings.push(m),
+		})).toBe(false);
+		expect(warnings).toHaveLength(0);
+	});
+
+	it("空 marker（上游 0.64.0 格式）→ 有活跃运行（保留）", () => {
+		const root = makeRunsRoot();
+		writeMarker(root, "run-1", "");
+		expect(hasActiveSubagentRuns({ asyncRunsDir: root, now: () => NOW })).toBe(true);
+	});
+
+	it("JSON marker state=running/queued → 有活跃运行（保留）", () => {
+		const root = makeRunsRoot();
+		writeMarker(root, "run-1", { state: "running" });
+		writeMarker(root, "run-2", { state: "queued" });
+		expect(hasActiveSubagentRuns({ asyncRunsDir: root, now: () => NOW })).toBe(true);
+	});
+
+	it("终态 marker（complete/failed）→ 无活跃运行", () => {
+		const root = makeRunsRoot();
+		writeMarker(root, "run-1", { state: "complete" });
+		writeMarker(root, "run-2", { state: "failed" });
+		expect(hasActiveSubagentRuns({ asyncRunsDir: root, now: () => NOW })).toBe(false);
+	});
+
+	it("过期 marker（mtime > 24h）→ crash 孤儿，无证据", () => {
+		const root = makeRunsRoot();
+		// NOW 为基准时间：marker mtime 在 25h 前。
+		writeMarker(root, "run-1", "", NOW - 25 * 60 * 60 * 1000);
+		expect(hasActiveSubagentRuns({ asyncRunsDir: root, now: () => NOW })).toBe(false);
+		// 23h 前的 marker 仍算活跃（边界）。
+		writeMarker(root, "run-2", "", NOW - 23 * 60 * 60 * 1000);
+		expect(hasActiveSubagentRuns({ asyncRunsDir: root, now: () => NOW })).toBe(true);
+	});
+
+	it("损坏 JSON marker → 无证据（fail-open）", () => {
+		const root = makeRunsRoot();
+		writeMarker(root, "run-1", "{ not json !!!");
+		expect(hasActiveSubagentRuns({ asyncRunsDir: root, now: () => NOW })).toBe(false);
+	});
+
+	it("state 非字符串 / 无 state 字段的 JSON → 无证据", () => {
+		const root = makeRunsRoot();
+		writeMarker(root, "run-1", { state: 42 });
+		writeMarker(root, "run-2", { hello: "world" });
+		expect(hasActiveSubagentRuns({ asyncRunsDir: root, now: () => NOW })).toBe(false);
+	});
+
+	it("一个活跃 + 一个终态 / 损坏 marker → 仍保留（任一活跃即证据）", () => {
+		const root = makeRunsRoot();
+		writeMarker(root, "run-1", { state: "complete" });
+		writeMarker(root, "run-2", "broken");
+		writeMarker(root, "run-3", { state: "running" });
+		expect(hasActiveSubagentRuns({ asyncRunsDir: root, now: () => NOW })).toBe(true);
+	});
+
+	it("marker 是目录（EISDIR，非 ENOENT）→ warn 且 fail-open", () => {
+		const warnings: string[] = [];
+		const root = makeRunsRoot();
+		mkdirSync(path.join(markerDir(root), "run-1"));
+		expect(hasActiveSubagentRuns({
+			asyncRunsDir: root,
+			now: () => NOW,
+			warn: (m) => warnings.push(m),
+		})).toBe(false);
+		expect(warnings).toHaveLength(1);
+	});
+
+	it("resolveAsyncRunsDir：PI_SUBAGENTS_TEMP_ROOT 覆盖 / 默认推导", () => {
+		expect(resolveAsyncRunsDir({ PI_SUBAGENTS_TEMP_ROOT: "/tmp/custom" }))
+			.toBe(path.join(path.resolve("/tmp/custom"), "async-subagent-runs"));
+		const cleanEnv = { PATH: "/usr/bin" } as unknown as NodeJS.ProcessEnv;
+		expect(resolveAsyncRunsDir(cleanEnv)).toBe(
+			path.join(tmpdir(), `pi-subagents-${resolveTempScopeId(cleanEnv)}`, "async-subagent-runs"),
+		);
 	});
 });
 


### PR DESCRIPTION
Fixes #52

## Problem

`set_cwd` (project switch) displaces the active conversation and — unless retained — disposes its runtime, killing the pi-subagents extension host and aborting every live workflow controller ("Workflow stopped because the extension session was replaced or reloaded"). `shouldRetainActive()` already retains conversations with a *pending pi-subagents wake-subscription* (for exactly this reason — see the existing comment in `displaceActive()`), but has no criterion for *actively running* pi-subagents async work. A project switch during a long-running workflow therefore silently kills the orchestrator; finished child runs survive on disk, but the wrapper's assembled result and any post-assembly delivery are lost.

## Fix

Adds a loose, disk-based probe — the same coupling pattern as the existing `hasPendingWaitSubscription()`:

- **`hasActiveSubagentRuns()`** (`server/wait-subscription-scan.ts`): scans pi-subagents' `.active-runs` marker index (derived from `PI_SUBAGENTS_TEMP_ROOT` / the pi-subagents temp scope, mirroring `resolveSubscriptionsDir()`). Directory entries are filtered to files via `withFileTypes` (pi-subagents keeps a permanent `tool-calls/` subdirectory in the index, mirroring upstream's own `readActiveRunIndex` guard). Marker semantics match pi-subagents 0.64.0: markers are written only for `queued`/`running` runs and deleted on terminal states, so a marker file means active; a JSON `{state}` body is honored for forward-compat (`queued|running`); an mtime older than 24h counts as a crash orphan (mirrors `DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS`, same `>` semantics as upstream). Fail-open parity with `hasPendingWaitSubscription`: ENOENT silent, other I/O errors warn once, parse errors = no evidence.
- **Wiring**: new `hasActiveSubagentWork` input on `shouldRetainActive()`, evaluated after the pending-wake check and before `listed + prompted`, with the thunk deferred so conversations without pi-subagents pay one silent `readdirSync` (ENOENT) per user-driven displacement, nothing more.

### Scope trade-off (deliberate)

The probe is **global** (any unexpired active marker retains the displaced conversation), not session-scoped: session mapping would require reading `<runId>/status.json` per marker, which may be transiently absent for queued runs. The global probe is self-limiting — markers are deleted on terminal states and 24h staleness caps crash orphans — and the retained-conversation pool was already unbounded via the existing `listed + prompted` rule.

## Tests

- 13 new tests in `tests/unit/wait-subscription-scan.test.ts`: active/stale/terminal/missing/corrupted markers, `tool-calls` subdirectory skipped silently (zero warns), exact-24h boundary (still active — `>` semantics), env-root derivation, thunk deferral.
- Full unit suite green; `tsc` clean on both `tsconfig.server.json` and `tsconfig.tests.json`.

Verified against pi-subagents 0.64.0 marker semantics (source-level cross-check).

🤖 Generated with [pi](https://github.com/nicobailon/pi-subagents) orchestration — happy to adjust scope (e.g. session-scoped probe) if maintainers prefer.
