### PR TITLE
feat(cli): bilingual pi-web-ui --help output (zh/en via LANG detection)

### DIFF
--- a/bin/pi-web-ui.mjs
+++ b/bin/pi-web-ui.mjs
@@ -62,7 +62,21 @@ try {
 	// version is best-effort — the server itself doesn't need it
 }
 
-const HELP = `pi-web-ui v${pkg.version} — web chat for the pi coding agent
+/** Detect if the user prefers Chinese locale: POSIX env vars win, then Intl API fallback. */
+function isZhLang() {
+	const env = process.env.LC_ALL || process.env.LC_MESSAGES || process.env.LANG || "";
+	if (env.startsWith("zh")) return true;
+	if (!env) {
+		try {
+			return Intl.DateTimeFormat().resolvedOptions().locale.startsWith("zh");
+		} catch {
+			/* ignore */
+		}
+	}
+	return false;
+}
+
+const HELP_ZH = `pi-web-ui v${pkg.version} — web chat for the pi coding agent
 
 用法:
   pi-web-ui                               启动服务器（前台，Ctrl+C 停止，自动打开浏览器）
@@ -109,6 +123,55 @@ server 选项:
   鉴权口令 PI_WEB_TOKEN：仅环境变量（不走命令行，避免被 ps 看到），需要时手动加入服务配置。
 `;
 
+const HELP_EN = `pi-web-ui v${pkg.version} — web chat for the pi coding agent
+
+Usage:
+  pi-web-ui                               Start server (foreground, Ctrl+C to stop, auto-opens browser)
+  pi-web-ui --engine dsh --port 9000 --cwd /path      Start with engine/port/cwd/data-dir overrides
+  pi-web-ui --no-browser                   Start without auto-opening browser
+  pi-web-ui server install [options]       Install system service (autostart on boot) and launch it
+  pi-web-ui server shortcut [options]      Create desktop "one-click start" icon
+  pi-web-ui server uninstall [options]     Uninstall system service (also removes desktop icon)
+  pi-web-ui server start|stop|restart|status [options]
+  pi-web-ui server quiesce [options]       Drain mode: reject new chats/messages/edits; let current runs finish
+  pi-web-ui server unquiesce [options]     Exit drain mode, resume accepting new work
+  pi-web-ui --version / --help
+
+Server options:
+  --port <n>        Port (default 8787, or $PI_WEB_PORT)
+  --cwd <dir>       Working directory (default $PI_WEB_CWD or home dir; foreground uses current dir)
+  --data-dir <dir>  Session data directory (default <cwd>/.pi-web)
+  --engine <pi|dsh> Agent engine (default $PI_WEB_ENGINE or pi)
+  --host <addr>     Listen address (default $PI_WEB_HOST or 127.0.0.1; 0.0.0.0 for LAN/containers)
+  --agent-dir <dir> pi config directory (default $PI_CODING_AGENT_DIR or ~/.pi/agent)
+  --name <name>     Service name (default pi-web-ui; macOS launchd label is
+                    com.xingshuyin.pi-web-ui, or com.<name>.server for custom names)
+  --print           Only print generated config files (no actual install)
+
+Platforms: macOS → launchd user agent · Linux → systemd · Windows → Logon Run key
+           (HKCU, no admin needed; wscript hidden launch, no black window)
+Shortcuts: Windows → desktop .lnk · macOS → desktop .command · Linux → desktop .desktop
+
+UI plugins (installed into <data-dir>/plugins/; refresh browser to activate while running):
+  pi-web-ui install <source>          Install a UI plugin from GitHub
+  pi-web-ui uninstall <id>            Uninstall a UI plugin
+  pi-web-ui plugins                   List installed UI plugins
+
+  Source formats: owner/repo · https://github.com/owner/repo · local directory path
+                  URL with /tree/<branch>/<subdir> to specify branch and sub-directory;
+                  append #<branch-or-tag> to any source to pin a branch (e.g. owner/repo#v1.2)
+  install options: --name <id>   Custom plugin directory name (default: repo name)
+                   --data-dir <dir>  Data directory (default: ~/.pi-web)
+                   --force       Overwrite if target already exists
+
+Environment variables (flag takes precedence, env var as fallback):
+  PI_WEB_PORT / PI_WEB_CWD / PI_WEB_DATA_DIR / PI_WEB_ENGINE / PI_WEB_HOST /
+  PI_CODING_AGENT_DIR
+  Auth token PI_WEB_TOKEN: env var only (not on command line, to avoid ps exposure)
+`;
+
+const HELP = isZhLang() ? HELP_ZH : HELP_EN;
+
 /** Minimum Node required by the pi SDK (its dist uses `import … with { type: "json" }`). */
 const NODE_MIN = [22, 19, 0];
 function checkNodeVersion() {
@@ -118,11 +181,13 @@ function checkNodeVersion() {
 		(v[0] === NODE_MIN[0] && v[1] < NODE_MIN[1]) ||
 		(v[0] === NODE_MIN[0] && v[1] === NODE_MIN[1] && v[2] < NODE_MIN[2]);
 	if (tooOld) {
-		console.error(
-			`✖ pi-web-ui 需要 Node.js >= ${NODE_MIN.join(".")}（当前 ${process.versions.node}）。\n` +
-				`  pi SDK 的代码使用了 import attributes（with）语法，旧版 Node 无法解析。\n` +
-				`  请升级 Node：https://nodejs.org（或 nvm-windows / fnm）后重装：npm i -g pi-web-ui`,
-		);
+		const zh = `✖ pi-web-ui 需要 Node.js >= ${NODE_MIN.join(".")}（当前 ${process.versions.node}）。\n` +
+			`  pi SDK 的代码使用了 import attributes（with）语法，旧版 Node 无法解析。\n` +
+			`  请升级 Node：https://nodejs.org（或 nvm-windows / fnm）后重装：npm i -g pi-web-ui`;
+		const en = `✖ pi-web-ui requires Node.js >= ${NODE_MIN.join(".")} (current: ${process.versions.node}).\n` +
+			`  The pi SDK uses import attributes (\`with\` syntax) which older Node versions can't parse.\n` +
+			`  Upgrade Node: https://nodejs.org then reinstall: npm i -g pi-web-ui`;
+		console.error(isZhLang() ? zh : en);
 		process.exit(1);
 	}
 }

--- a/bin/pi-web-ui.mjs
+++ b/bin/pi-web-ui.mjs
@@ -181,10 +181,12 @@ function checkNodeVersion() {
 		(v[0] === NODE_MIN[0] && v[1] < NODE_MIN[1]) ||
 		(v[0] === NODE_MIN[0] && v[1] === NODE_MIN[1] && v[2] < NODE_MIN[2]);
 	if (tooOld) {
-		const zh = `✖ pi-web-ui 需要 Node.js >= ${NODE_MIN.join(".")}（当前 ${process.versions.node}）。\n` +
+		const zh =
+			`✖ pi-web-ui 需要 Node.js >= ${NODE_MIN.join(".")}（当前 ${process.versions.node}）。\n` +
 			`  pi SDK 的代码使用了 import attributes（with）语法，旧版 Node 无法解析。\n` +
 			`  请升级 Node：https://nodejs.org（或 nvm-windows / fnm）后重装：npm i -g pi-web-ui`;
-		const en = `✖ pi-web-ui requires Node.js >= ${NODE_MIN.join(".")} (current: ${process.versions.node}).\n` +
+		const en =
+			`✖ pi-web-ui requires Node.js >= ${NODE_MIN.join(".")} (current: ${process.versions.node}).\n` +
 			`  The pi SDK uses import attributes (\`with\` syntax) which older Node versions can't parse.\n` +
 			`  Upgrade Node: https://nodejs.org then reinstall: npm i -g pi-web-ui`;
 		console.error(isZhLang() ? zh : en);


### PR DESCRIPTION
Add isZhLang() helper that detects Chinese locale from LC_ALL/LC_MESSAGES/LANG env vars with Intl.DateTimeFormat() fallback. Split HELP into HELP_ZH (original Chinese) and HELP_EN (full English equivalent), selected at runtime.

Also make checkNodeVersion() error bilingual.