### PR TITLE
fix: replace sync pi CLI probes with async background probes (Android/Termux server hang)

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -10,7 +10,7 @@
  * snapshots. The frontend is snapshot-driven (server is the source of truth),
  * so reconnects just re-request a snapshot.
  */
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, rmSync, statSync, mkdirSync, watch } from "node:fs";
 import { basename, dirname, join, resolve, sep } from "node:path";
@@ -2081,29 +2081,64 @@ export class ClientSession {
 	 * Whether the pi CLI binary is installed and runnable (`pi --version`
 	 * probe). Cached machine-wide (same binary for every client) for 10s —
 	 * the check is only rerun after install or when the cache expires.
+	 *
+	 * The probe runs ASYNCHRONOUSLY in the background: this getter serves the
+	 * last known value and never blocks the event loop. It previously used
+	 * spawnSync here, which could deadlock the whole server on Android/Termux:
+	 * fork() inside a multi-threaded process (websocket handlers + snapshot
+	 * serialization are active) occasionally left the forked child stuck
+	 * between fork and exec (futex_wait) while the blocked main thread sat in
+	 * spawnSync's pipe_read — the server kept running but stopped accepting
+	 * connections. Observed reproducibly on Android/Termux (Node 26).
 	 */
 	private static piCliProbe: { at: number; installed: boolean } | null = null;
+	private static piCliProbePending = false;
 	private static readonly PI_CLI_PROBE_TTL_MS = 10_000;
 
 	private isPiCliInstalled(): boolean {
 		const now = Date.now();
 		const cached = ClientSession.piCliProbe;
 		if (cached && now - cached.at < ClientSession.PI_CLI_PROBE_TTL_MS) return cached.installed;
-		let installed = false;
+		ClientSession.refreshPiCliProbe();
+		return cached?.installed ?? false;
+	}
+
+	private static refreshPiCliProbe(): void {
+		if (ClientSession.piCliProbePending) return;
+		ClientSession.piCliProbePending = true;
+		let proc: ReturnType<typeof spawn>;
 		try {
-			const res = spawnSync("pi", ["--version"], {
-				timeout: 5000,
+			proc = spawn("pi", ["--version"], {
 				stdio: "ignore",
-				// Windows: `pi` resolves to a pi.cmd shim — spawnSync can only
+				// Windows: `pi` resolves to a pi.cmd shim — spawn can only
 				// exec those through a shell (else ENOENT).
 				shell: process.platform === "win32",
 			});
-			installed = !res.error && res.status === 0;
 		} catch {
-			installed = false;
+			ClientSession.piCliProbe = { at: Date.now(), installed: false };
+			ClientSession.piCliProbePending = false;
+			return;
 		}
-		ClientSession.piCliProbe = { at: now, installed };
-		return installed;
+		const finish = (installed: boolean) => {
+			ClientSession.piCliProbe = { at: Date.now(), installed };
+			ClientSession.piCliProbePending = false;
+		};
+		const timer = setTimeout(() => {
+			try {
+				proc.kill();
+			} catch {
+				/* already exited */
+			}
+			finish(false);
+		}, 5000);
+		proc.on("error", () => {
+			clearTimeout(timer);
+			finish(false);
+		});
+		proc.on("close", (code) => {
+			clearTimeout(timer);
+			finish(code === 0);
+		});
 	}
 
 	private static invalidatePiCliProbe(): void {

--- a/server/update-check.ts
+++ b/server/update-check.ts
@@ -7,7 +7,7 @@
  * (and an injected pi-core probe); ClientSession only wires it to the wire
  * protocol.
  */
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -169,32 +169,70 @@ function readLocalPackage(dir: string): LocalPackage | null {
 	}
 }
 
-/** Uncached pi core probe (memoized machine-wide below). */
-function rawProbePiCore(): string | null {
-	try {
-		const res = spawnSync("pi", ["--version"], {
-			timeout: 5000,
-			stdio: "pipe",
-			shell: process.platform === "win32",
-		});
-		if (res.error || res.status !== 0) return null;
-		return parsePiVersionOutput(res.stdout?.toString() ?? "");
-	} catch {
-		return null;
-	}
-}
-
 /** How long a pi probe result stays hot (mirrors ClientSession.piCliProbe). */
 const PI_PROBE_TTL_MS = 10_000;
+
+let piCoreProbe: { at: number; version: string | null } | null = null;
+let piCoreProbePending = false;
+
+function refreshPiCoreProbe(): void {
+	if (piCoreProbePending) return;
+	piCoreProbePending = true;
+	let proc: ReturnType<typeof spawn>;
+	try {
+		proc = spawn("pi", ["--version"], {
+			stdio: ["ignore", "pipe", "pipe"],
+			// Windows: `pi` resolves to a pi.cmd shim — spawn can only
+			// exec those through a shell (else ENOENT).
+			shell: process.platform === "win32",
+		});
+	} catch {
+		piCoreProbe = { at: Date.now(), version: null };
+		piCoreProbePending = false;
+		return;
+	}
+	let out = "";
+	const finish = (version: string | null) => {
+		piCoreProbe = { at: Date.now(), version };
+		piCoreProbePending = false;
+	};
+	const timer = setTimeout(() => {
+		try {
+			proc.kill();
+		} catch {
+			/* already exited */
+		}
+		finish(null);
+	}, 5000);
+	proc.stdout?.on("data", (d: Buffer) => (out += d.toString()));
+	proc.on("error", () => {
+		clearTimeout(timer);
+		finish(null);
+	});
+	proc.on("close", (code) => {
+		clearTimeout(timer);
+		finish(code === 0 ? parsePiVersionOutput(out) : null);
+	});
+}
 
 /**
  * Default pi core probe: run the globally installed `pi --version`, memoized
  * machine-wide for PI_PROBE_TTL_MS so repeated collectTargets calls never
- * re-block the event loop on a 5s spawnSync. Null on any failure or absence.
- * Mirrors ClientSession.isPiCliInstalled() (same spawnSync shape; Windows
- * resolves `pi` to a pi.cmd shim that only execs through a shell).
+ * re-probe. Serves the last known value and refreshes ASYNCHRONOUSLY in the
+ * background — never blocks the event loop. (It previously used spawnSync
+ * here, which can deadlock the whole server on Android/Termux: fork() in a
+ * multi-threaded process occasionally leaves the forked child stuck between
+ * fork and exec while the main thread sits in spawnSync's pipe_read. Mirrors
+ * ClientSession.isPiCliInstalled(); Windows resolves `pi` to a pi.cmd shim
+ * that only execs through a shell.)
  */
-export const defaultProbePiCore = memoizeWithTtl(rawProbePiCore, PI_PROBE_TTL_MS);
+export function defaultProbePiCore(): string | null {
+	const now = Date.now();
+	const cached = piCoreProbe;
+	if (cached && now - cached.at < PI_PROBE_TTL_MS) return cached.version;
+	refreshPiCoreProbe();
+	return cached?.version ?? null;
+}
 
 /**
  * Fallback when the CLI probe yields nothing: the version of the vendored pi


### PR DESCRIPTION
Fixes #78.

## Root cause

`ClientSession.isPiCliInstalled()` runs in the snapshot builder (so, with the 10 s TTL, roughly every 10 seconds — and right when a message is flushed). It used `spawnSync("pi", ["--version"], { timeout: 5000 })` **on the main thread**.

On Android/Termux (aarch64, Node 26.3.1, busy server with websocket handlers + the ~60 ms snapshot serialization threads), `fork()` inside `spawnSync` occasionally deadlocked:

- parent main thread: blocked forever in `pipe_read` (spawnSync's internal pipe) — event loop dead, port no longer accepting connections;
- forked child: stuck with **1 thread** in `futex_wait_queue`, cmdline still identical to the parent → it never completed exec / node bootstrap.

The child inherits a lock held by another parent thread at fork() time (classic fork-in-multithreaded-process deadlock). The 5 s `timeout` did not recover the parent in practice.

Reproduced 4× in one day, each time right after a message was sent (a snapshot flush). Mobile-browser websocket reconnect churn + multiple open tabs appear to increase the race probability.

`server/update-check.ts#defaultProbePiCore` has the same `spawnSync` shape and was fixed the same way.

## Change

Both probes now serve the last cached value and refresh **asynchronously** via `spawn()` (kill-after-5 s, error/close handlers). The event loop is never blocked anymore:

- `isPiCliInstalled()`: sync getter, background `refreshPiCliProbe()` when the TTL expires; first-ever value resolves within one snapshot flush (~50 ms) instead of blocking.
- `defaultProbePiCore()`: same pattern (memoized state + background refresh), keeping the existing `() => string | null` contract so callers and injected-probe tests are unaffected.

`memoizeWithTtl` remains exported (still used by tests).

## Testing

- `npm run typecheck` — passes (server, web, tests tsconfigs)
- `npx vitest run tests/unit/update-check.test.ts` — 19/19 pass
- Smoke-tested on-device (Termux/Android, the environment where the deadlock reproduced 4×): patched server starts, `/api/health` reports `ok: true` with `piVersion` resolved via the new async probe.

The real proof is the missing deadlock: the previous build hung within hours of normal mobile use; the async build removes the only synchronous spawn on the hot path. I'll report back after longer-term use.
