### PR TITLE
feat(commands): add /name slash command to rename current session

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -436,6 +436,8 @@ const DEFAULT_CONV_TITLE = "新对话";
 /** First user text in a session, truncated for the conversation list. */
 function conversationTitle(session: AgentSession): string {
 	try {
+		const customName = session.sessionName?.trim();
+		if (customName) return customName;
 		for (const m of session.agent.state.messages) {
 			if (m.role !== "user") continue;
 			const content = m.content as unknown;
@@ -2097,6 +2099,20 @@ export class ClientSession {
 		setModel: (id) => this.setModel(id),
 		setCwd: (path) => this.setCwd(path),
 		setThinking: (level) => this.setThinking(level),
+		renameSession: async (name) => {
+			this.session.setSessionName(name);
+			this.conv.title = name;
+			this.invalidateSessionInfos();
+			this.emitConversations();
+			await this.pushSessions();
+			this.emit({
+				type: "notice",
+				level: "info",
+				text: `已重命名当前会话为「${name}」`,
+				textEn: `Renamed current session to "${name}"`,
+			});
+			this.flushSnapshot();
+		},
 		refreshSessions: () => this.refreshSessions(),
 		afterReload: () => this.applyTerminalToolGating(this.session),
 		pluginCommands: () => this.pluginCommandsProvider?.() ?? [],
@@ -2465,7 +2481,7 @@ export class ClientSession {
 			// rename entirely. A failed send still leaves the name, which matches
 			// what the user typed intent-wise; the entry_appended fallback below
 			// re-derives it from the persisted transcript when needed.
-			if (conv.title === DEFAULT_CONV_TITLE && text.trim()) {
+			if (conv.title === DEFAULT_CONV_TITLE && text.trim() && !conv.session.sessionName?.trim()) {
 				const trimmed = text.trim().replace(/\s+/g, " ");
 				conv.title = trimmed.length > 30 ? `${trimmed.slice(0, 30)}…` : trimmed;
 				this.emitConversations();

--- a/server/slash-commands.ts
+++ b/server/slash-commands.ts
@@ -27,6 +27,7 @@ export interface SlashHost {
 	setModel: (modelId: string) => Promise<void>;
 	setCwd: (path: string) => Promise<void>;
 	setThinking: (level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max") => void;
+	renameSession?: (name: string) => Promise<void> | void;
 	refreshSessions: () => Promise<void>;
 	/** supervisor 的优雅重启调度；返回 false 时 exec 兜底 process.exit(0)。 */
 	onQuit?: () => boolean;
@@ -51,6 +52,13 @@ export const NATIVE_COMMANDS: {
 	argumentHintEn?: string;
 }[] = [
 	{ name: "new", description: "新建对话", descriptionEn: "New chat" },
+	{
+		name: "name",
+		description: "重命名当前会话",
+		descriptionEn: "Set session display name",
+		argumentHint: "<名称>",
+		argumentHintEn: "<name>",
+	},
 	{
 		name: "model",
 		description: "切换模型",
@@ -172,6 +180,32 @@ export class SlashCommandsService {
 			case "new":
 				await this.host.newChat();
 				return true;
+			case "name": {
+				const trimmed = args.trim();
+				if (!trimmed) {
+					const current = this.host.getSession().sessionName;
+					this.host.emit({
+						type: "notice",
+						level: "info",
+						text: current ? `当前会话名称：${current}。用法：/name <名称>` : `用法：/name <名称>`,
+						textEn: current ? `Current session name: ${current}. Usage: /name <name>` : `Usage: /name <name>`,
+					});
+					return true;
+				}
+				if (this.host.renameSession) {
+					await this.host.renameSession(trimmed);
+				} else {
+					this.host.getSession().setSessionName(trimmed);
+					await this.host.refreshSessions();
+					this.host.emit({
+						type: "notice",
+						level: "info",
+						text: `已重命名当前会话为「${trimmed}」`,
+						textEn: `Renamed current session to "${trimmed}"`,
+					});
+				}
+				return true;
+			}
 			case "model": {
 				if (!args) {
 					const current = this.host.getSession().model;


### PR DESCRIPTION
This pull request implements the built-in `/name` slash command inside the web UI, establishing feature-parity with the standard pi CLI tool.

It leverages the native SDK's `AgentSession.setSessionName()` interface.

### 📝 Key Changes:
1. **Command Registration (`slash-commands.ts`):**
   - Adds `/name` to the server's `NATIVE_COMMANDS` registry with proper descriptions and a localized argument hint `<名称> / <name>`.
2. **Interactive Execution Handling:**
   - Typing `/name` with no arguments outputs a localized notice indicating the current session name and its usage hint.
   - Typing `/name <new_title>` invokes `ClientSession.renameSession()` to apply the changes.
3. **Reactive Re-pushing & Session Sync (`agent-service.ts`):**
   - Calls `session.setSessionName(name)` to store the name persistently within the session's native metadata.
   - Updates the live-running conversation title (`conv.title = name`) immediately.
   - Clears the internal `SessionInfo` list cache (`this.invalidateSessionInfos()`) and triggers both a `conversations` list broadcast and a `pushSessions()` dispatch so that both the running tab list and left-side session history update in real-time.
   - Dispatches a localized feedback toast acknowledging the rename.
4. **Auto-titling Guards:**
   - Fixes the initial auto-titling logic: if a session is manually named (e.g. created and named right away, or resumed and named), sending prompts will not trigger the fallback first-user-message auto-titler, preserving your custom name forever.
   - Adapts `conversationTitle()` to prefer the native `session.sessionName` over the default first-message truncation when loading state.