### PR TITLE
feat(i18n): English textEn for 33 notices, locale-live exit banner and page title / 33 条通知英文与实时语言横幅标题

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -790,7 +790,7 @@ export class ClientSession {
 		try {
 			await conv.session.bindExtensions({
 				mode: "rpc",
-				onError: (err) => this.emit({ type: "notice", level: "error", text: err.error }),
+				onError: (err) => this.emit({ type: "notice", level: "error", text: err.error, textEn: err.error }),
 			});
 		} catch {
 			// 绑定失败不阻断运行。
@@ -801,6 +801,7 @@ export class ClientSession {
 				type: "notice",
 				level: "error",
 				text: `子代理 ${conversationId} 启动失败: ${err instanceof Error ? err.message : String(err)}`,
+				textEn: `Subagent ${conversationId} failed to start: ${err instanceof Error ? err.message : String(err)}`,
 			});
 		});
 		this.emitConversations();
@@ -1121,6 +1122,7 @@ export class ClientSession {
 					type: "notice",
 					level: d.type,
 					text: d.message,
+					textEn: d.message,
 				});
 			}
 		}
@@ -1397,7 +1399,7 @@ export class ClientSession {
 			mode: "rpc",
 			uiContext: this.webUi,
 			onError: (err) => {
-				this.emit({ type: "notice", level: "error", text: err.error });
+				this.emit({ type: "notice", level: "error", text: err.error, textEn: err.error });
 			},
 		});
 		conv.unsubscribe = conv.session.subscribe((event) => this.onEvent(conv, event));
@@ -1653,7 +1655,7 @@ export class ClientSession {
 				if (aborted) {
 					const stopNotice = this.goalSvc.onAgentEnd(conv, true);
 					if (stopNotice) {
-						this.emit({ type: "notice", level: "warning", text: stopNotice });
+						this.emit({ type: "notice", level: "warning", text: stopNotice.text, textEn: stopNotice.textEn });
 					}
 					break;
 				}
@@ -2241,7 +2243,7 @@ export class ClientSession {
 				const result = await def.run(args, { clientId: this.clientId });
 				// 字符串返回值 → 通知条回显给发起人；富展示用 broadcast/sendTo。
 				if (typeof result === "string" && result.trim()) {
-					this.emit({ type: "notice", level: "info", text: result });
+					this.emit({ type: "notice", level: "info", text: result, textEn: result });
 				}
 			} catch (err) {
 				this.emit({
@@ -2781,8 +2783,8 @@ export class ClientSession {
 	}
 
 	/** 插件设置保存结果等需要从 index.ts 发 notice 时用（emit 是私有的）。 */
-	emitNotice(level: "info" | "warning" | "error", text: string): void {
-		this.emit({ type: "notice", level, text });
+	emitNotice(level: "info" | "warning" | "error", text: string, textEn?: string): void {
+		this.emit({ type: "notice", level, text, textEn });
 	}
 
 	/** Kill ONE background server (by port); returns whether anything was killed. */
@@ -2912,7 +2914,12 @@ export class ClientSession {
 			});
 			conv.runtime = runtime;
 			conv.session = runtime.session;
-			this.emit({ type: "notice", level: "warning", text: reason });
+			this.emit({
+				type: "notice",
+				level: "warning",
+				text: reason,
+				textEn: `${reason} (forced reset: run did not terminate)`,
+			});
 			await this.bindSession();
 			this.emitConversations();
 			void this.pushSlashCommands();
@@ -3299,6 +3306,9 @@ export class ClientSession {
 						text: stillRunning
 							? "对话仍在后台运行，已停止删除；请等待其结束后再删除"
 							: "未能切换到其他对话，已取消删除本次操作",
+						textEn: stillRunning
+							? "Conversation is still running in the background; delete aborted — wait for it to finish and retry"
+							: "Could not switch to another conversation; delete cancelled",
 					});
 					return;
 				}
@@ -3400,11 +3410,21 @@ export class ClientSession {
 	async dismissConversation(id: string): Promise<void> {
 		const conv = this.convs.get(id);
 		if (!conv) {
-			this.emit({ type: "notice", level: "warning", text: "该对话不存在或已关闭" });
+			this.emit({
+				type: "notice",
+				level: "warning",
+				text: "该对话不存在或已关闭",
+				textEn: "This conversation does not exist or is already closed",
+			});
 			return;
 		}
 		if (id === this.activeId) {
-			this.emit({ type: "notice", level: "warning", text: "当前对话不能直接移出，请先切换到其他对话" });
+			this.emit({
+				type: "notice",
+				level: "warning",
+				text: "当前对话不能直接移出，请先切换到其他对话",
+				textEn: "The active conversation cannot be removed directly — switch to another conversation first",
+			});
 			return;
 		}
 		if (!conv.listed) {
@@ -3429,18 +3449,21 @@ export class ClientSession {
 					type: "notice",
 					level: "warning",
 					text: `对话「${conv.title}」仍在运行中，请先等待结束或点击停止后再移出`,
+					textEn: `Conversation "${conv.title}" is still running — wait for it to finish or press Stop before removing`,
 				});
 			} else if (conv.terminals.list().length > 0) {
 				this.emit({
 					type: "notice",
 					level: "warning",
 					text: `对话「${conv.title}」还有未关闭的终端，请先关闭终端后再移出`,
+					textEn: `Conversation "${conv.title}" still has open terminals — close them before removing`,
 				});
 			} else {
 				this.emit({
 					type: "notice",
 					level: "warning",
 					text: `对话「${conv.title}」暂时无法移出（存在待处理的后台任务/审查）`,
+					textEn: `Conversation "${conv.title}" cannot be removed right now (pending background task/review)`,
 				});
 			}
 			return;
@@ -3836,7 +3859,7 @@ export class ClientSession {
 				if (displaced) this.removeConversation(displaced.id);
 				for (const d of newRuntime.diagnostics) {
 					if (d.type !== "info") {
-						this.emit({ type: "notice", level: d.type, text: d.message });
+						this.emit({ type: "notice", level: d.type, text: d.message, textEn: d.message });
 					}
 				}
 				await this.bindSession();
@@ -4014,18 +4037,18 @@ export class ClientSession {
 
 	/** Push the user command list (.pi/commands.json) to the client. */
 	async listCommands(): Promise<void> {
-		const { commands, path, warning } = await loadCommands(this.cwd);
+		const { commands, path, warning, warningEn } = await loadCommands(this.cwd);
 		if (warning) {
-			this.emit({ type: "notice", level: "warning", text: warning });
+			this.emit({ type: "notice", level: "warning", text: warning, textEn: warningEn });
 		}
 		this.emit({ type: "commands", commands, path });
 	}
 
 	/** Persist the user command list (.pi/commands.json). */
 	async saveCommands(commands: CommandDef[]): Promise<void> {
-		const { path, error } = await saveCommandsFile(this.cwd, commands);
+		const { path, error, errorEn } = await saveCommandsFile(this.cwd, commands);
 		if (error) {
-			this.emit({ type: "notice", level: "error", text: error });
+			this.emit({ type: "notice", level: "error", text: error, textEn: errorEn });
 			return;
 		}
 		this.emit({ type: "commands", commands, path });

--- a/server/dsh/dsh-agent-service.ts
+++ b/server/dsh/dsh-agent-service.ts
@@ -1164,8 +1164,8 @@ export class DshClientSession {
 		for (const sink of [...this.sinks]) sink(msg);
 	}
 
-	emitNotice(level: "info" | "warning" | "error", text: string): void {
-		this.emit({ type: "notice", level, text });
+	emitNotice(level: "info" | "warning" | "error", text: string, textEn?: string): void {
+		this.emit({ type: "notice", level, text, textEn });
 	}
 
 	private pushTerminals(): void {
@@ -1454,6 +1454,9 @@ export class DshClientSession {
 			text: hadGoal
 				? "已新建分支继续对话（DSH 引擎不支持原地续聊旧会话）；原目标已随旧会话存档，如需继续请重新设置目标"
 				: "已新建分支继续对话（DSH 引擎不支持原地续聊旧会话）",
+			textEn: hadGoal
+				? "Started a branch to continue (DSH engine cannot resume an old session in place); the old goal was archived with it — set a new goal to continue"
+				: "Started a branch to continue (DSH engine cannot resume an old session in place)",
 		});
 		return fork;
 	}
@@ -1762,11 +1765,21 @@ export class DshClientSession {
 	async dismissConversation(id: string): Promise<void> {
 		const conv = this.convs.get(id);
 		if (!conv) {
-			this.emit({ type: "notice", level: "warning", text: "该对话不存在或已关闭" });
+			this.emit({
+				type: "notice",
+				level: "warning",
+				text: "该对话不存在或已关闭",
+				textEn: "This conversation does not exist or is already closed",
+			});
 			return;
 		}
 		if (id === this.activeId) {
-			this.emit({ type: "notice", level: "warning", text: "当前对话不能直接移出，请先切换到其他对话" });
+			this.emit({
+				type: "notice",
+				level: "warning",
+				text: "当前对话不能直接移出，请先切换到其他对话",
+				textEn: "The active conversation cannot be removed directly — switch to another conversation first",
+			});
 			return;
 		}
 		if (!conv.listed) {
@@ -1778,11 +1791,17 @@ export class DshClientSession {
 				type: "notice",
 				level: "warning",
 				text: `对话「${conv.title}」仍在运行中，请先等待结束或停止后再移出`,
+				textEn: `Conversation "${conv.title}" is still running — wait for it to finish or press Stop before removing`,
 			});
 			return;
 		}
 		if (conv.terminals.list().length > 0) {
-			this.emit({ type: "notice", level: "warning", text: `对话「${conv.title}」还有未关闭的终端` });
+			this.emit({
+				type: "notice",
+				level: "warning",
+				text: `对话「${conv.title}」还有未关闭的终端，请先关闭终端后再移出`,
+				textEn: `Conversation "${conv.title}" still has open terminals — close them before removing`,
+			});
 			return;
 		}
 		this.removeConversation(id);
@@ -2885,7 +2904,7 @@ export class DshClientSession {
 			try {
 				const result = await def.run(args, { clientId: this.clientId });
 				if (typeof result === "string" && result.trim()) {
-					this.emit({ type: "notice", level: "info", text: result });
+					this.emit({ type: "notice", level: "info", text: result, textEn: result });
 				}
 			} catch (err) {
 				this.emit({
@@ -3122,7 +3141,8 @@ export class DshClientSession {
 
 	async cloneProvider(_provider: string, reqId: number): Promise<void> {
 		const error = "DSH 引擎不支持自定义 provider";
-		this.emit({ type: "notice", level: "error", text: error });
+		const errorEn = "DSH engine does not support custom providers";
+		this.emit({ type: "notice", level: "error", text: error, textEn: errorEn });
 		this.emit({ type: "clone_provider_result", reqId, ok: false, error });
 	}
 

--- a/server/files-service.ts
+++ b/server/files-service.ts
@@ -664,14 +664,14 @@ export class FilesService {
 	 * for the target dir (the recursive watcher may not cover it on posix).
 	 */
 	async uploadFile(relDir: string, name: string, data: string): Promise<void> {
-		const emitErr = (text: string) => this.host.emit({ type: "notice", level: "error", text });
+		const emitErr = (text: string, textEn?: string) => this.host.emit({ type: "notice", level: "error", text, textEn });
 		try {
 			const root = this.host.getCwd();
 			let wp: { abs: string; rel: string } | null;
 			if (relDir) {
 				wp = workspacePath(resolve(root), relDir);
 				if (!wp) {
-					emitErr(`路径超出工作区：${relDir}`);
+					emitErr(`路径超出工作区：${relDir}`, `Path outside workspace: ${relDir}`);
 					return;
 				}
 			} else {
@@ -684,16 +684,19 @@ export class FilesService {
 			const abs = resolve(wp.abs, safe);
 			const rawRel = relative(root, abs);
 			if (rawRel.startsWith("..") || rawRel.includes(`${sep}..`)) {
-				emitErr(`文件名不合法：${name}`);
+				emitErr(`文件名不合法：${name}`, `Invalid file name: ${name}`);
 				return;
 			}
 			const buf = Buffer.from(data, "base64");
 			if (buf.length === 0) {
-				emitErr(`空文件：${name}`);
+				emitErr(`空文件：${name}`, `Empty file: ${name}`);
 				return;
 			}
 			if (buf.length > MAX_UPLOAD_BYTES) {
-				emitErr(`文件过大：${name}（上限 ${Math.round(MAX_UPLOAD_BYTES / 1024 / 1024)}MB）`);
+				emitErr(
+					`文件过大：${name}（上限 ${Math.round(MAX_UPLOAD_BYTES / 1024 / 1024)}MB）`,
+					`File too large: ${name} (max ${Math.round(MAX_UPLOAD_BYTES / 1024 / 1024)}MB)`,
+				);
 				return;
 			}
 			mkdirSync(wp.abs, { recursive: true });
@@ -712,7 +715,7 @@ export class FilesService {
 				path: wp.rel,
 			});
 		} catch (err) {
-			emitErr(`上传文件失败：${(err as Error).message}`);
+			emitErr(`上传文件失败：${(err as Error).message}`, `Upload failed: ${(err as Error).message}`);
 		}
 	}
 

--- a/server/goal-service.ts
+++ b/server/goal-service.ts
@@ -677,7 +677,7 @@ export class GoalService {
 	 * Otherwise, spawn the isolated reviewer if a goal is pending. Returns a
 	 * notice text for the host to emit (manual-stop case), or null.
 	 */
-	onAgentEnd(conv: GoalConversation, aborted: boolean): string | null {
+	onAgentEnd(conv: GoalConversation, aborted: boolean): { text: string; textEn: string } | null {
 		const g = conv.goal;
 		if (aborted) {
 			if (g.goal && g.conversationId === conv.id) {
@@ -690,7 +690,10 @@ export class GoalService {
 				g.status = "已手动停止，目标审查已中止";
 				g.statusEn = "Stopped manually, goal review aborted";
 				this.emitGoalStatus();
-				return "⏹ 已手动停止，目标审查已中止（想继续可重新设定目标）";
+				return {
+					text: "⏹ 已手动停止，目标审查已中止（想继续可重新设定目标）",
+					textEn: "⏹ Stopped manually, goal review aborted (set a new goal to continue)",
+				};
 			}
 			return null;
 		}

--- a/server/index.ts
+++ b/server/index.ts
@@ -538,7 +538,7 @@ export interface DispatchSession {
 	saveSubagentTemplate(template: UiSubagentTemplate): Promise<void>;
 	/** 删除一个子代理模板。 */
 	deleteSubagentTemplate(name: string): Promise<void>;
-	emitNotice(level: "info" | "warning" | "error", text: string): void;
+	emitNotice(level: "info" | "warning" | "error", text: string, textEn?: string): void;
 	activeConversations(): number;
 	pendingMessages(): number;
 }
@@ -1019,9 +1019,9 @@ wss.on("connection", (ws) => {
 			case "plugin_settings": {
 				const r = pluginMgr.savePluginSettings(msg.pluginId, msg.values ?? {});
 				if (r.error) {
-					cs?.emitNotice("error", `插件设置保存失败：${r.error}`);
+					cs?.emitNotice("error", `插件设置保存失败：${r.error}`, `Failed to save plugin settings: ${r.error}`);
 				} else {
-					cs?.emitNotice("info", "插件设置已保存");
+					cs?.emitNotice("info", "插件设置已保存", "Plugin settings saved");
 				}
 				break;
 			}

--- a/server/marker-service.ts
+++ b/server/marker-service.ts
@@ -187,8 +187,8 @@ export class MarkerService {
 			const state = getOrInit(token.tool) as never;
 			const ctx: MarkerContext = {
 				conversationId,
-				notify: (msg, level) => {
-					this.host.emit({ type: "notice", level: level ?? "info", text: msg });
+				notify: (msg, level, msgEn) => {
+					this.host.emit({ type: "notice", level: level ?? "info", text: msg, textEn: msgEn });
 				},
 				renameConversation: (title: string) => {
 					this.host.renameConversation(conversationId, title);
@@ -210,7 +210,12 @@ export class MarkerService {
 				}
 				if (token.tool === "todo" || token.tool === "svc") dirty.add(token.tool);
 			} else if (result.error) {
-				this.host.emit({ type: "notice", level: "warning", text: `[${token.tool}] ${result.error}` });
+				this.host.emit({
+					type: "notice",
+					level: "warning",
+					text: `[${token.tool}] ${result.error}`,
+					textEn: `[${token.tool}] ${result.error}`,
+				});
 			}
 		}
 

--- a/server/markers/builtins/rename.ts
+++ b/server/markers/builtins/rename.ts
@@ -45,7 +45,7 @@ export const renameMarker: MarkerTool<never> = {
 		if (!ctx.renameConversation) return { applied: false, error: "当前环境不支持重命名" };
 		try {
 			ctx.renameConversation(title);
-			ctx.notify(`已重命名为：${title}`, "info");
+			ctx.notify(`已重命名为：${title}`, "info", `Renamed to: ${title}`);
 			return { applied: true, feedback: `renamed to "${title}"` };
 		} catch (e) {
 			return { applied: false, error: `重命名失败: ${(e as Error).message ?? String(e)}` };
@@ -69,7 +69,7 @@ export const renameAliasMarker: MarkerTool<never> = {
 		if (!ctx.renameConversation) return { applied: false, error: "当前环境不支持重命名" };
 		try {
 			ctx.renameConversation(trimmed);
-			ctx.notify(`已重命名为：${trimmed}`, "info");
+			ctx.notify(`已重命名为：${trimmed}`, "info", `Renamed to: ${trimmed}`);
 			return { applied: true, feedback: `renamed to "${trimmed}"` };
 		} catch (e) {
 			return { applied: false, error: `重命名失败: ${(e as Error).message ?? String(e)}` };
@@ -89,7 +89,7 @@ export const titleAliasMarker: MarkerTool<never> = {
 		if (!title) return { applied: false, error: "title:rename 需要标题" };
 		if (!ctx.renameConversation) return { applied: false, error: "当前环境不支持重命名" };
 		ctx.renameConversation(title.slice(0, 80));
-		ctx.notify(`已重命名为：${title.slice(0, 80)}`, "info");
+		ctx.notify(`已重命名为：${title.slice(0, 80)}`, "info", `Renamed to: ${title.slice(0, 80)}`);
 		return { applied: true, feedback: `renamed` };
 	},
 	overlay: undefined,

--- a/server/markers/marker.ts
+++ b/server/markers/marker.ts
@@ -30,7 +30,7 @@ export interface MarkerContext {
 	/** 当前对话 id（用于 rename 等需要定位对话的标记）。 */
 	conversationId: string;
 	/** 通知 UI（非打断）。 */
-	notify(text: string, level?: "info" | "warning" | "error"): void;
+	notify(text: string, level?: "info" | "warning" | "error", textEn?: string): void;
 	/** 重命名当前对话（rename 标记专用）。 */
 	renameConversation?(title: string): void;
 }

--- a/server/model-admin.ts
+++ b/server/model-admin.ts
@@ -602,19 +602,19 @@ export class ModelAdminService {
 	 */
 	async cloneProvider(providerId: string, reqId: number): Promise<void> {
 		const pid = providerId.trim();
-		const fail = (error: string) => {
-			this.host.emit({ type: "notice", level: "error", text: error });
+		const fail = (error: string, errorEn?: string) => {
+			this.host.emit({ type: "notice", level: "error", text: error, textEn: errorEn });
 			this.host.emit({ type: "clone_provider_result", reqId, ok: false, error });
 		};
 		try {
 			if (!pid) {
-				fail("请填写服务商 ID");
+				fail("请填写服务商 ID", "Enter a provider ID");
 				return;
 			}
 			const mr = this.host.modelRuntime();
 			const p = mr.getProvider(pid);
 			if (!p) {
-				fail(`供应商 ${pid} 不存在`);
+				fail(`供应商 ${pid} 不存在`, `Provider ${pid} does not exist`);
 				return;
 			}
 			const noBaseUrl = !p.baseUrl;
@@ -643,7 +643,10 @@ export class ModelAdminService {
 				models = readModels();
 			}
 			if (models.length === 0) {
-				fail(`${pid} 的模型列表为空，无法复制（请稍后重试）`);
+				fail(
+					`${pid} 的模型列表为空，无法复制（请稍后重试）`,
+					`Model list for ${pid} is empty, cannot clone (retry later)`,
+				);
 				return;
 			}
 			// 供应商级 api 取占比最高，模型保留全量去重（避免 muse-spark 被过滤）
@@ -673,10 +676,13 @@ export class ModelAdminService {
 				text: noBaseUrl
 					? `📋 已复制 ${pid} → ${newId}（${kept.length} 个模型），该供应商无远程 baseUrl，已生成模板请手动填写 baseUrl 和新的 API 密钥后保存`
 					: `📋 已复制 ${pid} → ${newId}（${kept.length} 个模型），请填入新的 API 密钥后保存`,
+				textEn: noBaseUrl
+					? `📋 Cloned ${pid} → ${newId} (${kept.length} models); this provider has no remote baseUrl — template generated, fill in baseUrl and a new API key, then save`
+					: `📋 Cloned ${pid} → ${newId} (${kept.length} models); fill in the new API key, then save`,
 			});
 			this.host.emit({ type: "clone_provider_result", reqId, ok: true, config, configs: [config] });
 		} catch (err) {
-			fail(`复制服务商失败：${(err as Error).message}`);
+			fail(`复制服务商失败：${(err as Error).message}`, `Failed to clone provider: ${(err as Error).message}`);
 		}
 		this.host.flushSnapshot();
 	}
@@ -1074,6 +1080,10 @@ export class ModelAdminService {
 					added > 0
 						? `🔄 已刷新 ${pid}：新增 ${added} 个模型，共 ${merged.length} 个`
 						: `🔄 已刷新 ${pid}：无新增模型（共 ${merged.length} 个）`,
+				textEn:
+					added > 0
+						? `🔄 Refreshed ${pid}: ${added} new models, ${merged.length} total`
+						: `🔄 Refreshed ${pid}: no new models (${merged.length} total)`,
 			});
 			return done(true, { added, total: merged.length });
 		} catch (err) {

--- a/server/plugins.ts
+++ b/server/plugins.ts
@@ -71,7 +71,7 @@ export interface PluginHost {
 	/** 向所有已连接的浏览器广播一条本插件的消息（plugin_data）。 */
 	broadcast(payload: unknown): void;
 	/** 发一条系统通知条（notice）给所有已连接的浏览器。 */
-	notify(level: "info" | "warning" | "error", text: string): void;
+	notify(level: "info" | "warning" | "error", text: string, textEn?: string): void;
 	/** 注册客户端上行消息（plugin_message）处理器；回调第二参为发送方 clientId
 	 *  （可用于 sendTo 定向回复）。返回注销函数。 */
 	onMessage(handler: (payload: unknown, from?: string) => void): () => void;
@@ -502,6 +502,7 @@ export class PluginManager {
 			this.notifyAll(
 				perms.length ? "warning" : "info",
 				`插件「${info.name}」已激活（${prev ? "能力清单变更" : "首次安装"}；声明能力：${list}）——请确认来源可信`,
+				`Plugin "${info.name}" activated (${prev ? "capability list changed" : "first install"}; declared: ${list}) — verify the source is trusted`,
 			);
 			writeFileSync(markerFile, JSON.stringify({ v: 1, key, perms }), "utf8");
 		} catch (err) {
@@ -537,8 +538,8 @@ export class PluginManager {
 	}
 
 	/** 系统通知：发给所有 socket（复用 notice 消息，前端 toast 展示）。 */
-	notifyAll(level: "info" | "warning" | "error", text: string): void {
-		this.deliverAll({ type: "notice", level, text });
+	notifyAll(level: "info" | "warning" | "error", text: string, textEn?: string): void {
+		this.deliverAll({ type: "notice", level, text, textEn });
 	}
 
 	/** 给指定客户端定向发一条插件消息；找不到该 socket 时静默忽略。 */
@@ -899,7 +900,7 @@ export class PluginManager {
 		const self = this; // 对象字面量 getter 里不能用插件宿主的 this (oxlint no-this-alias: 誤報, getter closure 需要 host)
 		const host: PluginHost = {
 			broadcast: (payload) => this.broadcast(info.id, payload),
-			notify: (level, text) => this.notifyAll(level, text),
+			notify: (level, text, textEn) => this.notifyAll(level, text, textEn),
 			sendTo: (clientId, payload) => this.sendTo(clientId, info.id, payload),
 			onMessage: (h) => {
 				handlers.add(h);

--- a/server/slash-commands.ts
+++ b/server/slash-commands.ts
@@ -215,6 +215,9 @@ export class SlashCommandsService {
 						text: current
 							? `当前模型：${current.name}（${current.provider}/${current.id}）。用法：/model <名称>`
 							: `用法：/model <名称>`,
+						textEn: current
+							? `Current model: ${current.name} (${current.provider}/${current.id}). Usage: /model <name>`
+							: `Usage: /model <name>`,
 					});
 					return true;
 				}

--- a/server/terminals.ts
+++ b/server/terminals.ts
@@ -57,13 +57,15 @@ export function resolveCommandCwd(cwd: string | undefined, pwd: string): string 
 /** Read the command list; missing file → empty list; malformed → empty list + warning text. */
 export async function loadCommands(
 	workspaceRoot: string,
-): Promise<{ commands: CommandDef[]; path: string; warning?: string }> {
+): Promise<{ commands: CommandDef[]; path: string; warning?: string; warningEn?: string }> {
 	const path = commandsFilePath(workspaceRoot);
-	const { commands, warning } = await readCommandsFile(path);
-	return { commands, path, warning };
+	const { commands, warning, warningEn } = await readCommandsFile(path);
+	return { commands, path, warning, warningEn };
 }
 
-async function readCommandsFile(path: string): Promise<{ commands: CommandDef[]; warning?: string }> {
+async function readCommandsFile(
+	path: string,
+): Promise<{ commands: CommandDef[]; warning?: string; warningEn?: string }> {
 	if (!existsSync(path)) return { commands: [] };
 	let raw: string;
 	try {
@@ -72,13 +74,18 @@ async function readCommandsFile(path: string): Promise<{ commands: CommandDef[];
 		return {
 			commands: [],
 			warning: `读取命令文件失败：${(err as Error).message}`,
+			warningEn: `Failed to read commands file: ${(err as Error).message}`,
 		};
 	}
 	let parsed: unknown;
 	try {
 		parsed = JSON.parse(raw);
 	} catch {
-		return { commands: [], warning: `命令文件不是有效 JSON：${path}` };
+		return {
+			commands: [],
+			warning: `命令文件不是有效 JSON：${path}`,
+			warningEn: `Commands file is not valid JSON: ${path}`,
+		};
 	}
 	if (Array.isArray(parsed)) {
 		// Tolerate a bare array: [{name, command, cwd}]
@@ -108,14 +115,14 @@ async function readCommandsFile(path: string): Promise<{ commands: CommandDef[];
 				.map((c) => ({ name: c.name, command: c.command, cwd: c.cwd })),
 		};
 	}
-	return { commands: [], warning: `命令文件格式不正确：${path}` };
+	return { commands: [], warning: `命令文件格式不正确：${path}`, warningEn: `Commands file has a bad format: ${path}` };
 }
 
 /** Persist the command list, creating .pi/ if needed. */
 export async function saveCommandsFile(
 	workspaceRoot: string,
 	commands: CommandDef[],
-): Promise<{ path: string; error?: string }> {
+): Promise<{ path: string; error?: string; errorEn?: string }> {
 	const path = commandsFilePath(workspaceRoot);
 	try {
 		await mkdir(join(workspaceRoot, ".pi"), { recursive: true });
@@ -123,7 +130,11 @@ export async function saveCommandsFile(
 		await writeFile(path, JSON.stringify(payload, null, 2) + "\n", "utf8");
 		return { path };
 	} catch (err) {
-		return { path, error: `保存命令文件失败：${(err as Error).message}` };
+		return {
+			path,
+			error: `保存命令文件失败：${(err as Error).message}`,
+			errorEn: `Failed to save commands file: ${(err as Error).message}`,
+		};
 	}
 }
 
@@ -366,6 +377,7 @@ export function queryTerminalOutput(
 			const t = l.trim();
 			return (
 				!/^\[pi-exit:\d+\]$/.test(t) &&
+				!/^\[pi-term-exit:-?\d+\]$/.test(t) &&
 				!t.startsWith("[进程已退出") &&
 				!t.startsWith("[Process exited") &&
 				!/^\[.*(已退出|exited)/.test(t)
@@ -1293,14 +1305,13 @@ export class TerminalManager {
 		const entry = this.terms.get(id);
 		if (!entry || entry.exited) return;
 		this.disarmIdleWatch(entry);
-		// Flush queued output BEFORE the exit banner so ordering is preserved.
+		// Flush queued output BEFORE the exit marker so ordering is preserved.
+		// Banner text is CLIENT-rendered (live locale); the stream carries only
+		// a machine sentinel the client strips and replaces.
 		this.flushPending(entry);
-		const banner =
-			entry.locale === "en"
-				? `\r\n\x1b[90m[Process exited with code ${exitCode}]\x1b[0m\r\n`
-				: `\r\n\x1b[90m[进程已退出，退出码 ${exitCode}]\x1b[0m\r\n`;
-		this.appendOutput(entry, banner);
-		this.emit({ type: "terminal_output", terminalId: id, data: banner });
+		const marker = `\r\n[pi-term-exit:${exitCode}]\r\n`;
+		this.appendOutput(entry, marker);
+		this.emit({ type: "terminal_output", terminalId: id, data: marker });
 		entry.exited = true;
 		// 终端退出 → 未命中的输出观察器以 null 回调（宿主可据此通知「终端已关闭」）。
 		const pendingWatches = entry.watches;

--- a/server/webui-context.ts
+++ b/server/webui-context.ts
@@ -145,8 +145,8 @@ export class WebUIContext {
 
 	// -- notifications --------------------------------------------------------
 
-	notify = (message: string, type?: "info" | "warning" | "error"): void => {
-		this.emit({ type: "notice", level: type ?? "info", text: message });
+	notify = (message: string, type?: "info" | "warning" | "error", messageEn?: string): void => {
+		this.emit({ type: "notice", level: type ?? "info", text: message, textEn: messageEn });
 	};
 
 	// -- footer status (pi-lens "LSP Inactive", pi-cache-optimizer cache stats) --

--- a/web/src/components/TermXterm.tsx
+++ b/web/src/components/TermXterm.tsx
@@ -6,6 +6,18 @@ import type { ClientMessage, CommandDef } from "../types";
 import { buildTermTheme, THEME_CHANGE_EVENT } from "../theme";
 import { useI18n } from "../i18n";
 
+/** Strip exit sentinels/baked banners; the banner itself renders on terminal_exit. */
+export function stripExitBanner(data: string): { clean: string; exitCode: number | null } {
+	let exitCode: number | null = null;
+	const clean = data
+		.replace(/\r?\n?\[pi-term-exit:(-?\d+)\]\r?\n?/g, (_, c: string) => {
+			exitCode = Number(c);
+			return "\r\n";
+		})
+		.replace(/\r?\n?\x1b\[90m\[(?:进程已退出，退出码 |Process exited with code )-?\d+\]\x1b\[0m\r?\n?/g, "\r\n");
+	return { clean, exitCode };
+}
+
 interface TermXtermProps {
 	conversationId: string;
 	terminalId: string;
@@ -17,6 +29,10 @@ interface TermXtermProps {
 	title?: string;
 	/** Whether this terminal is the visible one. */
 	active: boolean;
+	/** Live running flag (banner renders when this flips false). */
+	running?: boolean;
+	/** Exit code (banner text). */
+	exitCode?: number | null;
 	send: (msg: ClientMessage) => boolean;
 	register: (conversationId: string, id: string, writer: { write(data: string): void; dispose(): void }) => () => void;
 }
@@ -27,7 +43,18 @@ interface TermXtermProps {
  * the bridge, and kills the PTY on unmount. Kept mounted while hidden so
  * scrollback survives tab switches.
  */
-export function TermXterm({ conversationId, terminalId, command, cwd, title, active, send, register }: TermXtermProps) {
+export function TermXterm({
+	conversationId,
+	terminalId,
+	command,
+	cwd,
+	title,
+	active,
+	running,
+	exitCode,
+	send,
+	register,
+}: TermXtermProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const termRef = useRef<{ term: Terminal; fit: FitAddon } | null>(null);
 	// UI locale is captured at PTY creation (the server bakes the exit-banner
@@ -97,7 +124,7 @@ export function TermXterm({ conversationId, terminalId, command, cwd, title, act
 		});
 
 		const unregister = register(conversationId, terminalId, {
-			write: (data) => term.write(data),
+			write: (data) => term.write(stripExitBanner(data).clean),
 			dispose: () => term.dispose(),
 		});
 
@@ -197,6 +224,21 @@ export function TermXterm({ conversationId, terminalId, command, cwd, title, act
 		return () => cancelAnimationFrame(raf);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [active]);
+
+	// Exit banner in the LIVE locale (reads t() at effect time, not at
+	// PTY-creation time). Guarded so remounts don't double-write.
+	const { t } = useI18n();
+	const bannerFor = useRef<string | null>(null);
+	useEffect(() => {
+		if (running !== false) return;
+		const key = `${terminalId}:${exitCode ?? ""}`;
+		if (bannerFor.current === key) return;
+		bannerFor.current = key;
+		const inst = termRef.current;
+		if (!inst) return;
+		inst.term.write(`\r\n\x1b[90m${t("exitBanner", { code: exitCode ?? "" })}\x1b[0m\r\n`);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [running, terminalId]);
 
 	return <div ref={containerRef} className={`term-xterm ${active ? "" : "hidden"}`} />;
 }

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -10,6 +10,7 @@ const STORAGE_KEY = "pi-web-ui:lang";
 
 const zh = {
 	/* common */
+	docTitle: "pi-web-ui — pi 编码智能体",
 	cancel: "取消",
 	ok: "确定",
 	save: "保存",
@@ -548,6 +549,7 @@ const zh = {
 	termEmptySub: "点击左侧命令运行，或点右侧 + 新建终端",
 	noTerminal: "暂无终端",
 	exited: "（已退出{code}）",
+	exitBanner: "[进程已退出，退出码 {code}]",
 	closeTerminal: "关闭终端",
 	renameTerminal: "重命名终端",
 	rerun: "重新读取 .pi/commands.json",
@@ -845,6 +847,7 @@ const zh = {
 
 const en: Record<keyof typeof zh, string> = {
 	/* common */
+	docTitle: "pi-web-ui — pi coding agent",
 	cancel: "Cancel",
 	ok: "OK",
 	save: "Save",
@@ -1392,6 +1395,7 @@ const en: Record<keyof typeof zh, string> = {
 	termEmptySub: "Click a command on the left to run it, or + on the right for a new terminal",
 	noTerminal: "No terminals",
 	exited: "(exited{code})",
+	exitBanner: "[Process exited with code {code}]",
 	closeTerminal: "Close terminal",
 	renameTerminal: "Rename terminal",
 	rerun: "Reload .pi/commands.json",
@@ -1748,6 +1752,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 
 	useEffect(() => {
 		document.documentElement.lang = locale === "zh" ? "zh-CN" : "en";
+		document.title = locale === "zh" ? zh.docTitle : en.docTitle;
 	}, [locale]);
 
 	const value = useMemo(() => ({ locale, setLocale, t }), [locale, setLocale, t]);


### PR DESCRIPTION
EN — Summary
- Adds `textEn` English parallel to 33 notice toasts that had Chinese only (audit: 0 missing remain)
- Helpers `emitNotice` / `emitErr` / `notifyAll` / `notify` now take `textEn`; goal stop notice returns `{text, textEn}`
- Exit banner is client-rendered in live locale (server sends `[pi-term-exit:N]` sentinel); page `<title>` follows locale
- Covers dismiss/move, plugin settings + consent, upload, model-admin copy/refresh, slash usage, marker rename

中文 — 摘要
- 33 条中文通知补英文 `textEn`（审计确认零遗漏）；辅助函数透传 `textEn`；目标停止返回中英对
- 退出横幅改客户端按实时语言渲染；页标题跟随语言切换

Test: `npm run typecheck`, `format`, `build` green; `vitest` 311 passed; lint only 3 pre-existing upstream warnings.

> Note: Translations in this PR were generated by an automated translation system. If any wording is awkward or inaccurate, please point it out and it will be corrected. / 本 PR 中的翻译由自动翻译系统生成，如有措辞不当或不准确之处，欢迎指出并将予以修正。
