### PR TITLE
feat(subagent): parent-linked tree with retention and clean rpc bind / 子代理父子链接树、保留与干净绑定

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -59,7 +59,7 @@ import {
 	TERMINAL_TOOLS_GUIDANCE,
 	TERMINAL_TOOL_NAMES,
 } from "./terminals.js";
-import { WebUIContext } from "./webui-context.js";
+import { WebUIContext, mockThemeProxy } from "./webui-context.js";
 import {
 	makeSubagentTools,
 	subagentTitle,
@@ -411,6 +411,8 @@ interface Conversation {
 	title: string;
 	/** 这是子代理对话（左栏带「子代理」徽标；inMemory session，不进历史/resume）。 */
 	isSubagent: boolean;
+	/** 派发它的父对话 id（Running 面板嵌套用；顶层子代理为空）。 */
+	parentId?: string;
 	/** 子代理类型/角色展示名（explore/implement/review…）。 */
 	subagentType?: string;
 	/** 子代理最近一次运行报错的文本（快照 error 字段的只读缓存位），消息内容不变 /
@@ -806,14 +808,24 @@ export class ClientSession {
 		});
 		const conv = this.makeConversation(runtime, conversationId, terminals);
 		conv.isSubagent = true;
+		// 派发时刻的 active 即父对话（子代理也可再派发，自然嵌套）。
+		conv.parentId = this.activeId || undefined;
 		conv.subagentType = type;
 		conv.listed = true;
 		conv.title = subagentTitle(prompt);
 		this.convs.set(conv.id, conv);
-		// 扩展绑定（rpc 模式；不给 uiContext，避免与主对话的 widget 冲突）。
+		// 扩展绑定（rpc 模式；uiContext 只给无害的 mock theme/status 槽，避免与主对话
+		// 的 widget 冲突。无 uiContext 时扩展的 ctx.ui.theme.fg 会打到 TUI 真 theme
+		// 代理上抛 "Theme not initialized"，每个扩展一条 error toast。）
 		try {
 			await conv.session.bindExtensions({
 				mode: "rpc",
+				uiContext: {
+					theme: mockThemeProxy,
+					setStatus: () => {},
+					setWidget: () => {},
+					notify: () => {},
+				} as never,
 				onError: (err) => this.emit({ type: "notice", level: "error", text: err.error, textEn: err.error }),
 			});
 		} catch {
@@ -3165,16 +3177,22 @@ export class ClientSession {
 		// Retain while the session has active (queued/running) pi-subagents async
 		// runs on disk — the extension host would otherwise be torn down and its
 		// workflow controllers aborted mid-flight.
-		const retained = shouldRetainActive({
-			reviewing: conv.goal.reviewing,
-			wizardRunning: conv.wizardRunning,
-			streaming: conv.session.isStreaming,
-			openTerminals: conv.terminals.list().length,
-			listed: conv.listed,
-			promptedSinceActive: conv.promptedSinceActive,
-			hasActiveSubagentRun: () => hasActiveSubagentRun({ sessionId: conv.session.sessionFile }),
-			hasPendingWake: () => hasPendingWaitSubscription({ sessionId: conv.session.sessionFile }),
-		});
+		// Also retain a parent while any live first-party subagent conversation
+		// points at it: dropping an idle in-memory parent orphans the child row
+		// (the child vanishes from Running Chats with no result available).
+		const hasLiveChild = [...this.convs.values()].some((child) => child.parentId === conv.id);
+		const retained =
+			hasLiveChild ||
+			shouldRetainActive({
+				reviewing: conv.goal.reviewing,
+				wizardRunning: conv.wizardRunning,
+				streaming: conv.session.isStreaming,
+				openTerminals: conv.terminals.list().length,
+				listed: conv.listed,
+				promptedSinceActive: conv.promptedSinceActive,
+				hasActiveSubagentRun: () => hasActiveSubagentRun({ sessionId: conv.session.sessionFile }),
+				hasPendingWake: () => hasPendingWaitSubscription({ sessionId: conv.session.sessionFile }),
+			});
 		if (retained) {
 			conv.listed = true;
 			return null;
@@ -3242,9 +3260,16 @@ export class ClientSession {
 	 *  its project (see switchConversation). The client groups the list by cwd. */
 	private emitConversations(): void {
 		const conversations: ConversationSummary[] = [];
+		// Active parents are normally absent from Running. Keep them visible while
+		// listed subagents hang under them, so both rows remain clickable.
+		const visibleParents = new Set(
+			[...this.convs.values()]
+				.filter((conv) => conv.listed)
+				.map((conv) => conv.parentId)
+				.filter(Boolean),
+		);
 		for (const conv of this.convs.values()) {
-			// Only conversations that were displaced to the background while running.
-			if (!conv.listed) continue;
+			if (!conv.listed && !visibleParents.has(conv.id)) continue;
 			let messageCount = 0;
 			let isStreaming = false;
 			try {
@@ -3262,6 +3287,7 @@ export class ClientSession {
 				isSubagent: !!conv.isSubagent,
 				// 子代理带 error 标记：左栏红点提示（普通对话不参与）。
 				...(conv.isSubagent ? this.subagentRunOutcome(conv) : {}),
+				parentId: conv.parentId,
 			});
 		}
 		this.emit({
@@ -3546,16 +3572,20 @@ export class ClientSession {
 			return;
 		}
 		// Streaming / retained conversations refuse dismissal — mirrors displaceActive retention.
-		const retained = shouldRetainActive({
-			reviewing: conv.goal.reviewing,
-			wizardRunning: conv.wizardRunning,
-			streaming: conv.session.isStreaming,
-			openTerminals: conv.terminals.list().length,
-			listed: conv.listed,
-			promptedSinceActive: conv.promptedSinceActive,
-			hasActiveSubagentRun: () => hasActiveSubagentRun({ sessionId: conv.session.sessionFile }),
-			hasPendingWake: () => hasPendingWaitSubscription({ sessionId: conv.session.sessionFile }),
-		});
+		// A parent with live children also refuses: dropping it orphans the child rows.
+		const hasLiveChild = [...this.convs.values()].some((child) => child.parentId === id);
+		const retained =
+			hasLiveChild ||
+			shouldRetainActive({
+				reviewing: conv.goal.reviewing,
+				wizardRunning: conv.wizardRunning,
+				streaming: conv.session.isStreaming,
+				openTerminals: conv.terminals.list().length,
+				listed: conv.listed,
+				promptedSinceActive: conv.promptedSinceActive,
+				hasActiveSubagentRun: () => hasActiveSubagentRun({ sessionId: conv.session.sessionFile }),
+				hasPendingWake: () => hasPendingWaitSubscription({ sessionId: conv.session.sessionFile }),
+			});
 		if (retained) {
 			if (conv.session.isStreaming) {
 				this.emit({
@@ -3570,6 +3600,13 @@ export class ClientSession {
 					level: "warning",
 					text: `对话「${conv.title}」还有未关闭的终端，请先关闭终端后再移出`,
 					textEn: `Conversation "${conv.title}" still has open terminals — close them before removing`,
+				});
+			} else if (hasLiveChild) {
+				this.emit({
+					type: "notice",
+					level: "warning",
+					text: `对话「${conv.title}」还有运行中的子代理，请先移出子代理后再移出`,
+					textEn: `Conversation "${conv.title}" still has running subagents — remove them first`,
 				});
 			} else {
 				this.emit({

--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -824,7 +824,11 @@ export class ClientSession {
 		// 显式搬过来（新 runtime 的默认模型未必等于主对话刚选的模型）。
 		const resolvedModel =
 			model ?? (apply?.model?.trim() || null) ?? (this.settingsSvc.current.subagentDefaultModel || null);
-		const followModel = resolvedModel ? resolvedModel : this.session.model ? `${this.session.model.provider}/${this.session.model.id}` : null;
+		const followModel = resolvedModel
+			? resolvedModel
+			: this.session.model
+				? `${this.session.model.provider}/${this.session.model.id}`
+				: null;
 		if (followModel) {
 			const slash = followModel.indexOf("/");
 			const m =

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -848,6 +848,8 @@ export interface ConversationSummary {
 	error?: string;
 	/** 子代理最近一次运行被中止。 */
 	canceled?: boolean;
+	/** 父对话 id（Running 面板嵌套展示用）。 */
+	parentId?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/settings-service.ts
+++ b/server/settings-service.ts
@@ -282,7 +282,9 @@ export class SettingsService {
 				}
 			}
 			// 稳定排序：provider 名 → 模型名。
-			return out.sort((a, b) => (a.provider === b.provider ? a.label.localeCompare(b.label) : a.provider.localeCompare(b.provider)));
+			return out.sort((a, b) =>
+				a.provider === b.provider ? a.label.localeCompare(b.label) : a.provider.localeCompare(b.provider),
+			);
 		} catch {
 			// Session not ready yet — the picker stays empty until next push.
 			return [];

--- a/server/subagents.ts
+++ b/server/subagents.ts
@@ -126,7 +126,7 @@ export function makeSubagentTools(host: SubagentToolHost): ToolDefinition[] {
 				"subagent_steer 中途改向、subagent_stop 停止。" +
 				"适合：长耗时探索、并行调研、独立子任务委派。可选 template 参数：使用设置面板配置的子代理模板" +
 				"（角色系统提示词 + 技能/扩展白名单 + 可选模型）；可选 model 参数：显式指定子代理模型（provider/id 格式，" +
-				"如 \"anthropic/claude-opus-4-5\"），优先级高于模板与设置面板的默认模型；都不传 = 跟随主对话当前模型。",
+				'如 "anthropic/claude-opus-4-5"），优先级高于模板与设置面板的默认模型；都不传 = 跟随主对话当前模型。',
 			promptSnippet: "spawn an independent background subagent for a deliverable task (parallel work)",
 			parameters: Type.Object({
 				prompt: Type.String({ description: "交给子代理的完整指令（要达成的目标 + 约束 + 期望产出）。" }),
@@ -143,7 +143,7 @@ export function makeSubagentTools(host: SubagentToolHost): ToolDefinition[] {
 				model: Type.Optional(
 					Type.String({
 						description:
-							"可选：子代理模型 \"provider/id\"（如 \"anthropic/claude-opus-4-5\"），显式指定本次子代理的模型，" +
+							'可选：子代理模型 "provider/id"（如 "anthropic/claude-opus-4-5"），显式指定本次子代理的模型，' +
 							"优先级高于模板自带模型与设置面板默认模型；不传 = 模板模型 → 设置面板默认模型 → 跟随主对话当前模型。",
 					}),
 				),
@@ -168,7 +168,8 @@ export function makeSubagentTools(host: SubagentToolHost): ToolDefinition[] {
 		defineTool({
 			name: "subagent_get_result",
 			label: "Get subagent result",
-			description: "取一个子代理的结果或当前运行态。若尚未完成，返回当前状态与已产出的文本；运行报错（如 provider 400）会在这里明确标出错误。",
+			description:
+				"取一个子代理的结果或当前运行态。若尚未完成，返回当前状态与已产出的文本；运行报错（如 provider 400）会在这里明确标出错误。",
 			promptSnippet: "fetch a subagent's result / current progress",
 			parameters: Type.Object({
 				runId: Type.String({ description: "subagent_spawn 返回的 convId。左栏点击同名对话可直接查看。" }),
@@ -240,7 +241,9 @@ export function makeSubagentTools(host: SubagentToolHost): ToolDefinition[] {
 			promptSnippet: "wait for multiple subagents to finish (no polling) and get all results",
 			parameters: Type.Object({
 				runIds: Type.Optional(
-					Type.Array(Type.String({ description: "要等待的子代理 convId（subagent_spawn 返回值）。缺省 = 等当前全部运行中的。" })),
+					Type.Array(
+						Type.String({ description: "要等待的子代理 convId（subagent_spawn 返回值）。缺省 = 等当前全部运行中的。" }),
+					),
 				),
 				timeoutSeconds: Type.Optional(
 					Type.Integer({

--- a/server/webui-context.ts
+++ b/server/webui-context.ts
@@ -21,7 +21,7 @@ export function stripAnsi(s: string): string {
 }
 
 /** Mock theme: TUI color functions degrade to identity so widget text survives. */
-const mockTheme = new Proxy(
+export const mockThemeProxy = new Proxy(
 	{
 		fg: (_color: string, text: string) => text,
 		bold: (text: string) => text,
@@ -64,7 +64,7 @@ interface WidgetEntry {
  * footer) are inert: dialogs resolve to cancellation instead of blocking.
  */
 export class WebUIContext {
-	readonly theme = mockTheme;
+	readonly theme = mockThemeProxy;
 	private widgets = new Map<string, WidgetEntry>();
 	private lastLines = new Map<string, string[]>();
 	private emit: (msg: ServerMessage) => void;
@@ -89,7 +89,7 @@ export class WebUIContext {
 			try {
 				// Mock TUI/theme: extensions only read a handful of theme helpers;
 				// everything else is a no-op, so the widget renders to plain text.
-				comp = content(mockTui as never, mockTheme as never) as typeof comp;
+				comp = content(mockTui as never, mockThemeProxy as never) as typeof comp;
 			} catch {
 				comp = undefined;
 			}

--- a/tests/subagent-template-test.mjs
+++ b/tests/subagent-template-test.mjs
@@ -214,11 +214,7 @@ async function main() {
 		check("subagentModels 字段存在（零模型环境为空数组）", Array.isArray(s0.settings.subagentModels));
 		// 设置一个显式默认模型（wire 只校验透传，不校验存在性）。
 		c.send({ type: "set_settings", subagentDefaultModel: "dashscope/qwen-max" });
-		const s1 = await c.waitFor(
-			"settings_state",
-			8000,
-			(m) => m.settings.subagentDefaultModel === "dashscope/qwen-max",
-		);
+		const s1 = await c.waitFor("settings_state", 8000, (m) => m.settings.subagentDefaultModel === "dashscope/qwen-max");
 		check("set_settings 更新 subagentDefaultModel", s1.settings.subagentDefaultModel === "dashscope/qwen-max");
 		// 再切回跟随主对话（null）。
 		c.send({ type: "set_settings", subagentDefaultModel: null });

--- a/tests/unit/subagents.test.ts
+++ b/tests/unit/subagents.test.ts
@@ -46,7 +46,13 @@ describe("subagents tools", () => {
 			undefined,
 			ctx as never,
 		);
-		expect(host.spawnSubagent).toHaveBeenCalledWith("调研", "explore", "/other", "reviewer", "anthropic/claude-opus-4-5");
+		expect(host.spawnSubagent).toHaveBeenCalledWith(
+			"调研",
+			"explore",
+			"/other",
+			"reviewer",
+			"anthropic/claude-opus-4-5",
+		);
 		// 结果文本含 convId（host 返回值）与类型。
 		const text = result.content?.[0] as { text: string };
 		expect(text.text).toContain("sa-explore-abc");
@@ -199,23 +205,53 @@ describe("subagents tools", () => {
 	it("subagent_wait_all 空 runIds 时等当前全部运行中的子代理", async () => {
 		const host = makeHostSpies();
 		(host.listSubagents as ReturnType<typeof vi.fn>).mockReturnValue([
-			{ convId: "sa-a", type: "general", title: "A", prompt: "", state: "running", streaming: true, messageCount: 1, output: "" },
-			{ convId: "sa-b", type: "general", title: "B", prompt: "", state: "running", streaming: true, messageCount: 1, output: "" },
+			{
+				convId: "sa-a",
+				type: "general",
+				title: "A",
+				prompt: "",
+				state: "running",
+				streaming: true,
+				messageCount: 1,
+				output: "",
+			},
+			{
+				convId: "sa-b",
+				type: "general",
+				title: "B",
+				prompt: "",
+				state: "running",
+				streaming: true,
+				messageCount: 1,
+				output: "",
+			},
 		]);
 		(host.getSubagent as ReturnType<typeof vi.fn>).mockImplementation((id: string) =>
 			id === "sa-a"
-				? { convId: "sa-a", type: "general", title: "A", prompt: "", state: "done", streaming: false, messageCount: 2, output: "OK A" }
-				: { convId: "sa-b", type: "general", title: "B", prompt: "", state: "running", streaming: true, messageCount: 1, output: "" },
+				? {
+						convId: "sa-a",
+						type: "general",
+						title: "A",
+						prompt: "",
+						state: "done",
+						streaming: false,
+						messageCount: 2,
+						output: "OK A",
+					}
+				: {
+						convId: "sa-b",
+						type: "general",
+						title: "B",
+						prompt: "",
+						state: "running",
+						streaming: true,
+						messageCount: 1,
+						output: "",
+					},
 		);
 		const tools = makeSubagentTools(host);
 		const waitTool = tools.find((t) => t.name === "subagent_wait_all")!;
-		const result = await waitTool.execute!(
-			"t1",
-			{ timeoutSeconds: 1 } as never,
-			undefined,
-			undefined,
-			{} as never,
-		);
+		const result = await waitTool.execute!("t1", { timeoutSeconds: 1 } as never, undefined, undefined, {} as never);
 		const text = result.content?.[0] as { text: string };
 		// sa-b 一直运行 → 超时返回未完成名单
 		expect(text.text).toContain("1 个仍在运行");

--- a/tests/unit/subagents.test.ts
+++ b/tests/unit/subagents.test.ts
@@ -266,3 +266,17 @@ describe("subagentTitle", () => {
 		expect(subagentTitle("x".repeat(80))).toHaveLength(41);
 	});
 });
+
+describe("subagent parent retention", () => {
+	it("有存活子代理指向父对话时保留父对话", () => {
+		type Conv = { id: string; parentId?: string };
+		const convs = new Map<string, Conv>([
+			["c1", { id: "c1" }],
+			["sa-1", { id: "sa-1", parentId: "c1" }],
+		]);
+		const hasLiveChild = (id: string) => [...convs.values()].some((child) => child.parentId === id);
+		expect(hasLiveChild("c1")).toBe(true);
+		convs.delete("sa-1");
+		expect(hasLiveChild("c1")).toBe(false);
+	});
+});

--- a/web/src/components/LeftPanel.tsx
+++ b/web/src/components/LeftPanel.tsx
@@ -73,11 +73,14 @@ interface ConvGroup {
  *  disambiguate same-titled chats across projects and shows where each
  *  background run lives. */
 function groupConversations(list: ConversationSummary[], currentCwd: string): ConvGroup[] {
+	const byId = new Map(list.map((c) => [c.id, c]));
 	const byCwd = new Map<string, ConversationSummary[]>();
 	for (const c of list) {
-		const arr = byCwd.get(c.cwd) ?? [];
+		// A child with an overridden cwd still belongs under its parent's project.
+		const groupCwd = c.parentId ? (byId.get(c.parentId)?.cwd ?? c.cwd) : c.cwd;
+		const arr = byCwd.get(groupCwd) ?? [];
 		arr.push(c);
-		byCwd.set(c.cwd, arr);
+		byCwd.set(groupCwd, arr);
 	}
 	const groups: ConvGroup[] = [...byCwd.entries()].map(([cwd, convs]) => ({
 		cwd,
@@ -348,93 +351,119 @@ export const LeftPanel = memo(function LeftPanel({
 											{projectName(g.cwd)}
 										</div>
 									)}
-									{g.convs.map((c) => {
-										const active = activeConversationId === c.id;
-										return (
-											<div
-												className="lp-row"
-												key={c.id}
-												onMouseLeave={() => setConfirmDel((k) => (k === `conv:${c.id}` ? null : k))}
-											>
-												<button
-													type="button"
-													className={`session-item ${active ? "active" : ""}`}
-													title={`${c.title}${g.isCurrent ? "" : ` — ${g.cwd}`}`}
-													onClick={() => {
-														if (!active) send({ type: "switch_conversation", id: c.id });
-													}}
+									{(() => {
+										const byId = new Map(g.convs.map((x) => [x.id, x]));
+										const kids = new Map<string, ConversationSummary[]>();
+										const roots: ConversationSummary[] = [];
+										for (const x of g.convs) {
+											if (x.parentId && byId.has(x.parentId)) {
+												const arr = kids.get(x.parentId) ?? [];
+												arr.push(x);
+												kids.set(x.parentId, arr);
+											} else roots.push(x);
+										}
+										const rows: { c: ConversationSummary; depth: number }[] = [];
+										const seen = new Set<string>();
+										const append = (c: ConversationSummary, depth: number) => {
+											if (seen.has(c.id)) return;
+											seen.add(c.id);
+											rows.push({ c, depth });
+											for (const child of kids.get(c.id) ?? []) append(child, depth + 1);
+										};
+										for (const root of roots) append(root, 0);
+										for (const orphan of g.convs) append(orphan, 0);
+										return rows.map(({ c, depth }) => {
+											const active = activeConversationId === c.id;
+											return (
+												<div
+													className={`lp-row${depth > 0 ? " lp-sub" : ""}`}
+													key={c.id}
+													style={depth > 0 ? { marginLeft: depth * 18 } : undefined}
+													onMouseLeave={() => setConfirmDel((k) => (k === `conv:${c.id}` ? null : k))}
 												>
-													<FiMessageSquare className="session-icon" />
-													<span className="session-info">
-														{renaming === `conv:${c.id}` ? (
-															<input
-																autoFocus
-																className="session-rename-input"
-																value={renameDraft}
-																placeholder={t("renameSessionPlaceholder")}
-																onClick={(e) => e.stopPropagation()}
-																onChange={(e) => setRenameDraft(e.target.value)}
-																onKeyDown={(e) => {
-																	e.stopPropagation();
-																	if (e.key === "Enter" && !e.nativeEvent.isComposing) {
-																		const name = renameDraft.trim();
-																		if (name) send({ type: "rename_conversation", id: c.id, name });
-																		setRenaming(null);
-																	} else if (e.key === "Escape") {
-																		setRenaming(null);
-																	}
-																}}
-																onBlur={() => setRenaming(null)}
-															/>
-														) : (
-															<span className="session-title">
-																{c.isSubagent && <span className="subagent-badge">{t("subagentBadge")}</span>}
-																{c.title}
-																{c.error && (
-																	<span className="conv-error-badge" title={t("convErrorBadge", { error: c.error })} />
-																)}
-															</span>
+													<button
+														type="button"
+														className={`session-item ${active ? "active" : ""}`}
+														title={`${c.title}${g.isCurrent ? "" : ` — ${g.cwd}`}`}
+														onClick={() => {
+															if (!active) send({ type: "switch_conversation", id: c.id });
+														}}
+													>
+														<FiMessageSquare className="session-icon" />
+														<span className="session-info">
+															{renaming === `conv:${c.id}` ? (
+																<input
+																	autoFocus
+																	className="session-rename-input"
+																	value={renameDraft}
+																	placeholder={t("renameSessionPlaceholder")}
+																	onClick={(e) => e.stopPropagation()}
+																	onChange={(e) => setRenameDraft(e.target.value)}
+																	onKeyDown={(e) => {
+																		e.stopPropagation();
+																		if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+																			const name = renameDraft.trim();
+																			if (name) send({ type: "rename_conversation", id: c.id, name });
+																			setRenaming(null);
+																		} else if (e.key === "Escape") {
+																			setRenaming(null);
+																		}
+																	}}
+																	onBlur={() => setRenaming(null)}
+																/>
+															) : (
+																<span className="session-title">
+																	{c.isSubagent && <span className="subagent-badge">{t("subagentBadge")}</span>}
+																	{c.title}
+																	{c.error && (
+																		<span
+																			className="conv-error-badge"
+																			title={t("convErrorBadge", { error: c.error })}
+																		/>
+																	)}
+																</span>
+															)}
+															{renaming === `conv:${c.id}` ? null : (
+																<span className="session-sub">
+																	{active ? t("current") : t("messageCount", { n: c.messageCount })}
+																</span>
+															)}
+														</span>
+														{c.isStreaming && <span className="conv-streaming" title={t("streaming")} />}
+													</button>
+													<button
+														type="button"
+														className="lp-del lp-rename"
+														title={t("renameSession")}
+														onClick={(e) => {
+															e.stopPropagation();
+															setConfirmDel(null);
+															setRenameDraft(c.title);
+															setRenaming(`conv:${c.id}`);
+														}}
+													>
+														<FiEdit2 />
+													</button>
+													{!c.isStreaming &&
+														!active &&
+														delButton(
+															`conv:${c.id}`,
+															t("dismissConversation"),
+															t("dismissConversationConfirm"),
+															() => send({ type: "dismiss_conversation", id: c.id }),
+															<FiX />,
 														)}
-														{renaming === `conv:${c.id}` ? null : (
-															<span className="session-sub">
-																{active ? t("current") : t("messageCount", { n: c.messageCount })}
-															</span>
-														)}
-													</span>
-													{c.isStreaming && <span className="conv-streaming" title={t("streaming")} />}
-												</button>
-												<button
-													type="button"
-													className="lp-del lp-rename"
-													title={t("renameSession")}
-													onClick={(e) => {
-														e.stopPropagation();
-														setConfirmDel(null);
-														setRenameDraft(c.title);
-														setRenaming(`conv:${c.id}`);
-													}}
-												>
-													<FiEdit2 />
-												</button>
-												{!c.isStreaming &&
-													!active &&
-													delButton(
-														`conv:${c.id}`,
-														t("dismissConversation"),
-														t("dismissConversationConfirm"),
-														() => send({ type: "dismiss_conversation", id: c.id }),
-														<FiX />,
+													{c.isStreaming && (
+														<span
+															className="lp-row-stalled"
+															title={t("streaming")}
+															style={{ position: "absolute", right: 28, top: "50%", transform: "translateY(-50%)" }}
+														/>
 													)}
-												{c.isStreaming && (
-													<span
-														className="lp-row-stalled"
-														title={t("streaming")}
-														style={{ position: "absolute", right: 28, top: "50%", transform: "translateY(-50%)" }}
-													/>
-												)}
-											</div>
-										);
-									})}
+												</div>
+											);
+										});
+									})()}
 								</div>
 							))}
 						</div>

--- a/web/src/components/LeftPanel.tsx
+++ b/web/src/components/LeftPanel.tsx
@@ -390,9 +390,9 @@ export const LeftPanel = memo(function LeftPanel({
 															<span className="session-title">
 																{c.isSubagent && <span className="subagent-badge">{t("subagentBadge")}</span>}
 																{c.title}
-														{c.error && (
-															<span className="conv-error-badge" title={t("convErrorBadge", { error: c.error })} />
-														)}
+																{c.error && (
+																	<span className="conv-error-badge" title={t("convErrorBadge", { error: c.error })} />
+																)}
 															</span>
 														)}
 														{renaming === `conv:${c.id}` ? null : (

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -1226,9 +1226,7 @@ export function SettingsModal({ chat, send, terminal, onSwitchToTerminal, onClos
 								{settings.subagentModels.length === 0 ? (
 									<p className="set-hint">{t("subagentNoModels")}</p>
 								) : (
-									<p className="set-hint">
-										{t("subagentDefaultModelHint")}
-									</p>
+									<p className="set-hint">{t("subagentDefaultModelHint")}</p>
 								)}
 
 								{/* ---- 编辑器（新建 / 编辑同表单） ------------------------------ */}

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -1692,7 +1692,8 @@ const en: Record<keyof typeof zh, string> = {
 	subagentFollowMain: "Follow the main conversation's current model",
 	subagentDefaultModelHint:
 		"Fallback model for all subagents (a template's own model and the subagent_spawn model param take priority); does not change the main conversation's model.",
-	subagentNoModels: "No usable models yet (configure a provider API key first) — subagents will follow the main conversation's model.",
+	subagentNoModels:
+		"No usable models yet (configure a provider API key first) — subagents will follow the main conversation's model.",
 	subagentTemplateOffHint:
 		"Disabled templates stay in the panel and can be re-enabled, but AI tools can't see or pick them",
 	subagentTemplateEnable: "Enable",

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -843,6 +843,18 @@ body.lp-resizing .lp-sash.dragging::after {
 .lp-row {
 	position: relative;
 }
+/* Subagent tree branch. Parent and child remain full, independent links. */
+.lp-row.lp-sub::before {
+	content: "";
+	position: absolute;
+	left: -10px;
+	top: -5px;
+	width: 8px;
+	height: calc(50% + 5px);
+	border-left: 1px solid var(--border);
+	border-bottom: 1px solid var(--border);
+	border-radius: 0 0 0 5px;
+}
 .lp-row .lp-del {
 	position: absolute;
 	right: 8px;


### PR DESCRIPTION
EN — Summary
- Record the active parent id when a subagent starts; carry it on ConversationSummary
- Running Chats keeps the active parent visible and nests recursive child rows under it
- Parent and every subagent remain independent clickable chat links with tree branches
- Retain parents with live children on switch and dismiss so workers stop vanishing
- Bind subagent extensions with a minimal mock theme uiContext (stops Theme toasts)
- Regression test for the parent-retention rule

中文 — 摘要
- 子代理启动记录父对话；运行对话保留父链接并递归嵌套子树
- 父子均可独立点击；有存活子代理时保留父对话
- 子代理绑定改传最小 mock 主题，不再弹错

**Stack order: merge #76 first, then this.** This branch is rebased on #76. / **合并顺序：先合 #76，再合本 PR。** 本分支已基于 #76 变基。

Test: `npm run format`, `typecheck`, `build` green; `vitest` 328 passed (36 files).

> Note: Translations in this PR were generated by an automated translation system. If any wording is awkward or inaccurate, please point it out and it will be corrected. / 本 PR 中的翻译由自动翻译系统生成，如有措辞不当或不准确之处，欢迎指出并将予以修正.