### PR TITLE
docs: Termux (Android) install guide (node-pty toolchain, exec-bit fix, background run)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,48 @@ silences the warning):
 npm i -g --allow-scripts=node-pty,@google/genai,protobufjs pi-web-ui@latest
 ```
 
+### Termux (Android)
+
+pi-web-ui runs fine on Android via [Termux](https://termux.dev), but `node-pty`
+(the native dependency) needs a toolchain, and Android has a few quirks worth
+knowing:
+
+1. **Install the build toolchain first** — `node-pty` needs Python and a C
+   toolchain:
+
+   ```bash
+   pkg install python clang make binutils
+   ```
+
+2. **Point the node-pty build at a dummy NDK path.** On Android, gyp fails with
+   `Undefined variable android_ndk_path` unless the variable is defined:
+
+   ```bash
+   GYP_DEFINES="android_ndk_path=' '" npm i -g --allow-scripts=node-pty,@google/genai,protobufjs pi-web-ui@latest
+   ```
+
+3. **If `pi-web-ui` won't execute after install** (the exec bit and/or shebang
+   can get mangled on Android): restore it:
+
+   ```bash
+   chmod +x "$(command -v pi-web-ui)"
+   sed -i 's/\r$//' "$(command -v pi-web-ui)"
+   ```
+
+4. **Run it in the background** with `--no-browser` (there is no desktop
+   browser to auto-open):
+
+   ```bash
+   setsid nohup pi-web-ui --no-browser --cwd /path/to/workspace >~/pi-web.log 2>&1 &
+   ```
+
+   `setsid` detaches the server from the launching shell's process group, so
+   closing the Termux session doesn't take the server down — `nohup` alone is
+   not enough when the parent process group gets killed.
+
+The `[control] socket error: EACCES …/.pi-web/pi-web-ui.sock` warning at startup
+is harmless on Android: `pi-web-ui server stop/restart` won't work over the
+control socket, but the web UI itself is unaffected.
 
 ## Quick start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -122,6 +122,45 @@ node-pty 是原生模块，需要放行其脚本（其余两个包只是 no-op/�
 npm i -g --allow-scripts=node-pty,@google/genai,protobufjs pi-web-ui@latest
 ```
 
+### Termux（Android）
+
+pi-web-ui 可以通过 [Termux](https://termux.dev) 在 Android 上运行，但原生依赖
+`node-pty` 需要编译工具链，而且 Android 有几个值得注意的坑：
+
+1. **先安装编译工具链** —— `node-pty` 需要 Python 和 C 工具链：
+
+   ```bash
+   pkg install python clang make binutils
+   ```
+
+2. **给 node-pty 构建指定一个占位 NDK 路径**。在 Android 上，gyp 会报
+   `Undefined variable android_ndk_path`，除非该变量有定义：
+
+   ```bash
+   GYP_DEFINES="android_ndk_path=' '" npm i -g --allow-scripts=node-pty,@google/genai,protobufjs pi-web-ui@latest
+   ```
+
+3. **如果安装后 `pi-web-ui` 无法执行**（Android 上 exec 位和/或 shebang 可能
+   被破坏）：恢复它：
+
+   ```bash
+   chmod +x "$(command -v pi-web-ui)"
+   sed -i 's/\r$//' "$(command -v pi-web-ui)"
+   ```
+
+4. **后台运行时加上 `--no-browser`**（没有桌面浏览器可以自动打开）：
+
+   ```bash
+   setsid nohup pi-web-ui --no-browser --cwd /path/to/workspace >~/pi-web.log 2>&1 &
+   ```
+
+   `setsid` 把服务器从启动它的 shell 的进程组中脱离，关闭 Termux 会话也不会
+   带走服务器 —— 单靠 `nohup` 在父进程组被杀时是不够的。
+
+启动时的 `[control] socket error: EACCES …/.pi-web/pi-web-ui.sock` 警告在
+Android 上无害：`pi-web-ui server stop/restart` 无法通过 control socket 工作，
+但 Web UI 本身不受影响。
+
 ## 启动
 
 **前台启动**


### PR DESCRIPTION
## What

Adds a **Termux (Android)** subsection to the install docs (English + 中文 README), covering the three pitfalls I hit running pi-web-ui on a Pixel 10 Pro (Android, Node 26.3.1, aarch64):

1. **`node-pty` toolchain**: needs `pkg install python clang make binutils`, plus the non-obvious `GYP_DEFINES="android_ndk_path=' '"` workaround — without it gyp fails with `Undefined variable android_ndk_path`.
2. **Mangled bin script after `npm i -g`**: the installed `pi-web-ui` bin can lose its exec bit and/or get a CRLF shebang (`env: 'node\r'`); documented the `chmod +x` + `sed -i 's/\r$//'` fix.
3. **Background running**: recommend `setsid nohup … --no-browser` — `setsid` detaches from the launching shell's process group (closing the Termux session otherwise takes the server down; `nohup` alone doesn't survive the process group being killed), and `--no-browser` since there's no desktop browser to auto-open. Also notes that the `[control] socket error: EACCES` startup warning is harmless on Android.

## Why

Everything in the guide was verified on-device. Related: the server-hang deadlock reported in #79 / #78 also reproduces specifically on this platform, so a supported-install doc for Termux seemed worthwhile.

Happy to adjust wording/structure — e.g. move it to a separate `docs/` page if you prefer keeping the README lean.
