### PR TITLE
feat(web): render Mermaid code blocks as diagrams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "compression": "^1.8.1",
         "express": "^4.21.2",
         "highlight.js": "^11.10.0",
+        "mermaid": "^11.17.2",
         "node-pty": "^1.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -50,6 +51,19 @@
       },
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-2.0.1.tgz",
+      "integrity": "sha512-iCKVQcIC0e3oDxEfs3SHQGW+ovhBMZmS1TE+bTk50rVyMCBmCfClv7Qi3HQKlumYwvjb/iIMeWCW2i67q6kFfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.7.0",
+        "tinyexec": "^1.2.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -333,6 +347,18 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@deepseek-ai/cordis": {
       "version": "4.0.2",
@@ -2951,6 +2977,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.5.tgz",
+      "integrity": "sha512-nT+AWyh5caHY6xa0PdLXpUooIz6l7qsT+adqsCTYBfbdn5Q18VrWs2fvuTa7KEoJnPBfEPqWkmAIht0EHtCi2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^2.0.1",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2999,6 +3042,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.1.tgz",
+      "integrity": "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
@@ -3858,6 +3910,259 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -3914,6 +4219,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.5",
@@ -4036,6 +4347,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -4057,6 +4375,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
       "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -4552,6 +4880,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -4674,6 +5011,15 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -4713,6 +5059,523 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.34.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.2.tgz",
+      "integrity": "sha512-Cm2jaj1X/PBNlzV9yH8zcfGOxO7U+CJ/+mxSBVPSchLaugdp4jtlGx5qaHtPRZ6tgiZ5P+o1XoRfJA+ba6KM3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4741,6 +5604,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/depd": {
@@ -4782,6 +5654,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -4863,6 +5744,18 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types",
+        "tests/browser-compat"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.28.2",
@@ -5050,6 +5943,15 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fastdom": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.12.tgz",
+      "integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
+      "license": "MIT",
+      "dependencies": {
+        "strictdom": "^1.0.1"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5212,6 +6114,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5366,6 +6274,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5377,6 +6295,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -5492,6 +6419,48 @@
         "node": ">=6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -5557,6 +6526,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -5854,6 +6835,36 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.17.2",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.2.tgz",
+      "integrity": "sha512-V6K3C8EBdEsPFZXSKMJe6ppQOENxuHARr9GvHX4hh47lAbhMRD9qf4oEK7LoaRQxULMa80/qt5gHO73aCleBBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.34.0",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.21",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "fastdom": "1.0.12",
+        "katex": "^0.16.47",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/methods": {
@@ -6617,6 +7628,12 @@
         }
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -6650,6 +7667,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -6705,6 +7728,22 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -6979,6 +8018,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.62.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
@@ -7024,6 +8069,24 @@
         "@rollup/rollup-win32-x64-msvc": "4.62.4",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -7298,6 +8361,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strictdom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+      "integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
+      "license": "MIT"
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -7358,6 +8427,12 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -7385,7 +8460,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
       "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7455,6 +8529,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {
@@ -7671,6 +8754,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "compression": "^1.8.1",
     "express": "^4.21.2",
     "highlight.js": "^11.10.0",
+    "mermaid": "^11.17.2",
     "node-pty": "^1.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/tests/unit/mermaid.test.ts
+++ b/tests/unit/mermaid.test.ts
@@ -66,9 +66,14 @@ describe("preserveMermaidSvgWidth", () => {
 	});
 
 	it("没有有效 viewBox 时保持 SVG 不变", () => {
-		const svg = '<svg width="100%"></svg>';
-		expect(preserveMermaidSvgWidth(svg)).toBe(svg);
-		expect(preserveMermaidSvgWidth("not svg")).toBe("not svg");
+		for (const svg of [
+			'<svg width="100%"></svg>',
+			'<svg viewBox="0 0 nope 70"></svg>',
+			"<svg viewBox='0,0,-20,70'></svg>",
+			"not svg",
+		]) {
+			expect(preserveMermaidSvgWidth(svg)).toBe(svg);
+		}
 	});
 });
 

--- a/tests/unit/mermaid.test.ts
+++ b/tests/unit/mermaid.test.ts
@@ -4,7 +4,13 @@
  */
 import { describe, expect, it } from "vitest";
 import { createElement, type ReactNode } from "react";
-import { childrenText, isMermaidLanguage, singleCodeChild } from "../../web/src/components/mermaid.js";
+import {
+	childrenText,
+	isMermaidLanguage,
+	preserveMermaidSvgWidth,
+	routePreToMermaid,
+	singleCodeChild,
+} from "../../web/src/components/mermaid.js";
 
 /** Simulate the <code> element react-markdown hands PreWithCopy's children. */
 function code(className: string | undefined, children: ReactNode) {
@@ -38,6 +44,39 @@ describe("singleCodeChild", () => {
 	it("非元素 children 返回 null", () => {
 		expect(singleCodeChild("text")).toBe(null);
 		expect(singleCodeChild(null)).toBe(null);
+	});
+});
+
+describe("preserveMermaidSvgWidth", () => {
+	it("保留小图自然宽度而不是拉伸到容器宽度", () => {
+		const svg = '<svg width="100%" style="max-width: 124px;" viewBox="0 0 124 174"></svg>';
+		const result = preserveMermaidSvgWidth(svg);
+		expect(result).toContain('width="124"');
+		expect(result).toContain('style="max-width:none"');
+		expect(result).not.toContain('width="100%"');
+	});
+
+	it("宽图使用 viewBox 像素宽度，使容器产生横向滚动", () => {
+		const svg =
+			'<svg width="100%" style="font-family: monospace; max-width: 2358.8125px;" viewBox="0 0 2358.8125 70"></svg>';
+		const result = preserveMermaidSvgWidth(svg);
+		expect(result).toContain('width="2358.8125"');
+		expect(result).toContain("font-family: monospace");
+		expect(result).toContain("max-width:none");
+	});
+
+	it("没有有效 viewBox 时保持 SVG 不变", () => {
+		const svg = '<svg width="100%"></svg>';
+		expect(preserveMermaidSvgWidth(svg)).toBe(svg);
+		expect(preserveMermaidSvgWidth("not svg")).toBe("not svg");
+	});
+});
+
+describe("routePreToMermaid", () => {
+	it("仅将严格匹配的 mermaid code 路由到图表组件", () => {
+		expect(routePreToMermaid([code("language-mermaid", "flowchart LR")])).toBe(true);
+		expect(routePreToMermaid([code("language-mermaid2", "source")])).toBe(false);
+		expect(routePreToMermaid(code("language-js", "source"))).toBe(false);
 	});
 });
 

--- a/tests/unit/mermaid.test.ts
+++ b/tests/unit/mermaid.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Mermaid fence detection unit tests — the pure helpers behind MermaidBlock's
+ * interception in PreWithCopy (see web/src/components/mermaid.ts).
+ */
+import { describe, expect, it } from "vitest";
+import { createElement, type ReactNode } from "react";
+import { childrenText, isMermaidLanguage, singleCodeChild } from "../../web/src/components/mermaid.js";
+
+/** Simulate the <code> element react-markdown hands PreWithCopy's children. */
+function code(className: string | undefined, children: ReactNode) {
+	return createElement("code", { className }, children);
+}
+
+describe("isMermaidLanguage", () => {
+	it("匹配 language-mermaid 单独 token", () => {
+		expect(isMermaidLanguage("language-mermaid")).toBe(true);
+	});
+
+	it("匹配多 class 中的 language-mermaid token", () => {
+		expect(isMermaidLanguage("hljs language-mermaid")).toBe(true);
+	});
+
+	it("不误匹配 language-mermaid2 / 子串", () => {
+		expect(isMermaidLanguage("language-mermaid2")).toBe(false);
+		expect(isMermaidLanguage("xlanguage-mermaid")).toBe(false);
+		expect(isMermaidLanguage("language-js")).toBe(false);
+		expect(isMermaidLanguage(undefined)).toBe(false);
+	});
+});
+
+describe("singleCodeChild", () => {
+	it("直接 code 元素与数组包装都能取到", () => {
+		const el = code("language-mermaid", "graph TD; a-->b;");
+		expect(singleCodeChild(el)).toBe(el);
+		expect(singleCodeChild([el])).toBe(el);
+	});
+
+	it("非元素 children 返回 null", () => {
+		expect(singleCodeChild("text")).toBe(null);
+		expect(singleCodeChild(null)).toBe(null);
+	});
+});
+
+describe("childrenText", () => {
+	it("展平 react-markdown children 为原始源码", () => {
+		const el = code("language-mermaid", [
+			"flowchart LR\n",
+			createElement("span", { key: "1" }, "    A[Start] --> B[Done]"),
+		]);
+		expect(childrenText([el])).toBe("flowchart LR\n    A[Start] --> B[Done]");
+		expect(childrenText("plain")).toBe("plain");
+	});
+});

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { CopyButton } from "./copy-button";
 import { splitCodeLines } from "../code-lines";
+import { MermaidBlock, mermaidCodeFromPre } from "./MermaidBlock";
 
 interface MarkdownProps {
 	text: string;
@@ -35,6 +36,9 @@ export const Markdown = memo(function Markdown({ text }: MarkdownProps) {
 });
 
 function PreWithCopy({ children, ...props }: JSX.IntrinsicElements["pre"]) {
+	// ```mermaid fences render as SVG diagrams instead of highlighted code.
+	const mermaidCode = mermaidCodeFromPre(children);
+	if (mermaidCode !== null) return <MermaidBlock code={mermaidCode} />;
 	// react-markdown 传进来的是 <pre><code …>…</code></pre> 里的 code 元素；
 	// 按逻辑行切分的是它内部的 span/文本 children，而不是 code 元素本身
 	// （否则每行会嵌套一个克隆的 <code>，且尾随空行无法被丢弃）。

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -6,6 +6,7 @@ import rehypeHighlight from "rehype-highlight";
 import { CopyButton } from "./copy-button";
 import { splitCodeLines } from "../code-lines";
 import { MermaidBlock, mermaidCodeFromPre } from "./MermaidBlock";
+import { routePreToMermaid } from "./mermaid";
 
 interface MarkdownProps {
 	text: string;
@@ -37,8 +38,7 @@ export const Markdown = memo(function Markdown({ text }: MarkdownProps) {
 
 function PreWithCopy({ children, ...props }: JSX.IntrinsicElements["pre"]) {
 	// ```mermaid fences render as SVG diagrams instead of highlighted code.
-	const mermaidCode = mermaidCodeFromPre(children);
-	if (mermaidCode !== null) return <MermaidBlock code={mermaidCode} />;
+	if (routePreToMermaid(children)) return <MermaidBlock code={mermaidCodeFromPre(children)!} />;
 	// react-markdown 传进来的是 <pre><code …>…</code></pre> 里的 code 元素；
 	// 按逻辑行切分的是它内部的 span/文本 children，而不是 code 元素本身
 	// （否则每行会嵌套一个克隆的 <code>，且尾随空行无法被丢弃）。

--- a/web/src/components/MermaidBlock.tsx
+++ b/web/src/components/MermaidBlock.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useId, useState } from "react";
 import { useT } from "../i18n";
 import { CopyButton } from "./copy-button";
-import { childrenText, routePreToMermaid, singleCodeChild } from "./mermaid";
+import { childrenText, preserveMermaidSvgWidth, routePreToMermaid } from "./mermaid";
 
 /** Lazily-loaded, memoized mermaid module — most chats never hit a mermaid
  *  fence, so this stays out of the main bundle until one actually renders. */
@@ -53,11 +53,9 @@ export function MermaidBlock({ code }: { code: string }) {
 		setSvg(null);
 		setError(null);
 		const renderId = `mermaid-${reactId}-${++renderSeq}`;
-		// Render through an offscreen container we own: mermaid sizes its root <svg>
-		// to the container width when one is supplied (it stays natural-size when
-		// rendering into body), and it removes the container itself once serialized —
-		// on parse/draw failures too, so nothing accumulates. Cancelled mid-flight
-		// renders are the only leftovers; cleaned in the catch below.
+		// Render in an offscreen holder we own. Passing it prevents Mermaid from
+		// attaching temporary render nodes directly to body; this component is
+		// responsible for removing the holder on success, failure, and unmount.
 		const holder = document.createElement("div");
 		holder.style.position = "absolute";
 		holder.style.left = "-99999px";
@@ -73,7 +71,7 @@ export function MermaidBlock({ code }: { code: string }) {
 			.then((mermaid) => mermaid.render(renderId, code, holder))
 			.then(({ svg }) => {
 				cleanup();
-				if (!cancelled) setSvg(svg);
+				if (!cancelled) setSvg(preserveMermaidSvgWidth(svg));
 			})
 			.catch((err: unknown) => {
 				cleanup();
@@ -121,7 +119,6 @@ export function MermaidBlock({ code }: { code: string }) {
 /** Helper for PreWithCopy: the fence's raw source when this <pre> wraps a
  *  single mermaid <code> element, else null (normal codeblock chrome applies). */
 export function mermaidCodeFromPre(children: unknown): string | null {
-	const code = singleCodeChild(children);
-	if (!code || !routePreToMermaid(children)) return null;
+	if (!routePreToMermaid(children)) return null;
 	return childrenText(children);
 }

--- a/web/src/components/MermaidBlock.tsx
+++ b/web/src/components/MermaidBlock.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { useT } from "../i18n";
 import { CopyButton } from "./copy-button";
-import { childrenText, isMermaidLanguage, singleCodeChild } from "./mermaid";
+import { childrenText, routePreToMermaid, singleCodeChild } from "./mermaid";
 
 /** Lazily-loaded, memoized mermaid module — most chats never hit a mermaid
  *  fence, so this stays out of the main bundle until one actually renders. */
@@ -47,28 +47,42 @@ export function MermaidBlock({ code }: { code: string }) {
 	const reactId = useId().replace(/[^a-zA-Z0-9]/g, "");
 	const [svg, setSvg] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
-	const containerRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		let cancelled = false;
 		setSvg(null);
 		setError(null);
 		const renderId = `mermaid-${reactId}-${++renderSeq}`;
+		// Render through an offscreen container we own: mermaid sizes its root <svg>
+		// to the container width when one is supplied (it stays natural-size when
+		// rendering into body), and it removes the container itself once serialized —
+		// on parse/draw failures too, so nothing accumulates. Cancelled mid-flight
+		// renders are the only leftovers; cleaned in the catch below.
+		const holder = document.createElement("div");
+		holder.style.position = "absolute";
+		holder.style.left = "-99999px";
+		holder.style.width = "1000px";
+		holder.dataset.mermaidRender = renderId;
+		document.body.appendChild(holder);
+		const cleanup = () => document.querySelector(`[data-mermaid-render="${renderId}"]`)?.remove();
 		loadMermaid()
-			.then((mermaid) => mermaid.render(renderId, code))
+			// Render into mermaid's offscreen temp container (no svgContainingElement
+			// — the documented path). Mermaid's own render() removes that container on
+			// success and on parse/draw failures, but NOT when the result lands after
+			// this component unmounted (cancelled below) — the catch cleans then.
+			.then((mermaid) => mermaid.render(renderId, code, holder))
 			.then(({ svg }) => {
+				cleanup();
 				if (!cancelled) setSvg(svg);
 			})
 			.catch((err: unknown) => {
+				cleanup();
 				if (cancelled) return;
 				setError(err instanceof Error ? err.message : String(err));
-				// mermaid's error path leaves its offscreen render target in the DOM
-				// (the raw id, or its "d"-prefixed fallback container). Nothing in
-				// our tree references it, but clean both up so they can't accumulate.
-				for (const id of [renderId, `d${renderId}`]) document.getElementById(id)?.remove();
 			});
 		return () => {
 			cancelled = true;
+			cleanup();
 		};
 	}, [code, reactId]);
 
@@ -99,7 +113,7 @@ export function MermaidBlock({ code }: { code: string }) {
 			<CopyButton text={code} />
 			{/* mermaid.render() output is markup we generated locally from plain-text
 			    source (securityLevel: "strict" sanitizes shapes/labels). */}
-			<div ref={containerRef} className="mermaid-svg" dangerouslySetInnerHTML={{ __html: svg }} />
+			<div className="mermaid-svg" dangerouslySetInnerHTML={{ __html: svg }} />
 		</div>
 	);
 }
@@ -108,6 +122,6 @@ export function MermaidBlock({ code }: { code: string }) {
  *  single mermaid <code> element, else null (normal codeblock chrome applies). */
 export function mermaidCodeFromPre(children: unknown): string | null {
 	const code = singleCodeChild(children);
-	if (!code || !isMermaidLanguage(code.props?.className)) return null;
+	if (!code || !routePreToMermaid(children)) return null;
 	return childrenText(children);
 }

--- a/web/src/components/MermaidBlock.tsx
+++ b/web/src/components/MermaidBlock.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { useT } from "../i18n";
+import { CopyButton } from "./copy-button";
+import { childrenText, isMermaidLanguage, singleCodeChild } from "./mermaid";
+
+/** Lazily-loaded, memoized mermaid module — most chats never hit a mermaid
+ *  fence, so this stays out of the main bundle until one actually renders. */
+let mermaidPromise: Promise<(typeof import("mermaid"))["default"]> | null = null;
+function loadMermaid() {
+	if (!mermaidPromise) {
+		mermaidPromise = import("mermaid").then((mod) => {
+			const mermaid = mod.default;
+			mermaid.initialize({
+				startOnLoad: false,
+				securityLevel: "strict",
+				// Diagrams render on their own light "paper" card (.mermaid-block in
+				// styles.css) under both app themes, so mermaid always uses its light
+				// base theme with explicit variables rather than tracking the app chrome.
+				theme: "base",
+				themeVariables: {
+					background: "#ffffff",
+					primaryColor: "#f1edfe",
+					primaryTextColor: "#1f2430",
+					primaryBorderColor: "#8b5cf6",
+					lineColor: "#6b7280",
+					secondaryColor: "#eef2ff",
+					tertiaryColor: "#f8fafc",
+					textColor: "#1f2430",
+					fontFamily: "var(--mono, monospace)",
+				},
+			});
+			return mermaid;
+		});
+	}
+	return mermaidPromise;
+}
+
+/** Module-level counter so render IDs stay unique across React instances too
+ *  (useId alone can repeat across Suspense boundaries / strict-mode remounts). */
+let renderSeq = 0;
+
+/** Renders a ```mermaid fenced block as an SVG diagram (flowcharts, sequence
+ *  diagrams, etc.). Falls back to the raw source in a normal codeblock when
+ *  mermaid can't parse it, so a typo never blanks out the message. */
+export function MermaidBlock({ code }: { code: string }) {
+	const t = useT();
+	const reactId = useId().replace(/[^a-zA-Z0-9]/g, "");
+	const [svg, setSvg] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		setSvg(null);
+		setError(null);
+		const renderId = `mermaid-${reactId}-${++renderSeq}`;
+		loadMermaid()
+			.then((mermaid) => mermaid.render(renderId, code))
+			.then(({ svg }) => {
+				if (!cancelled) setSvg(svg);
+			})
+			.catch((err: unknown) => {
+				if (cancelled) return;
+				setError(err instanceof Error ? err.message : String(err));
+				// mermaid's error path leaves its offscreen render target in the DOM
+				// (the raw id, or its "d"-prefixed fallback container). Nothing in
+				// our tree references it, but clean both up so they can't accumulate.
+				for (const id of [renderId, `d${renderId}`]) document.getElementById(id)?.remove();
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [code, reactId]);
+
+	if (error) {
+		return (
+			<div className="mermaid-block mermaid-block-error">
+				<div className="mermaid-note">{t("mermaidRenderFailed")}</div>
+				<div className="codeblock">
+					<CopyButton text={code} />
+					<pre>
+						<code>{code}</code>
+					</pre>
+				</div>
+			</div>
+		);
+	}
+
+	if (!svg) {
+		return (
+			<div className="mermaid-block mermaid-block-loading">
+				<div className="mermaid-note">{t("mermaidRendering")}</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="mermaid-block">
+			<CopyButton text={code} />
+			{/* mermaid.render() output is markup we generated locally from plain-text
+			    source (securityLevel: "strict" sanitizes shapes/labels). */}
+			<div ref={containerRef} className="mermaid-svg" dangerouslySetInnerHTML={{ __html: svg }} />
+		</div>
+	);
+}
+
+/** Helper for PreWithCopy: the fence's raw source when this <pre> wraps a
+ *  single mermaid <code> element, else null (normal codeblock chrome applies). */
+export function mermaidCodeFromPre(children: unknown): string | null {
+	const code = singleCodeChild(children);
+	if (!code || !isMermaidLanguage(code.props?.className)) return null;
+	return childrenText(children);
+}

--- a/web/src/components/StreamMarkdown.tsx
+++ b/web/src/components/StreamMarkdown.tsx
@@ -1,7 +1,6 @@
 import { memo, useEffect, useMemo, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
 import { segmentStream } from "../stream-markdown";
-import { MarkdownBody, rehypePlugins, remarkPlugins } from "./Markdown";
+import { MarkdownBody } from "./Markdown";
 
 /**
  * Prefix-cached streaming markdown renderer (see stream-markdown.ts for the
@@ -25,11 +24,9 @@ import { MarkdownBody, rehypePlugins, remarkPlugins } from "./Markdown";
 
 /** One frozen segment: immutable input → parses exactly once thanks to memo. */
 const FrozenSegment = memo(function FrozenSegment({ text }: { text: string }) {
-	return (
-		<ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
-			{text}
-		</ReactMarkdown>
-	);
+	// Must go through MarkdownBody — the shared pipeline config (codeblock chrome +
+	// mermaid interception). A bare <ReactMarkdown> here silently skipped mermaid.
+	return <MarkdownBody text={text} />;
 });
 
 const TAIL_INTERVAL_MS = 200;

--- a/web/src/components/mermaid.ts
+++ b/web/src/components/mermaid.ts
@@ -31,6 +31,31 @@ export function singleCodeChild(children: unknown): { props?: { className?: unkn
 	return child as { props?: { className?: unknown } };
 }
 
+/** Give Mermaid's root SVG an intrinsic pixel width from its viewBox.
+ * Mermaid emits width="100%" plus max-width for small charts; for wide charts
+ * that makes mobile browsers squeeze the entire diagram until labels are
+ * unreadable. A concrete width preserves both cases: small charts stay at
+ * their natural size and wide charts overflow their scroll container. */
+export function preserveMermaidSvgWidth(svg: string): string {
+	const match = svg.match(/<svg\b([^>]*)>/i);
+	if (!match) return svg;
+	const attrs = match[1];
+	const viewBox = attrs.match(/\bviewBox=(['"])([^'"]+)\1/i)?.[2];
+	if (!viewBox) return svg;
+	const values = viewBox
+		.trim()
+		.split(/[\s,]+/)
+		.map(Number);
+	const width = values.length === 4 ? values[2] : Number.NaN;
+	if (!Number.isFinite(width) || width <= 0) return svg;
+
+	const existingStyle = attrs.match(/\sstyle=(['"])(.*?)\1/i)?.[2] ?? "";
+	const cleanStyle = existingStyle.replace(/(?:^|;)\s*(?:max-)?width\s*:[^;]*/gi, "").replace(/^\s*;|;\s*$/g, "");
+	const sizedAttrs = attrs.replace(/\swidth=(['"])[^'"]*\1/i, "").replace(/\sstyle=(['"])(.*?)\1/i, "");
+	const style = cleanStyle ? `${cleanStyle}; max-width:none` : "max-width:none";
+	return svg.replace(match[0], `<svg${sizedAttrs} width="${width}" style="${style}">`);
+}
+
 /** The `components={{ pre: ... }}` decision: does this pre's children hold a
  *  mermaid-tagged code element? Pure so tests can assert routing without React. */
 export function routePreToMermaid(children: unknown): boolean {

--- a/web/src/components/mermaid.ts
+++ b/web/src/components/mermaid.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure helpers for ```mermaid fenced-code detection — kept free of React so
+ * they're unit-testable (tests/unit/mermaid.test.ts) and importable from
+ * MermaidBlock.tsx without pulling DOM/React into the test graph.
+ */
+
+/** True only when a code element's className token list contains exactly
+ *  `language-mermaid` (react-markdown/rehype-highlight emits language-* classes).
+ *  Deliberately NOT a substring match: `language-mermaid2` must not match. */
+export function isMermaidLanguage(className: unknown): boolean {
+	return typeof className === "string" && /(^|\s)language-mermaid(\s|$)/.test(className);
+}
+
+/** Flatten react-markdown children (string / nested element / array) to text. */
+export function childrenText(children: unknown): string {
+	if (typeof children === "string") return children;
+	if (Array.isArray(children)) return children.map(childrenText).join("");
+	if (children && typeof children === "object" && "props" in children) {
+		const props = (children as { props?: { children?: unknown } }).props;
+		return childrenText(props?.children);
+	}
+	return "";
+}
+
+/** The single `<code>` element react-markdown hands a `<pre>`'s children
+ *  (possibly wrapped in an array), or null when absent. */
+export function singleCodeChild(children: unknown): { props?: { className?: unknown } } | null {
+	const child = Array.isArray(children) ? children[0] : children;
+	if (!child || typeof child !== "object" || !("props" in child)) return null;
+	return child as { props?: { className?: unknown } };
+}

--- a/web/src/components/mermaid.ts
+++ b/web/src/components/mermaid.ts
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 /**
  * Pure helpers for ```mermaid fenced-code detection — kept free of React so
  * they're unit-testable (tests/unit/mermaid.test.ts) and importable from
@@ -28,4 +29,11 @@ export function singleCodeChild(children: unknown): { props?: { className?: unkn
 	const child = Array.isArray(children) ? children[0] : children;
 	if (!child || typeof child !== "object" || !("props" in child)) return null;
 	return child as { props?: { className?: unknown } };
+}
+
+/** The `components={{ pre: ... }}` decision: does this pre's children hold a
+ *  mermaid-tagged code element? Pure so tests can assert routing without React. */
+export function routePreToMermaid(children: unknown): boolean {
+	const code = singleCodeChild(children);
+	return code !== null && isMermaidLanguage(code.props?.className);
 }

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -145,6 +145,8 @@ const zh = {
 	slashCopied: "已复制上一条助手回复",
 	slashCopyFailed: "复制失败，请手动复制",
 	slashCopyEmpty: "还没有可复制的助手回复",
+	mermaidRendering: "图表渲染中…",
+	mermaidRenderFailed: "图表渲染失败，以下为原始代码：",
 
 	/* left panel */
 	recentProjects: "最近项目",
@@ -984,6 +986,8 @@ const en: Record<keyof typeof zh, string> = {
 	slashCopied: "Copied the last assistant reply",
 	slashCopyFailed: "Copy failed — please copy manually",
 	slashCopyEmpty: "No assistant reply to copy yet",
+	mermaidRendering: "Rendering diagram…",
+	mermaidRenderFailed: "Failed to render diagram — raw source below:",
 
 	/* left panel */
 	recentProjects: "Recent projects",

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4522,8 +4522,6 @@ span.msg-editor-hint svg {
 	border: 1px solid var(--border);
 	border-radius: 8px;
 }
-/* Wide diagrams must scroll inside the container rather than blow out the
-   message area; the SVG fits smaller widths naturally. */
 /* Mermaid sizes its root <svg> to the drawn diagram (inline width/height), so
    small diagrams stay small — do NOT force them to the container width. Only
    oversized renders need scrolling. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4511,6 +4511,44 @@ span.msg-editor-hint svg {
 	border-color: var(--accent);
 }
 
+/* Mermaid diagrams: own light "paper" card so charts stay readable under both
+   app themes (mermaid always renders with its light base theme, see
+   web/src/components/MermaidBlock.tsx). */
+.mermaid-block {
+	position: relative;
+	margin: 10px 0;
+	padding: 12px;
+	background: #ffffff;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+}
+/* Wide diagrams must scroll inside the container rather than blow out the
+   message area; the SVG fits smaller widths naturally. */
+.mermaid-svg {
+	overflow-x: auto;
+}
+.mermaid-svg svg {
+	max-width: 100% !important;
+	height: auto !important;
+	display: block;
+	margin: 0 auto;
+}
+.mermaid-note {
+	font-size: 12px;
+	color: var(--text-faint);
+	font-style: italic;
+	padding: 2px 34px 2px 0;
+}
+.mermaid-block-loading {
+	min-height: 34px;
+}
+.mermaid-block-error .codeblock {
+	margin: 6px 0 0;
+}
+.mermaid-block:hover .copy-btn {
+	opacity: 1;
+}
+
 .trunc-note {
 	margin-top: 6px;
 	font-size: 11.5px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4524,12 +4524,13 @@ span.msg-editor-hint svg {
 }
 /* Wide diagrams must scroll inside the container rather than blow out the
    message area; the SVG fits smaller widths naturally. */
+/* Mermaid sizes its root <svg> to the drawn diagram (inline width/height), so
+   small diagrams stay small — do NOT force them to the container width. Only
+   oversized renders need scrolling. */
 .mermaid-svg {
 	overflow-x: auto;
 }
 .mermaid-svg svg {
-	max-width: 100% !important;
-	height: auto !important;
 	display: block;
 	margin: 0 auto;
 }


### PR DESCRIPTION
## Summary

Render fenced `mermaid` code blocks as diagrams directly in chat messages.

This supersedes #25 and includes only the Mermaid rendering functionality. It does not include the unrelated Markdown file preview, slash-command matching, cursor animation, or other UI changes from that PR.

## Changes

- Add a standalone `MermaidBlock` component.
- Detect Mermaid fences using an exact `language-mermaid` class token match.
- Support the array-wrapped children passed by `react-markdown`.
- Lazy-load Mermaid through a cached dynamic `import("mermaid")`.
- Configure Mermaid with `startOnLoad: false` and `securityLevel: "strict"`.
- Generate collision-resistant render IDs using React `useId()` and a module-level sequence.
- Render completed Mermaid blocks consistently in both regular and streaming Markdown.
- Keep unclosed streaming fences as raw source until the fence is complete.
- Fall back to the original code block, including its copy button, when parsing fails.
- Add localized rendering and failure messages in English and Chinese.
- Use a stable light chart canvas so diagrams remain readable in both application themes.
- Preserve the natural size of small diagrams.
- Preserve the readable intrinsic width of wide diagrams and expose horizontal scrolling instead of shrinking labels to an unreadable size.
- Clean temporary Mermaid DOM nodes after success, failure, cancellation, and unmount.

## Implementation Notes

Mermaid is loaded locally from the application dependency and is not fetched from a CDN or external service. Because loading uses a dynamic import, Mermaid and its diagram modules stay outside the initial application bundle and are downloaded only when the first Mermaid block is rendered.

Detection deliberately uses the strict expression:

```ts
/(^|\s)language-mermaid(\s|$)/
```

Classes such as `language-mermaid2` and `xlanguage-mermaid` therefore continue to render as normal code blocks.

The generated SVG width is derived from its `viewBox`. This keeps small diagrams at their natural dimensions while allowing very wide diagrams to retain readable labels inside a horizontally scrollable container.

## Failure Behavior

Invalid Mermaid syntax displays a localized error notice and falls back to the raw source code. The existing copy behavior remains available.

Temporary rendering containers are owned and removed by `MermaidBlock`, including when a render is cancelled or the component is unmounted while Mermaid is still loading.

## Tests

Added regression coverage for:

- Exact Mermaid language detection
- False-positive language classes
- Array-wrapped `react-markdown` children
- Nested child text extraction
- Mermaid pre-element routing
- Small SVG intrinsic sizing
- Wide SVG intrinsic sizing
- Invalid or missing SVG `viewBox` values

Browser verification covered:

- Lazy Mermaid chunk loading
- No CDN or external requests
- Multiple diagrams with unique render IDs
- Streaming frozen-segment rendering
- Invalid-syntax fallback and copy button
- Cancellation and unmount cleanup
- No orphan Mermaid DOM nodes
- Light and dark application themes
- Desktop and mobile layouts
- Small diagrams remaining at natural size
- Wide diagrams retaining readable width with horizontal scrolling

## Verification

- TypeScript type check passed
- Protocol consistency check passed
- Prettier check passed
- Production build passed
- Unit tests: 321 passed
- Browser regression checks passed

Lint reports only three pre-existing unused-variable warnings in unrelated files.