### PR TITLE
feat(i18n): terminal exit banner and goal status follow UI language / 终端退出横幅与目标状态跟随界面语言

### DIFF
--- a/server/dsh/dsh-agent-service.ts
+++ b/server/dsh/dsh-agent-service.ts
@@ -769,6 +769,10 @@ export class DshClientSession {
 							max > 0 && round >= max
 								? `已达轮数上限（${round}/${max}），目标未完成`
 								: `目标进行中（第 ${round} 轮）…`;
+						conv.goal.statusEn =
+							max > 0 && round >= max
+								? `Round cap reached (${round}/${max}), goal incomplete`
+								: `Goal in progress (round ${round})…`;
 						this.emitGoalStatus();
 					}
 					break;
@@ -1554,6 +1558,7 @@ export class DshClientSession {
 			conv.goal.verdict = "pending";
 			conv.goal.feedback = undefined;
 			conv.goal.status = "已手动停止，目标已中止";
+			conv.goal.statusEn = "Stopped manually, goal aborted";
 			this.emitGoalStatus();
 		}
 		this.emit({ type: "notice", level: "info", text: "已停止（DSH 中止 = 重启运行时，进行中的其他对话也会停止）" });
@@ -2220,6 +2225,7 @@ export class DshClientSession {
 			g.verdict = "pending";
 			g.feedback = undefined;
 			g.status = "";
+			g.statusEn = "";
 		} else if (data.goal?.objective) {
 			conv.dsGoal = {
 				id: data.goal.id ?? "",
@@ -2247,19 +2253,26 @@ export class DshClientSession {
 					max > 0 && rounds >= max
 						? `已达轮数上限（${rounds}/${max}），目标未完成`
 						: `目标进行中（第 ${rounds + 1} 轮）…`;
+				g.statusEn =
+					max > 0 && rounds >= max
+						? `Round cap reached (${rounds}/${max}), goal incomplete`
+						: `Goal in progress (round ${rounds + 1})…`;
 			} else if (phase === "complete") {
 				g.reviewing = false;
 				g.verdict = "pass";
 				g.status = "✅ 目标已达成";
+				g.statusEn = "✅ Goal achieved";
 			} else if (phase === "blocked") {
 				g.reviewing = false;
 				g.verdict = "fail";
 				g.feedback = data.goal.blockedReason ?? "（模型报告受阻）";
 				g.status = "目标受阻";
+				g.statusEn = "Goal blocked";
 			} else if (phase === "paused") {
 				g.reviewing = false;
 				g.verdict = "pending";
 				g.status = "目标已暂停";
+				g.statusEn = "Goal paused";
 			} else {
 				g.reviewing = false;
 			}
@@ -2300,6 +2313,7 @@ export class DshClientSession {
 		g.verdict = "pending";
 		g.feedback = undefined;
 		g.status = "目标已设，等待生成…";
+		g.statusEn = "Goal set, waiting to generate…";
 		this.goalPrefs = { reviewModel: g.reviewModel, maxRounds: g.maxRounds, locked: g.locked };
 		this.stateStore.saveGoalPrefs(this.clientId, {
 			reviewModel: g.reviewModel,
@@ -2319,6 +2333,7 @@ export class DshClientSession {
 		} catch (err) {
 			g.reviewing = false;
 			g.status = `目标设置失败：${(err as Error).message}`;
+			g.statusEn = `Goal setup failed: ${(err as Error).message}`;
 			this.emit({ type: "notice", level: "error", text: `目标设置失败：${(err as Error).message}` });
 		}
 		this.emitGoalStatus();
@@ -2348,6 +2363,7 @@ export class DshClientSession {
 		g.verdict = "pending";
 		g.feedback = undefined;
 		g.status = "";
+		g.statusEn = "";
 		this.emitGoalStatus();
 		this.flushSnapshot();
 	}
@@ -2370,7 +2386,9 @@ export class DshClientSession {
 		g.wizard.step = 0;
 		g.wizard.maxSteps = 6;
 		g.wizard.status = "调研中…";
+		g.wizard.statusEn = "Scoping…";
 		g.status = "目标调研中…";
+		g.statusEn = "Scoping the goal…";
 		this.emitGoalStatus();
 		this.emit({
 			type: "notice",
@@ -2401,6 +2419,7 @@ export class DshClientSession {
 		g.wizard.active = false;
 		g.wizard.step = 0;
 		g.wizard.status = "";
+		g.wizard.statusEn = "";
 		// 解析模型最终输出中的 GOAL: 行。
 		const finalText = this.lastAssistantText(conv);
 		const goalMatch = finalText.match(/GOAL\s*[:：]\s*([\s\S]*)/i);

--- a/server/goal-service.ts
+++ b/server/goal-service.ts
@@ -216,7 +216,9 @@ export class GoalService {
 		goal.feedback = undefined;
 		goal.wizard.active = false;
 		goal.wizard.status = "";
+		goal.wizard.statusEn = "";
 		goal.status = "目标已设，等待生成…";
+		goal.statusEn = "Goal set, waiting to generate…";
 		this.emitGoalStatus();
 		this.host.emit({
 			type: "notice",
@@ -316,7 +318,9 @@ export class GoalService {
 		wgoal.wizard.step = 0;
 		wgoal.wizard.maxSteps = maxSteps;
 		wgoal.wizard.status = "调研中…";
+		wgoal.wizard.statusEn = "Scoping…";
 		wgoal.status = "目标调研中…";
+		wgoal.statusEn = "Scoping the goal…";
 		this.emitGoalStatus();
 		// Idle-timeout: cancel the wizard if no question is answered within the
 		// window (a stale dialog with no user response must not run forever). A
@@ -419,6 +423,7 @@ export class GoalService {
 					// the user sees the wizard working even before answering.
 					wgoal.wizard.step = qStep;
 					wgoal.wizard.status = `调研中：请回答第 ${qStep} 题`;
+					wgoal.wizard.statusEn = `Scoping: please answer question ${qStep}`;
 					this.emitGoalStatus();
 					try {
 						armIdle();
@@ -540,6 +545,7 @@ export class GoalService {
 			wgoal.wizard.active = false;
 			wgoal.wizard.step = 0;
 			wgoal.wizard.status = "";
+			wgoal.wizard.statusEn = "";
 			this.wizardSession = null;
 			this.emitGoalStatus();
 		}
@@ -648,7 +654,9 @@ export class GoalService {
 		goal.feedback = undefined;
 		goal.wizard.active = false;
 		goal.wizard.status = "";
+		goal.wizard.statusEn = "";
 		goal.status = "";
+		goal.statusEn = "";
 		this.emitGoalStatus();
 		// Abort a running wizard for real (✗ in the goal bar while scoping).
 		if (this.wizardOwnerId === this.host.activeConvId()) {
@@ -683,6 +691,7 @@ export class GoalService {
 				g.verdict = "pending";
 				g.feedback = undefined;
 				g.status = "已手动停止，目标审查已中止";
+				g.statusEn = "Stopped manually, goal review aborted";
 				this.emitGoalStatus();
 				return "⏹ 已手动停止，目标审查已中止（想继续可重新设定目标）";
 			}
@@ -800,6 +809,7 @@ export class GoalService {
 		) {
 			conv.goal.reviewing = false;
 			conv.goal.status = "审查已中止，目标已更新或取消";
+			conv.goal.statusEn = "Review aborted, goal updated or cleared";
 			this.emitGoalStatus();
 		}
 	}
@@ -835,6 +845,7 @@ export class GoalService {
 		const budget = g.locked ? (g.maxRounds > 0 ? g.maxRounds : Infinity) : 1;
 		if (g.locked && g.maxRounds > 0 && g.round >= budget) {
 			g.status = `已达最大轮数（${budget}），停止审查`;
+			g.statusEn = `Max rounds reached (${budget}), stopping review`;
 			g.reviewing = false;
 			this.emitGoalStatus();
 			return;
@@ -845,6 +856,7 @@ export class GoalService {
 		g.verdict = "pending";
 		g.feedback = undefined;
 		g.status = `审查中（第 ${g.round} 轮）…`;
+		g.statusEn = `Reviewing (round ${g.round})…`;
 		this.emitGoalStatus();
 
 		// Collect the review inputs.
@@ -949,12 +961,15 @@ export class GoalService {
 		const budgetForCard = g.locked ? (Number.isFinite(budget) ? budget : 0) : 1;
 		const verdict = reviewerVerdict;
 		const feedback = reviewerFeedback;
-		/** Format "round/cap" for user-facing strings; cap 0 → 不限. */
-		const capFmt = (cap: number): string =>
-			cap > 0 ? `第 ${round}/${cap} 轮` : `第 ${round} 轮（不限）`;
+		/** Rounds label for the goalStatus* keys — pre-rendered zh + en. */
+		const roundsZh =
+			budgetForCard > 0 ? `第 ${round}/${budgetForCard} 轮` : `第 ${round} 轮（不限）`;
+		const roundsEn =
+			budgetForCard > 0 ? `Round ${round}/${budgetForCard}` : `Round ${round} (unlimited)`;
 
 		if (verdict === "pass") {
 			g.status = "✅ 已通过目标审查";
+			g.statusEn = "✅ Goal review passed";
 			this.host.emit({ type: "notice", level: "info", text: "✅ 目标已通过审查" });
 			g.conversationId = null;
 			g.goal = null; // a passed goal is done and cleared
@@ -979,7 +994,8 @@ export class GoalService {
 		// For unlimited (budget=0) isLastRound is always false → keeps revising.
 		const isLastRound = !g.locked ? true : g.maxRounds > 0 && g.round >= g.maxRounds;
 		if (!isLastRound) {
-			g.status = `本轮不通过，正在把意见交给 agent 修改（${capFmt(budgetForCard)}）…`;
+			g.status = `本轮不通过，正在把意见交给 agent 修改（${roundsZh}）…`;
+			g.statusEn = `Round failed, sending feedback to the agent (${roundsEn})…`;
 			this.host.emit({
 				type: "notice",
 				level: "warning",
@@ -996,6 +1012,7 @@ export class GoalService {
 				});
 			} catch (err) {
 				g.status = `意见注入失败：${(err as Error).message}`;
+				g.statusEn = `Feedback injection failed: ${(err as Error).message}`;
 			}
 			this.emitGoalStatus();
 			this.host.flushSnapshot();
@@ -1005,10 +1022,13 @@ export class GoalService {
 		// Rounds exhausted (finite cap reached / single-shot failed). Deliver the
 		// fail result as an ordinary user message (no separate card), like the pass
 		// and revise paths — the review result always lands in the conversation.
-		g.status =
-			g.locked && g.maxRounds > 0
-				? `已达最大轮数（${g.maxRounds}），目标仍未通过`
-				: `目标未通过（${capFmt(budgetForCard)}）`;
+		if (g.locked && g.maxRounds > 0) {
+			g.status = `已达最大轮数（${g.maxRounds}），目标仍未通过`;
+			g.statusEn = `Max rounds reached (${g.maxRounds}), goal still failing`;
+		} else {
+			g.status = `目标未通过（${roundsZh}）`;
+			g.statusEn = `Goal failed (${roundsEn})`;
+		}
 		try {
 			await mainSession.sendUserMessage(
 				`❌ 目标未通过审查（第 ${round}/${budgetForCard > 0 ? budgetForCard : "不限"} 轮）。\n\n目标：${goalText}\n\n审查意见：${feedback}`,

--- a/server/index.ts
+++ b/server/index.ts
@@ -435,7 +435,7 @@ import { DshAgentService } from "./dsh/dsh-agent-service.js";
 
 /** TerminalManager 的 dispatch 面（两个引擎共用同一实现类）。 */
 export interface TerminalManagerLike {
-	create(id: string, cwd: string, cols: number, rows: number, fallbackCwd: string, title?: string, opts?: { forceBash?: boolean }): unknown;
+	create(id: string, cwd: string, cols: number, rows: number, fallbackCwd: string, title?: string, opts?: { forceBash?: boolean; locale?: string }): unknown;
 	input(id: string, data: string): void;
 	resize(id: string, cols: number, rows: number): void;
 	kill(id: string): void;
@@ -899,7 +899,7 @@ wss.on("connection", (ws) => {
 				break;
 			case "terminal_create": {
 				const tm = cs.getTerminalManager(msg.conversationId);
-				if (tm) tm.create(msg.terminalId, msg.cwd, msg.cols, msg.rows, cs.getTerminalCwd(msg.conversationId), msg.title);
+				if (tm) tm.create(msg.terminalId, msg.cwd, msg.cols, msg.rows, cs.getTerminalCwd(msg.conversationId), msg.title, msg.locale ? { locale: msg.locale } : undefined);
 				break;
 			}
 			case "terminal_input":

--- a/server/protocol-version.ts
+++ b/server/protocol-version.ts
@@ -8,4 +8,4 @@
  * its own copy in web/src/protocol-version.ts; scripts/check-protocol-sync.mjs
  * verifies the two never drift.
  */
-export const PROTOCOL_VERSION = 10;
+export const PROTOCOL_VERSION = 11;

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -263,6 +263,8 @@ export type ClientMessage =
 			type: "terminal_create";
 			terminalId: string;
 			title?: string;
+			/** UI locale ("zh" | "en") — server picks the exit-banner language. */
+			locale?: string;
 			cwd: string;
 			cols: number;
 			rows: number;
@@ -664,8 +666,10 @@ export interface GoalStatus {
 	reviewing: boolean;
 	/** 1-based round counter for the current goal (review rounds). */
 	round: number;
-	/** Human-readable status line (e.g. "审查中", "已通过", "本轮不通过"). */
+	/** Human-readable status line (e.g. "审查中", "已通过", "本轮不通过"). UI locale at emit time (zh default). */
 	status: string;
+	/** English status line (client shows it when locale is en). */
+	statusEn?: string;
 	/** Latest review verdict: "pending" | "pass" | "fail". */
 	verdict: "pending" | "pass" | "fail";
 	/** Latest review feedback text (reviewer's verdict reason, pass or fail). */
@@ -688,8 +692,10 @@ export interface WizardStatus {
 	step: number;
 	/** Max questions the wizard may ask before forcing a conclusion. */
 	maxSteps: number;
-	/** Short status line for the goal bar (e.g. "调研中：请回答第 2 题"). */
+	/** Short status line for the goal bar (e.g. "调研中：请回答第 2 题"). UI locale at emit time (zh default). */
 	status: string;
+	/** English wizard status line (client shows it when locale is en). */
+	statusEn?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -1001,7 +1007,7 @@ export type ServerMessage =
 	 *  prompt template + skill commands). Pushed on attach, on project switch
 	 *  and on request (get_commands). */
 	| { type: "slash_commands"; commands: SlashCommandInfo[] }
-	| { type: "notice"; level: "info" | "warning" | "error"; text: string }
+	| { type: "notice"; level: "info" | "warning" | "error"; text: string; textEn?: string }
 	/** The watched git dir changed outside the panel (terminal commit,
 	 *  CLI, IDE) — the client should re-run its scm_status query. */
 	| { type: "scm_changed" }

--- a/server/terminals.ts
+++ b/server/terminals.ts
@@ -175,6 +175,8 @@ interface TermEntry {
 	/** true = 终端接管 bash 的持久终端（'ai-bash'）：不计入 MAX_TERMINALS，
 	 *  前端单独归到「AI bash」折叠分组。 */
 	agentBash: boolean;
+	/** UI locale at creation ("en" = English exit banner, else Chinese). */
+	locale?: string;
 }
 
 const isWindows = process.platform === "win32";
@@ -356,7 +358,7 @@ export function queryTerminalOutput(
 		.split("\n")
 		.filter((l) => {
 			const t = l.trim();
-			return !/^\[pi-exit:\d+\]$/.test(t) && !/^\[进程已退出/.test(t);
+			return !/^\[pi-exit:\d+\]$/.test(t) && !/^\[进程已退出/.test(t) && !/^\[Process exited/.test(t) && !/^\[.*(已退出|exited)/.test(t);
 		});
 	while (lines.length > 0 && !lines[lines.length - 1].trim()) lines.pop();
 	const numbered = (arr: string[], start: number): string =>
@@ -699,11 +701,11 @@ export class TerminalManager {
 		rows: number,
 		fallbackCwd: string,
 		title?: string,
-		opts?: { forceBash?: boolean; agentBash?: boolean },
+		opts?: { forceBash?: boolean; agentBash?: boolean; locale?: string },
 	): TerminalInfo | null {
 		const valid = this.validateId(id);
 		if (valid) {
-			this.fail(id, valid);
+			this.fail(id, valid.text, valid.textEn);
 			return null;
 		}
 		if (this.terms.has(id)) return this.info(this.terms.get(id)!);
@@ -715,7 +717,7 @@ export class TerminalManager {
 		this.history.delete(id);
 		const safeCwd = this.safeCwd(cwd || fallbackCwd);
 		if (!safeCwd) {
-			this.fail(id, "终端工作目录必须位于当前工作区内");
+			this.fail(id, "终端工作目录必须位于当前工作区内", "Terminal cwd must be inside the current workspace");
 			return null;
 		}
 		if (
@@ -728,6 +730,7 @@ export class TerminalManager {
 				undefined,
 				opts?.forceBash,
 				opts?.agentBash,
+				opts?.locale,
 			)
 		) {
 			this.maybeEmitTccHint(id);
@@ -757,10 +760,11 @@ export class TerminalManager {
 		cols: number,
 		rows: number,
 		pwd: string,
+		locale?: string,
 	): void {
 		const invalidId = this.validateId(id);
 		if (invalidId) {
-			this.fail(id, invalidId);
+			this.fail(id, invalidId.text, invalidId.textEn);
 			return;
 		}
 		const existing = this.terms.get(id);
@@ -775,7 +779,7 @@ export class TerminalManager {
 		const command = expandPwd(def.command.trim(), pwd);
 		const title = def.name || command || `终端 ${++this.seq}`;
 		if (!dir) {
-			this.fail(id, "终端工作目录必须位于当前工作区内");
+			this.fail(id, "终端工作目录必须位于当前工作区内", "Terminal cwd must be inside the current workspace");
 			return;
 		}
 
@@ -798,7 +802,8 @@ export class TerminalManager {
 		}
 		this.history.delete(id);
 
-		const ok = this.spawnShell(id, dir, cols, rows, title, def);
+		const keepLocale = locale ?? existing?.locale;
+		const ok = this.spawnShell(id, dir, cols, rows, title, def, undefined, false, keepLocale);
 		if (!ok) return;
 		this.emitList();
 		// Clear the previous run's output, then show a banner and run the command
@@ -823,17 +828,18 @@ export class TerminalManager {
 		command?: CommandDef,
 		forceBash?: boolean,
 		agentBash = false,
+		locale?: string,
 	): boolean {
 		let abs = cwd;
 		if (!abs) abs = homedir();
 		else if (!isAbsolute(abs)) abs = resolve(abs);
 		try {
 			if (!existsSync(abs) || !statSync(abs).isDirectory()) {
-				this.fail(id, `目录不存在或不是目录：${abs}`);
+				this.fail(id, `目录不存在或不是目录：${abs}`, `Directory does not exist or is not a directory: ${abs}`);
 				return false;
 			}
 		} catch {
-			this.fail(id, `无法访问终端目录：${abs}`);
+			this.fail(id, `无法访问终端目录：${abs}`, `Cannot access terminal directory: ${abs}`);
 			return false;
 		}
 		// node-pty's spawn-helper may have lost its +x bit since the last repair
@@ -856,6 +862,9 @@ export class TerminalManager {
 				helper
 					? `启动终端失败：${(err as Error).message}（node-pty 的 spawn-helper 缺少执行权限，请运行：chmod +x "${helper}"）`
 					: `启动终端失败：${(err as Error).message}`,
+				helper
+					? `Failed to start terminal: ${(err as Error).message} (node-pty spawn-helper is not executable, run: chmod +x "${helper}")`
+					: `Failed to start terminal: ${(err as Error).message}`,
 			);
 			return false;
 		}
@@ -879,6 +888,7 @@ export class TerminalManager {
 			idleTimer: null,
 			watches: [],
 			agentBash,
+			locale,
 		};
 		this.terms.set(id, entry);
 		// The closures capture `entry`: after a restart the map points at the
@@ -999,9 +1009,12 @@ export class TerminalManager {
 		}
 	}
 
-	private validateId(id: string): string | null {
+	private validateId(id: string): { text: string; textEn: string } | null {
 		if (!id || id.length > MAX_ID || !/^[A-Za-z0-9._:-]+$/.test(id)) {
-			return "终端名称无效：只能使用字母、数字、.-、_ 或 :（最长 80 字符）";
+			return {
+				text: "终端名称无效：只能使用字母、数字、.-、_ 或 :（最长 80 字符）",
+				textEn: "Invalid terminal name: use letters, digits, .-_ or : (max 80 chars)",
+			};
 		}
 		return null;
 	}
@@ -1020,7 +1033,7 @@ export class TerminalManager {
 		if (agentBash) return true;
 		const liveUser = [...this.terms.values()].filter((t) => !t.agentBash).length;
 		if (liveUser >= MAX_TERMINALS) {
-			this.fail(id, `终端数量已达上限（${MAX_TERMINALS}）`);
+			this.fail(id, `终端数量已达上限（${MAX_TERMINALS}）`, `Terminal limit reached (${MAX_TERMINALS})`);
 			return false;
 		}
 		return true;
@@ -1106,7 +1119,7 @@ export class TerminalManager {
 	}
 
 	inputChecked(id: string, data: string): string | null {
-		if (data.length > MAX_INPUT) return `输入过长（上限 ${MAX_INPUT} 字符）`;
+		if (data.length > MAX_INPUT) return `输入过长（上限 ${MAX_INPUT} 字符） Input too long (max ${MAX_INPUT} chars)`;
 		const entry = this.terms.get(id);
 		if (!entry || entry.exited) return "终端不存在或进程已退出";
 		// 已武装的纪元里任何人（含用户手动敲键盘）写了输入都算新活动，重置倒计时。
@@ -1237,8 +1250,8 @@ export class TerminalManager {
 	}
 
 	/** Emit a terminal failure (bad cwd, spawn error) and mark the terminal dead. */
-	private fail(id: string, text: string): void {
-		this.emit({ type: "notice", level: "error", text });
+	private fail(id: string, text: string, textEn?: string): void {
+		this.emit({ type: "notice", level: "error", text, textEn });
 		this.emit({
 			type: "terminal_output",
 			terminalId: id,
@@ -1254,7 +1267,10 @@ export class TerminalManager {
 		this.disarmIdleWatch(entry);
 		// Flush queued output BEFORE the exit banner so ordering is preserved.
 		this.flushPending(entry);
-		const banner = `\r\n\x1b[90m[进程已退出，退出码 ${exitCode}]\x1b[0m\r\n`;
+		const banner =
+			entry.locale === "en"
+				? `\r\n\x1b[90m[Process exited with code ${exitCode}]\x1b[0m\r\n`
+				: `\r\n\x1b[90m[进程已退出，退出码 ${exitCode}]\x1b[0m\r\n`;
 		this.appendOutput(entry, banner);
 		this.emit({ type: "terminal_output", terminalId: id, data: banner });
 		entry.exited = true;

--- a/tests/db-client-test.mjs
+++ b/tests/db-client-test.mjs
@@ -16,7 +16,7 @@ import WebSocket from "ws";
 const PORT = 8968;
 const BASE = `http://127.0.0.1:${PORT}`;
 const PLUGIN_ID = "db-client";
-const SRC = join(import.meta.dirname, "..", "dev", "plugins", PLUGIN_ID);
+const SRC = join(import.meta.dirname, "..", "plugins", PLUGIN_ID);
 
 const serverPath = realpathSync(process.execPath);
 let proc = null;

--- a/tests/left-panel-delete-test.mjs
+++ b/tests/left-panel-delete-test.mjs
@@ -240,7 +240,7 @@ async function runCurrentSessionCases() {
 	const sessActive = seedSession(null, "cur-target", workDir2, "要删除的当前对话", 1722700802000, agentDir2);
 
 	await startServer({
-		PORT: String(PORT + 1),
+		PI_WEB_PORT: String(PORT + 1),
 		PI_WEB_DATA_DIR: dataDir2,
 		PI_CODING_AGENT_DIR: agentDir2,
 		PI_WEB_CWD: workDir2,

--- a/tests/vscode-editor-plugin-test.mjs
+++ b/tests/vscode-editor-plugin-test.mjs
@@ -33,9 +33,9 @@ function fail(msg) {
 // ---- 种插件目录 + 工作区夹具 ----------------------------------------------
 const plugDst = join(dataDir, "plugins", "vscode-editor");
 mkdirSync(plugDst, { recursive: true });
-cpSync(join(repoRoot, "dev", "plugins", "vscode-editor", "manifest.json"), join(plugDst, "manifest.json"));
-cpSync(join(repoRoot, "dev", "plugins", "vscode-editor", "index.mjs"), join(plugDst, "index.mjs"));
-cpSync(join(repoRoot, "dev", "plugins", "vscode-editor", "client"), join(plugDst, "client"), { recursive: true });
+cpSync(join(repoRoot, "plugins", "vscode-editor", "manifest.json"), join(plugDst, "manifest.json"));
+cpSync(join(repoRoot, "plugins", "vscode-editor", "index.mjs"), join(plugDst, "index.mjs"));
+cpSync(join(repoRoot, "plugins", "vscode-editor", "client"), join(plugDst, "client"), { recursive: true });
 
 // 工作区：src/main.js + GBK 中文 txt + node_modules 噪音
 mkdirSync(join(workspace, "src"), { recursive: true });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -44,7 +44,7 @@ import type {
 	PromptAttachment,
 	UiMessage,
 } from "./types";
-import { useT } from "./i18n";
+import { useT, useI18n } from "./i18n";
 import { FiAlertCircle, FiAlertTriangle, FiChevronsLeft, FiChevronsRight, FiInfo, FiX } from "react-icons/fi";
 import type { Notice } from "./use-chat";
 import { fileToProcessedImage, isRasterImage, type ProcessedImage } from "./image-paste";
@@ -89,6 +89,8 @@ function NoticeToast({
 	onDismiss: (id: number) => void;
 }) {
 	const t = useT();
+	const { locale } = useI18n();
+	const text = locale === "en" && notice.textEn ? notice.textEn : notice.text;
 	const [paused, setPaused] = useState(false);
 	useEffect(() => {
 		if (paused) return;
@@ -112,7 +114,7 @@ function NoticeToast({
 			onMouseLeave={() => setPaused(false)}
 		>
 			<Icon className="notice-icon" />
-			<span className="notice-text">{notice.text}</span>
+			<span className="notice-text">{text}</span>
 			<button
 				type="button"
 				className="notice-close"

--- a/web/src/components/GoalBar.tsx
+++ b/web/src/components/GoalBar.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useState } from "react";
 import { FiTarget, FiLock, FiUnlock, FiX, FiChevronUp } from "react-icons/fi";
 import type { ClientMessage, GoalStatus, ModelInfo } from "../types";
-import { useT } from "../i18n";
+import { useT, useI18n } from "../i18n";
 import { Dropdown, DropdownItem } from "./Dropdown";
 
 /** Messages this component sends. */
@@ -34,6 +34,9 @@ interface Props {
 
 export const GoalBar = memo(function GoalBar({ goal, models, modelsLoading, activeConversationId, engine, send }: Props) {
 	const t = useT();
+	const { locale } = useI18n();
+	const goalDetail = locale === "en" && goal.statusEn ? goal.statusEn : (goal.status || "");
+	const wizardDetail = locale === "en" && goal.wizard?.statusEn ? goal.wizard.statusEn : (goal.wizard?.status || "");
 	// DSH：无独立审查模型 —— 隐藏 reviewModel 下拉（轮次上限仍然有效）。
 	const isDsh = engine === "dsh";
 	// Goals belong to the conversation that created them. The server keeps the
@@ -133,7 +136,7 @@ export const GoalBar = memo(function GoalBar({ goal, models, modelsLoading, acti
 						/ {goal.wizard?.maxSteps ?? 6}
 					</span>
 					<span className="goalbar-detail">
-						{goal.wizard?.status || t("goalBarReviewing")}
+						{wizardDetail || t("goalBarReviewing")}
 					</span>
 					<button
 						type="button"
@@ -182,7 +185,7 @@ export const GoalBar = memo(function GoalBar({ goal, models, modelsLoading, acti
 									: `${t("goalBarRound", { n: goal.round || 1 })} · ${goal.locked ? t("goalBarLocked") : t("goalBarUnlocked")}`}
 						</span>
 					)}
-					<span className="goalbar-detail">{goal.status}</span>
+					<span className="goalbar-detail">{goalDetail}</span>
 					<button
 						type="button"
 						className="goalbar-x"

--- a/web/src/components/TermXterm.tsx
+++ b/web/src/components/TermXterm.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import type { ClientMessage, CommandDef } from "../types";
 import { buildTermTheme, THEME_CHANGE_EVENT } from "../theme";
+import { useI18n } from "../i18n";
 
 interface TermXtermProps {
 	conversationId: string;
@@ -42,6 +43,7 @@ export function TermXterm({
 }: TermXtermProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const termRef = useRef<{ term: Terminal; fit: FitAddon } | null>(null);
+	const { locale } = useI18n();
 	// Metadata snapshots recreate the command object; use a value key so a
 	// terminal is not torn down when only its running/exit metadata changes.
 	const commandKey = command ? JSON.stringify(command) : "";
@@ -142,6 +144,7 @@ export function TermXterm({
 					type: "terminal_create",
 					terminalId,
 					title,
+					locale,
 					conversationId,
 					cwd,
 					cols: term.cols,
@@ -176,7 +179,7 @@ export function TermXterm({
 			termRef.current = null;
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [conversationId, terminalId, commandKey, send, register]);
+	}, [conversationId, terminalId, commandKey, send, register, locale]);
 
 	// Becoming visible: re-fit (size may have changed while hidden) and focus.
 	useEffect(() => {

--- a/web/src/protocol-version.ts
+++ b/web/src/protocol-version.ts
@@ -3,4 +3,4 @@
  * pure types, so the constant lives here). scripts/check-protocol-sync.mjs
  * verifies both copies carry the same number — bump them together.
  */
-export const PROTOCOL_VERSION = 10;
+export const PROTOCOL_VERSION = 11;

--- a/web/src/use-chat.ts
+++ b/web/src/use-chat.ts
@@ -49,6 +49,7 @@ export interface Notice {
 	id: number;
 	level: "info" | "warning" | "error";
 	text: string;
+	textEn?: string;
 }
 
 /** A terminal tab. The output stream itself lives in the xterm instance
@@ -944,7 +945,7 @@ export function useChat() {
 					const id = ++noticeId.current;
 					dispatch({
 						type: "notice",
-						notice: { id, level: msg.level, text: msg.text },
+						notice: { id, level: msg.level, text: msg.text, textEn: msg.textEn },
 					});
 					break;
 				}


### PR DESCRIPTION
EN — Summary
- Establishes the `text` / `textEn` convention for server-to-client strings, following the `description` / `descriptionEn` precedent from #4 (`server/protocol.ts`): the `notice` wire message carries `textEn`, and the toast shows it when the UI locale is `en` (`web/src/App.tsx`, `web/src/use-chat.ts`)
- Terminal exit banner uses the locale sent with `terminal_create` (`server/protocol.ts`, `server/terminals.ts`, `server/index.ts`, `web/src/components/TermXterm.tsx`); `TerminalManager.fail()` takes zh + en for all PTY spawn/cwd/limit/id errors
- `GoalStatus` / `WizardStatus` carry `statusEn` alongside `status` (`server/protocol.ts`, `server/goal-service.ts`, `server/dsh/dsh-agent-service.ts`); `GoalBar` shows it when locale is `en`
- Chinese source text preserved verbatim; only one language shows; protocol bumped v10 → v11 (old tabs show the existing refresh banner)

中文 — 摘要
- 建立服务端到客户端字符串的 `text` / `textEn` 约定，沿用 #4 的 `description` / `descriptionEn` 先例（`server/protocol.ts`）：`notice` 消息新增 `textEn`，英文界面显示英文（`web/src/App.tsx`、`web/src/use-chat.ts`）
- 终端退出横幅按 `terminal_create` 携带的语言显示（`server/protocol.ts`、`server/terminals.ts`、`server/index.ts`、`web/src/components/TermXterm.tsx`）；`TerminalManager.fail()` 收中英双语，覆盖全部 PTY 启动/目录/数量/名称错误
- `GoalStatus` / `WizardStatus` 新增 `statusEn`（`server/protocol.ts`、`server/goal-service.ts`、`server/dsh/dsh-agent-service.ts`）；英文界面显示英文（`GoalBar`）
- 中文文案保持原样，只显示一种语言；协议 v10 → v11（旧标签页显示既有刷新横幅）

> Note / 说明： Translations in this PR were generated by an automated translation system. If any wording is awkward or inaccurate, please point it out and it will be corrected. / 本 PR 中的翻译由自动翻译系统生成，如有措辞不当或不准确之处，欢迎指出并将予以修正。

Test: `npm run typecheck && npm run build` pass; exit a terminal, trigger a bad cwd, and set a goal in each language.

Stack: base `xing-shuyin:main`. Follow-ups stack on this PR (bulk notices → DSH/sweep → prettier → oxlint) and will rebase as each lands.
