### PR TITLE
fix(tests): repair smoke fixtures broken by the plugins move / 修复插件目录搬迁后坏掉的冒烟测试

### DIFF
--- a/tests/db-client-test.mjs
+++ b/tests/db-client-test.mjs
@@ -16,7 +16,7 @@ import WebSocket from "ws";
 const PORT = 8968;
 const BASE = `http://127.0.0.1:${PORT}`;
 const PLUGIN_ID = "db-client";
-const SRC = join(import.meta.dirname, "..", "dev", "plugins", PLUGIN_ID);
+const SRC = join(import.meta.dirname, "..", "plugins", PLUGIN_ID);
 
 const serverPath = realpathSync(process.execPath);
 let proc = null;

--- a/tests/left-panel-delete-test.mjs
+++ b/tests/left-panel-delete-test.mjs
@@ -240,7 +240,7 @@ async function runCurrentSessionCases() {
 	const sessActive = seedSession(null, "cur-target", workDir2, "要删除的当前对话", 1722700802000, agentDir2);
 
 	await startServer({
-		PORT: String(PORT + 1),
+		PI_WEB_PORT: String(PORT + 1),
 		PI_WEB_DATA_DIR: dataDir2,
 		PI_CODING_AGENT_DIR: agentDir2,
 		PI_WEB_CWD: workDir2,

--- a/tests/vscode-editor-plugin-test.mjs
+++ b/tests/vscode-editor-plugin-test.mjs
@@ -33,9 +33,9 @@ function fail(msg) {
 // ---- 种插件目录 + 工作区夹具 ----------------------------------------------
 const plugDst = join(dataDir, "plugins", "vscode-editor");
 mkdirSync(plugDst, { recursive: true });
-cpSync(join(repoRoot, "dev", "plugins", "vscode-editor", "manifest.json"), join(plugDst, "manifest.json"));
-cpSync(join(repoRoot, "dev", "plugins", "vscode-editor", "index.mjs"), join(plugDst, "index.mjs"));
-cpSync(join(repoRoot, "dev", "plugins", "vscode-editor", "client"), join(plugDst, "client"), { recursive: true });
+cpSync(join(repoRoot, "plugins", "vscode-editor", "manifest.json"), join(plugDst, "manifest.json"));
+cpSync(join(repoRoot, "plugins", "vscode-editor", "index.mjs"), join(plugDst, "index.mjs"));
+cpSync(join(repoRoot, "plugins", "vscode-editor", "client"), join(plugDst, "client"), { recursive: true });
 
 // 工作区：src/main.js + GBK 中文 txt + node_modules 噪音
 mkdirSync(join(workspace, "src"), { recursive: true });


### PR DESCRIPTION
fix(tests): repair smoke fixtures broken by the plugins move / 修复插件目录搬迁后坏掉的冒烟测试

MERGE THIS ONE FIRST — it fixes CI on main, and every PR below needs a green base to prove itself. Without it, all smoke runs fail identically with or without any other change.

Why CI is red on main right now: commit 2934e3f moved dev/plugins to plugins/ but two smoke tests still copy fixtures from the old path (ENOENT on manifest.json), and left-panel-delete passes PORT instead of PI_WEB_PORT to its second server (Number(undefined) = NaN, server never starts). Upstream run 33702752941 shows the identical three failures on unmodified main.

先合这个——它修好 main 的 CI，后面所有 PR 都要靠绿色的基线自证。没有它，任何改动（改或不改）的冒烟结果都一样红。

EN — Summary
- tests/db-client-test.mjs, tests/vscode-editor-plugin-test.mjs: read fixtures from plugins/ (the move in 2934e3f left dev/plugins/ behind)
- tests/left-panel-delete-test.mjs: pass PI_WEB_PORT (was PORT) to the second server — fixes FATAL: server did not start on NaN
- No product code touched; test-only change

中文 — 摘要
- tests/db-client-test.mjs、tests/vscode-editor-plugin-test.mjs：从 plugins/ 读夹具（2934e3f 搬迁后旧路径已不存在）
- tests/left-panel-delete-test.mjs：第二个 server 改传 PI_WEB_PORT（原 PORT 导致 Number(undefined) = NaN，服务起不来）
- 只改测试，不碰产品代码

> Note / 说明： Translations in this PR were generated by an automated translation system. If any wording is awkward or inaccurate, please point it out and it will be corrected. / 本 PR 中的翻译由自动翻译系统生成，如有措辞不当或不准确之处，欢迎指出并将予以修正。

Test: upstream CI proves it (local runs on a Tailscale-default-bind host cannot probe 127.0.0.1, so left-panel-delete cannot go green here by hand).


Test: upstream CI proves it (local runs on a Tailscale-default-bind host cannot probe 127.0.0.1, so left-panel-delete cannot go green by hand).

Stack: base `xing-shuyin:main`. Merge this before PRs #54–#58 — they all need a green base.
