### PR TITLE
feat(chat): wide chat column toggle for ultrawide monitors / 超宽屏聊天列开关

### DIFF
--- a/tests/unit/chat-width-settings.test.ts
+++ b/tests/unit/chat-width-settings.test.ts
@@ -1,0 +1,28 @@
+/**
+ * 宽屏聊天列开关规整单测（见 web/src/chat-width-settings.ts）。
+ * 仅测纯函数 normalizeChatWidthSettings —— localStorage 存取在 node 环境不可用，
+ * load/save 都有 try/catch 兜底，不在单测范围内。
+ */
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CHAT_WIDTH_SETTINGS, normalizeChatWidthSettings } from "../../web/src/chat-width-settings.js";
+
+describe("normalizeChatWidthSettings", () => {
+	it("非对象回退默认（默认关闭）", () => {
+		expect(normalizeChatWidthSettings(null)).toEqual(DEFAULT_CHAT_WIDTH_SETTINGS);
+		expect(normalizeChatWidthSettings(undefined)).toEqual(DEFAULT_CHAT_WIDTH_SETTINGS);
+		expect(normalizeChatWidthSettings("yes")).toEqual(DEFAULT_CHAT_WIDTH_SETTINGS);
+		expect(normalizeChatWidthSettings(1)).toEqual(DEFAULT_CHAT_WIDTH_SETTINGS);
+	});
+
+	it("保留合法的布尔值", () => {
+		expect(normalizeChatWidthSettings({ wide: true })).toEqual({ wide: true });
+		expect(normalizeChatWidthSettings({ wide: false })).toEqual({ wide: false });
+	});
+
+	it("字段类型错误/缺失回退默认", () => {
+		expect(normalizeChatWidthSettings({ wide: "yes" })).toEqual(DEFAULT_CHAT_WIDTH_SETTINGS);
+		expect(normalizeChatWidthSettings({ wide: 1 })).toEqual(DEFAULT_CHAT_WIDTH_SETTINGS);
+		expect(normalizeChatWidthSettings({})).toEqual(DEFAULT_CHAT_WIDTH_SETTINGS);
+		expect(normalizeChatWidthSettings({ other: false })).toEqual(DEFAULT_CHAT_WIDTH_SETTINGS);
+	});
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -39,6 +39,7 @@ import type { Notice } from "./use-chat";
 import { fileToProcessedImage, isRasterImage, type ProcessedImage } from "./image-paste";
 import { randomUuid } from "./uuid";
 import { loadSoundSettings, playSound, saveSoundSettings, type SoundKind, type SoundSettings } from "./sounds";
+import { useWideChat } from "./chat-width-settings";
 import { notify } from "./notify";
 import { useTheme } from "./theme";
 
@@ -222,6 +223,8 @@ export function App() {
 	const [manageModelsOpen, setManageModelsOpen] = useState(false);
 	// Settings panel (system prompt / skills / extensions / presets).
 	const [settingsOpen, setSettingsOpen] = useState(false);
+	// Wide chat column (client-local, default off).
+	const wide = useWideChat();
 	// Background-task panel (AI-started servers — stop individually or all).
 	const [bgTasksOpen, setBgTasksOpen] = useState(false);
 	// Global search panel (sessions / projects / workspace files).
@@ -659,7 +662,7 @@ export function App() {
 							/>
 						</div>
 						{!isMobile && <ResizeHandle side="left" width={leftWidth} onResize={resizeLeft} />}
-						<main className="main">
+						<main className={wide ? "main wide-chat" : "main"}>
 							{chat.state ? (
 								<MessageList
 									key={chat.state.conversationId ?? "boot"}

--- a/web/src/chat-width-settings.ts
+++ b/web/src/chat-width-settings.ts
@@ -1,0 +1,74 @@
+/// <reference lib="dom" />
+/**
+ * 宽屏聊天列开关（纯前端 localStorage，不经过 server）。
+ *
+ * - 默认关闭：中央列保持 860px 上限。
+ * - 开启后：`.main` 挂 `wide-chat`，所有 860px 上限的消息/输入/附件元素
+ *   改为铺满列宽（左右各留 260px 内边距，与问题导航栏同宽）。
+ * - normalize/load 为纯函数，可单测（tests/unit/chat-width-settings.test.ts）。
+ */
+
+import { useSyncExternalStore } from "react";
+
+export const CHAT_WIDTH_SETTINGS_KEY = "pi-web-ui:wide-chat";
+
+export interface ChatWidthSettings {
+	/** 中央列是否铺满宽度（false = 保持 860px 上限） */
+	wide: boolean;
+}
+
+export const DEFAULT_CHAT_WIDTH_SETTINGS: ChatWidthSettings = { wide: false };
+
+/** 规整设置值：非对象 / 字段类型错误一律回退默认值。 */
+export function normalizeChatWidthSettings(raw: unknown): ChatWidthSettings {
+	if (!raw || typeof raw !== "object") return { ...DEFAULT_CHAT_WIDTH_SETTINGS };
+	const o = raw as Record<string, unknown>;
+	return {
+		wide: typeof o.wide === "boolean" ? o.wide : DEFAULT_CHAT_WIDTH_SETTINGS.wide,
+	};
+}
+
+/** 读取持久化的开关（localStorage 不可用 / 数据损坏时回退默认关闭）。 */
+export function loadChatWidthSettings(): ChatWidthSettings {
+	try {
+		const raw = localStorage.getItem(CHAT_WIDTH_SETTINGS_KEY);
+		if (!raw) return { ...DEFAULT_CHAT_WIDTH_SETTINGS };
+		return normalizeChatWidthSettings(JSON.parse(raw));
+	} catch {
+		return { ...DEFAULT_CHAT_WIDTH_SETTINGS };
+	}
+}
+
+/** 保存并广播变更（localStorage 不可写时静默忽略）。 */
+export function saveChatWidthSettings(s: ChatWidthSettings): void {
+	const norm = normalizeChatWidthSettings(s);
+	try {
+		localStorage.setItem(CHAT_WIDTH_SETTINGS_KEY, JSON.stringify(norm));
+	} catch {
+		/* ignore */
+	}
+	cached = norm;
+	for (const l of listeners) l();
+}
+
+// ---- 订阅：单例 listener 集合。----------------------------------------------
+
+let cached: ChatWidthSettings | null = null;
+const listeners = new Set<() => void>();
+
+function subscribe(onStoreChange: () => void): () => void {
+	listeners.add(onStoreChange);
+	return () => {
+		listeners.delete(onStoreChange);
+	};
+}
+
+function getSnapshot(): boolean {
+	if (!cached) cached = loadChatWidthSettings();
+	return cached.wide;
+}
+
+/** 中央列当前是否铺满宽度（设置面板切换后即时生效，无需刷新）。 */
+export function useWideChat(): boolean {
+	return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -39,6 +39,7 @@ import {
 } from "../prompt-history";
 import { randomUuid } from "../uuid";
 import { useMermaidEnabled, loadMermaidSettings, saveMermaidSettings } from "../mermaid-settings";
+import { useWideChat, saveChatWidthSettings } from "../chat-width-settings";
 import { useT } from "../i18n";
 
 /** Minimal terminal-tab bridge (same shape SCMPanel uses). */
@@ -220,6 +221,8 @@ export function SettingsModal({ chat, send, terminal, onSwitchToTerminal, onClos
 	const [showFullPrompt, setShowFullPrompt] = useState(false);
 	// Mermaid 图表渲染开关（纯前端 localStorage，见 mermaid-settings.ts）。
 	const mermaidEnabled = useMermaidEnabled();
+	// 宽屏聊天列开关（纯前端 localStorage，见 chat-width-settings.ts）。
+	const wideChat = useWideChat();
 	// Prompt history settings (纯前端 localStorage，不经过 server).
 	const [phSettings, setPhSettings] = useState(() => loadPromptHistorySettings());
 	const [phCount, setPhCount] = useState(() => {
@@ -736,6 +739,12 @@ export function SettingsModal({ chat, send, terminal, onSwitchToTerminal, onClos
 									tip={t("mermaidRenderSettingDesc")}
 									enabled={mermaidEnabled}
 									onToggle={() => saveMermaidSettings({ enabled: !mermaidEnabled })}
+								/>
+								<ToggleRow
+									title={t("wideChat")}
+									tip={t("wideChatDesc")}
+									enabled={wideChat}
+									onToggle={() => saveChatWidthSettings({ wide: !wideChat })}
 								/>
 							</div>
 						)}

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -775,6 +775,8 @@ const zh = {
 		"开启：思考内容始终完整展开并自动换行（流式推理过程也实时可见）；关闭：折叠成一行摘要，流式中一行实时显示最新文本",
 	toolsWrap: "完整显示工具",
 	toolsWrapDesc: "开启：工具调用始终完整展开显示参数和输出；关闭：默认折叠，点击展开",
+	wideChat: "宽屏聊天列",
+	wideChatDesc: "开启：中央列铺满宽度（超宽屏有用）；关闭：保持 860px 上限",
 	terminalBashTakeover: "终端接管 bash",
 	terminalBashTakeoverDesc:
 		"此开关决定 bash 是否覆盖为终端版：关 = 原生 SDK bash（纯进程、不开终端）；开 = 跑进可见终端，且 persist 参数在本开关的基础上决定一次性（false，命令跑完进程退出、输出留档）还是持久（true，shell 状态跨调用保留、静默自动转后台并通知 AI）",
@@ -1642,6 +1644,8 @@ const en: Record<keyof typeof zh, string> = {
 	toolsWrap: "Show full tools",
 	toolsWrapDesc:
 		"On: tool calls always expand fully showing arguments and output; Off: collapsed by default, click to expand",
+	wideChat: "Wide chat column",
+	wideChatDesc: "On: the center column fills the width (useful on ultrawide monitors); Off: keep the 860px cap",
 	terminalBashTakeover: "Terminal-backed bash",
 	terminalBashTakeoverDesc:
 		"This switch decides whether bash is overridden to a terminal version: OFF = native SDK bash (process spawn, no terminal); ON = runs in a visible terminal, where the persist parameter decides (on top of the switch) one-shot (false — process exits when the command finishes, output retained) vs persistent (true — shell state retained across calls, silent commands move to the background and notify the AI)",

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -131,6 +131,29 @@ body {
 	min-height: 0;
 }
 
+/* 宽屏聊天列（设置 → 消息显示 → 宽屏聊天列，默认关闭）：中央列铺满宽度，
+ * 所有 860px 上限的消息/输入/附件元素改满列宽，左右各留 260px（问题导航栏同宽）。 */
+.main.wide-chat .msg,
+.main.wide-chat .msg-lazy-ph,
+.main.wide-chat .msg-collapsed,
+.main.wide-chat .goalbar,
+.main.wide-chat .queue-hint,
+.main.wide-chat .inputbox,
+.main.wide-chat .attach-row,
+.main.wide-chat .fp-markdown-zoom > .md {
+	max-width: none;
+	margin-left: 260px;
+	margin-right: 260px;
+}
+.main.wide-chat .input-suggest,
+.main.wide-chat .dialog-inline,
+.main.wide-chat .slash-help {
+	width: calc(100% - 520px);
+	max-width: none;
+	margin-left: 260px;
+	margin-right: 260px;
+}
+
 /* ---- Panel base (left & right) ---- */
 .panel {
 	display: flex;


### PR DESCRIPTION
EN — Summary
- Client-local toggle (Settings → Message display → Wide chat column, default off)
- Lifts the 860px center-column cap so chat fills ultrawide monitors, with 260px side padding
- Bilingual strings (zh + en), no server changes

中文 — 摘要
- 纯前端开关（设置 → 消息显示 → 宽屏聊天列，默认关闭）
- 解除 860px 中央列上限，超宽屏铺满，左右各留 260px
- 中英双语，无服务端改动

Test: `npm run format`, `typecheck`, `build` green; `vitest` 3 passed (new `tests/unit/chat-width-settings.test.ts`).

> Note: Translations in this PR were generated by an automated translation system. If any wording is awkward or inaccurate, please point it out and it will be corrected. / 本 PR 中的翻译由自动翻译系统生成，如有措辞不当或不准确之处，欢迎指出并将予以修正。
