### PR TITLE
fix(mobile): keep send button above thinking-level bottom sheet / 发送按钮盖过思考强度底弹层

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6022,6 +6022,9 @@ span.msg-editor-hint svg {
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
+	/* Mobile: thinking-level bottom sheet (z-90) must not cover send/stop. */
+	position: relative;
+	z-index: 100;
 }
 .inputbox:focus-within {
 	border-color: color-mix(in srgb, var(--accent) 55%, var(--border));


### PR DESCRIPTION
EN — Summary
- `.composer-tools-right` gets `position: relative; z-index: 100` so send/stop stays above the thinking-level bottom sheet (z-90) on mobile

中文 — 摘要
- 发送/停止按钮层级盖过思考强度底弹层，移动端始终可点

Test: `npm run build` green.

> Note: Translations in this PR were generated by an automated translation system. If any wording is awkward or inaccurate, please point it out and it will be corrected. / 本 PR 中的翻译由自动翻译系统生成，如有措辞不当或不准确之处，欢迎指出并将予以修正。
