### PR TITLE
style(prettier): pass over upstream subagents files / 上游子代理文件格式化

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -824,7 +824,11 @@ export class ClientSession {
 		// 显式搬过来（新 runtime 的默认模型未必等于主对话刚选的模型）。
 		const resolvedModel =
 			model ?? (apply?.model?.trim() || null) ?? (this.settingsSvc.current.subagentDefaultModel || null);
-		const followModel = resolvedModel ? resolvedModel : this.session.model ? `${this.session.model.provider}/${this.session.model.id}` : null;
+		const followModel = resolvedModel
+			? resolvedModel
+			: this.session.model
+				? `${this.session.model.provider}/${this.session.model.id}`
+				: null;
 		if (followModel) {
 			const slash = followModel.indexOf("/");
 			const m =

--- a/server/settings-service.ts
+++ b/server/settings-service.ts
@@ -282,7 +282,9 @@ export class SettingsService {
 				}
 			}
 			// 稳定排序：provider 名 → 模型名。
-			return out.sort((a, b) => (a.provider === b.provider ? a.label.localeCompare(b.label) : a.provider.localeCompare(b.provider)));
+			return out.sort((a, b) =>
+				a.provider === b.provider ? a.label.localeCompare(b.label) : a.provider.localeCompare(b.provider),
+			);
 		} catch {
 			// Session not ready yet — the picker stays empty until next push.
 			return [];

--- a/server/subagents.ts
+++ b/server/subagents.ts
@@ -126,7 +126,7 @@ export function makeSubagentTools(host: SubagentToolHost): ToolDefinition[] {
 				"subagent_steer 中途改向、subagent_stop 停止。" +
 				"适合：长耗时探索、并行调研、独立子任务委派。可选 template 参数：使用设置面板配置的子代理模板" +
 				"（角色系统提示词 + 技能/扩展白名单 + 可选模型）；可选 model 参数：显式指定子代理模型（provider/id 格式，" +
-				"如 \"anthropic/claude-opus-4-5\"），优先级高于模板与设置面板的默认模型；都不传 = 跟随主对话当前模型。",
+				'如 "anthropic/claude-opus-4-5"），优先级高于模板与设置面板的默认模型；都不传 = 跟随主对话当前模型。',
 			promptSnippet: "spawn an independent background subagent for a deliverable task (parallel work)",
 			parameters: Type.Object({
 				prompt: Type.String({ description: "交给子代理的完整指令（要达成的目标 + 约束 + 期望产出）。" }),
@@ -143,7 +143,7 @@ export function makeSubagentTools(host: SubagentToolHost): ToolDefinition[] {
 				model: Type.Optional(
 					Type.String({
 						description:
-							"可选：子代理模型 \"provider/id\"（如 \"anthropic/claude-opus-4-5\"），显式指定本次子代理的模型，" +
+							'可选：子代理模型 "provider/id"（如 "anthropic/claude-opus-4-5"），显式指定本次子代理的模型，' +
 							"优先级高于模板自带模型与设置面板默认模型；不传 = 模板模型 → 设置面板默认模型 → 跟随主对话当前模型。",
 					}),
 				),
@@ -168,7 +168,8 @@ export function makeSubagentTools(host: SubagentToolHost): ToolDefinition[] {
 		defineTool({
 			name: "subagent_get_result",
 			label: "Get subagent result",
-			description: "取一个子代理的结果或当前运行态。若尚未完成，返回当前状态与已产出的文本；运行报错（如 provider 400）会在这里明确标出错误。",
+			description:
+				"取一个子代理的结果或当前运行态。若尚未完成，返回当前状态与已产出的文本；运行报错（如 provider 400）会在这里明确标出错误。",
 			promptSnippet: "fetch a subagent's result / current progress",
 			parameters: Type.Object({
 				runId: Type.String({ description: "subagent_spawn 返回的 convId。左栏点击同名对话可直接查看。" }),
@@ -240,7 +241,9 @@ export function makeSubagentTools(host: SubagentToolHost): ToolDefinition[] {
 			promptSnippet: "wait for multiple subagents to finish (no polling) and get all results",
 			parameters: Type.Object({
 				runIds: Type.Optional(
-					Type.Array(Type.String({ description: "要等待的子代理 convId（subagent_spawn 返回值）。缺省 = 等当前全部运行中的。" })),
+					Type.Array(
+						Type.String({ description: "要等待的子代理 convId（subagent_spawn 返回值）。缺省 = 等当前全部运行中的。" }),
+					),
 				),
 				timeoutSeconds: Type.Optional(
 					Type.Integer({

--- a/tests/subagent-template-test.mjs
+++ b/tests/subagent-template-test.mjs
@@ -214,11 +214,7 @@ async function main() {
 		check("subagentModels 字段存在（零模型环境为空数组）", Array.isArray(s0.settings.subagentModels));
 		// 设置一个显式默认模型（wire 只校验透传，不校验存在性）。
 		c.send({ type: "set_settings", subagentDefaultModel: "dashscope/qwen-max" });
-		const s1 = await c.waitFor(
-			"settings_state",
-			8000,
-			(m) => m.settings.subagentDefaultModel === "dashscope/qwen-max",
-		);
+		const s1 = await c.waitFor("settings_state", 8000, (m) => m.settings.subagentDefaultModel === "dashscope/qwen-max");
 		check("set_settings 更新 subagentDefaultModel", s1.settings.subagentDefaultModel === "dashscope/qwen-max");
 		// 再切回跟随主对话（null）。
 		c.send({ type: "set_settings", subagentDefaultModel: null });

--- a/tests/unit/subagents.test.ts
+++ b/tests/unit/subagents.test.ts
@@ -46,7 +46,13 @@ describe("subagents tools", () => {
 			undefined,
 			ctx as never,
 		);
-		expect(host.spawnSubagent).toHaveBeenCalledWith("调研", "explore", "/other", "reviewer", "anthropic/claude-opus-4-5");
+		expect(host.spawnSubagent).toHaveBeenCalledWith(
+			"调研",
+			"explore",
+			"/other",
+			"reviewer",
+			"anthropic/claude-opus-4-5",
+		);
 		// 结果文本含 convId（host 返回值）与类型。
 		const text = result.content?.[0] as { text: string };
 		expect(text.text).toContain("sa-explore-abc");
@@ -199,23 +205,53 @@ describe("subagents tools", () => {
 	it("subagent_wait_all 空 runIds 时等当前全部运行中的子代理", async () => {
 		const host = makeHostSpies();
 		(host.listSubagents as ReturnType<typeof vi.fn>).mockReturnValue([
-			{ convId: "sa-a", type: "general", title: "A", prompt: "", state: "running", streaming: true, messageCount: 1, output: "" },
-			{ convId: "sa-b", type: "general", title: "B", prompt: "", state: "running", streaming: true, messageCount: 1, output: "" },
+			{
+				convId: "sa-a",
+				type: "general",
+				title: "A",
+				prompt: "",
+				state: "running",
+				streaming: true,
+				messageCount: 1,
+				output: "",
+			},
+			{
+				convId: "sa-b",
+				type: "general",
+				title: "B",
+				prompt: "",
+				state: "running",
+				streaming: true,
+				messageCount: 1,
+				output: "",
+			},
 		]);
 		(host.getSubagent as ReturnType<typeof vi.fn>).mockImplementation((id: string) =>
 			id === "sa-a"
-				? { convId: "sa-a", type: "general", title: "A", prompt: "", state: "done", streaming: false, messageCount: 2, output: "OK A" }
-				: { convId: "sa-b", type: "general", title: "B", prompt: "", state: "running", streaming: true, messageCount: 1, output: "" },
+				? {
+						convId: "sa-a",
+						type: "general",
+						title: "A",
+						prompt: "",
+						state: "done",
+						streaming: false,
+						messageCount: 2,
+						output: "OK A",
+					}
+				: {
+						convId: "sa-b",
+						type: "general",
+						title: "B",
+						prompt: "",
+						state: "running",
+						streaming: true,
+						messageCount: 1,
+						output: "",
+					},
 		);
 		const tools = makeSubagentTools(host);
 		const waitTool = tools.find((t) => t.name === "subagent_wait_all")!;
-		const result = await waitTool.execute!(
-			"t1",
-			{ timeoutSeconds: 1 } as never,
-			undefined,
-			undefined,
-			{} as never,
-		);
+		const result = await waitTool.execute!("t1", { timeoutSeconds: 1 } as never, undefined, undefined, {} as never);
 		const text = result.content?.[0] as { text: string };
 		// sa-b 一直运行 → 超时返回未完成名单
 		expect(text.text).toContain("1 个仍在运行");

--- a/web/src/components/LeftPanel.tsx
+++ b/web/src/components/LeftPanel.tsx
@@ -390,9 +390,9 @@ export const LeftPanel = memo(function LeftPanel({
 															<span className="session-title">
 																{c.isSubagent && <span className="subagent-badge">{t("subagentBadge")}</span>}
 																{c.title}
-														{c.error && (
-															<span className="conv-error-badge" title={t("convErrorBadge", { error: c.error })} />
-														)}
+																{c.error && (
+																	<span className="conv-error-badge" title={t("convErrorBadge", { error: c.error })} />
+																)}
 															</span>
 														)}
 														{renaming === `conv:${c.id}` ? null : (

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -1226,9 +1226,7 @@ export function SettingsModal({ chat, send, terminal, onSwitchToTerminal, onClos
 								{settings.subagentModels.length === 0 ? (
 									<p className="set-hint">{t("subagentNoModels")}</p>
 								) : (
-									<p className="set-hint">
-										{t("subagentDefaultModelHint")}
-									</p>
+									<p className="set-hint">{t("subagentDefaultModelHint")}</p>
 								)}
 
 								{/* ---- 编辑器（新建 / 编辑同表单） ------------------------------ */}

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -1692,7 +1692,8 @@ const en: Record<keyof typeof zh, string> = {
 	subagentFollowMain: "Follow the main conversation's current model",
 	subagentDefaultModelHint:
 		"Fallback model for all subagents (a template's own model and the subagent_spawn model param take priority); does not change the main conversation's model.",
-	subagentNoModels: "No usable models yet (configure a provider API key first) — subagents will follow the main conversation's model.",
+	subagentNoModels:
+		"No usable models yet (configure a provider API key first) — subagents will follow the main conversation's model.",
 	subagentTemplateOffHint:
 		"Disabled templates stay in the panel and can be re-enabled, but AI tools can't see or pick them",
 	subagentTemplateEnable: "Enable",


### PR DESCRIPTION
EN — Summary
- Upstream 11c84df fails `npm run format:check` on 7 files; this applies the prettier pass so CI goes green
- Pure formatting, no behavior change

中文 — 摘要
- 上游 11c84df 未过格式化检查；本 PR 纯格式化，无行为变化

**Stack order: merge this first, then #75.** #75 is rebased on top of this branch. / **合并顺序：先合本 PR，再合 #75。** #75 已基于本分支变基。

Test: `npm run format:check` passes (was: 7 files warned).

> Note: Translations in this PR were generated by an automated translation system. If any wording is awkward or inaccurate, please point it out and it will be corrected. / 本 PR 中的翻译由自动翻译系统生成，如有措辞不当或不准确之处，欢迎指出并将予以修正.