### PR TITLE
feat(plugins): adapt Mermaid diagrams to active theme

### DIFF
--- a/plugins/mermaid/client/entry.mjs
+++ b/plugins/mermaid/client/entry.mjs
@@ -41,7 +41,12 @@ function isDarkTheme() {
 	return rgb[0] * 0.299 + rgb[1] * 0.587 + rgb[2] * 0.114 < 128;
 }
 
-function themeVariables(dark) {
+function diagramFontSize() {
+	const size = Number.parseFloat(cssVar("--mermaid-font-size", "12px"));
+	return Number.isFinite(size) && size > 0 ? size : 12;
+}
+
+function themeVariables(dark, fontSize) {
 	return dark
 		? {
 				background: cssVar("--bg-elev2", "#1a1d26"),
@@ -53,7 +58,7 @@ function themeVariables(dark) {
 				nodeBorder: cssVar("--accent", "#8b5cf6"),
 				labelBackground: cssVar("--bg", "#0d0e12"),
 				fontFamily: cssVar("--mono", "monospace"),
-				fontSize: "13px",
+				fontSize: `${fontSize}px`,
 			}
 		: {
 				background: cssVar("--bg", "#ffffff"),
@@ -65,7 +70,7 @@ function themeVariables(dark) {
 				nodeBorder: cssVar("--accent", "#0969da"),
 				labelBackground: cssVar("--bg", "#ffffff"),
 				fontFamily: cssVar("--mono", "monospace"),
-				fontSize: "13px",
+				fontSize: `${fontSize}px`,
 			};
 }
 
@@ -98,11 +103,22 @@ function renderSvg(code) {
 	const result = renderQueue.then(async () => {
 		const mermaid = await loadMermaid();
 		const dark = isDarkTheme();
+		const fontSize = diagramFontSize();
 		mermaid.initialize({
 			startOnLoad: false,
 			securityLevel: "strict",
 			theme: dark ? "dark" : "base",
-			themeVariables: themeVariables(dark),
+			fontSize,
+			sequence: {
+				actorFontSize: fontSize,
+				messageFontSize: fontSize,
+				noteFontSize: fontSize,
+			},
+			gantt: {
+				fontSize,
+				sectionFontSize: fontSize,
+			},
+			themeVariables: themeVariables(dark, fontSize),
 		});
 
 		const renderId = `mermaid-fence-${++seq}-${Date.now().toString(36)}`;

--- a/plugins/mermaid/client/entry.mjs
+++ b/plugins/mermaid/client/entry.mjs
@@ -1,67 +1,77 @@
 /**
- * mermaid renderer 插件 —— fenced-code 渲染插件机制的第一个实现。
+ * Mermaid fenced-code renderer plugin.
  *
- * 约定：ESM 默认导出 { renderers }，`renderers["mermaid"]` 是一个
- * (code, ctx) → HTMLElement|null 工厂，把 ```mermaid 围栏渲染成 SVG。
- * 返回 null = 不渲染（回退普通代码块）。
- *
- * 引擎加载（本地优先，CDN 回退）：
- * - 优先 `./vendor/mermaid.bundle.mjs`（构建产物，见 scripts/build-mermaid-vendor
- *   .mjs）——插件目录自带引擎时**完全离线**渲染，不碰网络；
- * - 缺 vendor 文件（比如只拷了 manifest/entry.mjs）→ 回退 CDN（esm.sh）。可用
- *   镜像/版本改 CDN_URL；生产内网可下拉 vendor 后不再走这里。
- *
- * 渲染由插件认领决定：manifest 的 renderers 认领 "mermaid"，主应用 fence 注册表
- * 命中即渲染（懒加载）；不需要时卸载/删除插件目录即回退普通代码块——无主应用开关。
- * 复用了主应用 styles.css 的 .mermaid-block 类名（白色纸面卡片），不额外注入
- * 样式；本文件是纯 DOM，不共享 React 实例。
+ * The engine is loaded lazily from the bundled vendor module, with a CDN
+ * fallback for partial plugin installations. Rendering stays entirely client
+ * side and the host falls back to the raw code block if rendering fails.
  */
 
-/** CDN 回退入口（vendor 缺失时使用。内网镜像直接替换这里）。 */
+/** CDN fallback used only when the bundled vendor module is unavailable. */
 const CDN_URL = "https://esm.sh/mermaid@11";
+const THEME_CHANGE_EVENT = "pi-web-ui:theme-change";
 
-// 模块级单例：同一页面只加载/初始化一次，后续复用。
 let mermaidPromise = null;
 
-/** 动态 import 包装：归一化 default 导出（vendor bundle 与 esm.sh 都是 default）。
- *  相对路径按 entry.mjs 所在目录解析；绝对 URL 原样交给浏览器。 */
 function importModule(url) {
 	return import(/* @vite-ignore */ url).then((mod) => mod.default ?? mod);
 }
 
-async function loadMermaid() {
+function loadMermaid() {
 	if (!mermaidPromise) {
-		// 1) 本地 vendor（随插件分发的打包引擎，完全离线）→ 2) CDN 回退。
-		/* vendor 与 entry.mjs 同在 client/ 子树（静态服务只暴露 client/*） */
-		mermaidPromise = importModule("./vendor/mermaid.bundle.mjs").catch(() =>
-			importModule(CDN_URL),
-		);
-		mermaidPromise = mermaidPromise.then((mermaid) => {
-			mermaid.initialize({
-				startOnLoad: false,
-				securityLevel: "strict",
-				theme: "base",
-				themeVariables: {
-					background: "#ffffff",
-					primaryColor: "#f1edfe",
-					primaryTextColor: "#1f2430",
-					primaryBorderColor: "#8b5cf6",
-					lineColor: "#6b7280",
-					secondaryColor: "#eef2ff",
-					tertiaryColor: "#f8fafc",
-					textColor: "#1f2430",
-					fontFamily: "var(--mono, monospace)",
-				},
-			});
-			return mermaid;
-		});
+		mermaidPromise = importModule("./vendor/mermaid.bundle.mjs").catch(() => importModule(CDN_URL));
 	}
 	return mermaidPromise;
 }
 
+function cssVar(name, fallback) {
+	return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+}
+
+/** Prefer an explicit color-scheme; use background luminance for legacy themes. */
+function isDarkTheme() {
+	const scheme = getComputedStyle(document.documentElement).colorScheme;
+	if (scheme.split(/\s+/).includes("dark")) return true;
+	if (scheme.split(/\s+/).includes("light")) return false;
+
+	const rgb = getComputedStyle(document.body)
+		.backgroundColor.match(/[\d.]+/g)
+		?.slice(0, 3)
+		.map(Number);
+	if (!rgb || rgb.length < 3) return true;
+	return rgb[0] * 0.299 + rgb[1] * 0.587 + rgb[2] * 0.114 < 128;
+}
+
+function themeVariables(dark) {
+	return dark
+		? {
+				background: cssVar("--bg-elev2", "#1a1d26"),
+				primaryColor: cssVar("--bg-elev", "#14161c"),
+				primaryBorderColor: cssVar("--border", "#262a35"),
+				lineColor: cssVar("--text-dim", "#9aa1b4"),
+				textColor: cssVar("--text", "#e6e8ef"),
+				primaryTextColor: cssVar("--text", "#e6e8ef"),
+				nodeBorder: cssVar("--accent", "#8b5cf6"),
+				labelBackground: cssVar("--bg", "#0d0e12"),
+				fontFamily: cssVar("--mono", "monospace"),
+				fontSize: "13px",
+			}
+		: {
+				background: cssVar("--bg", "#ffffff"),
+				primaryColor: cssVar("--bg-elev2", "#f6f8fa"),
+				primaryBorderColor: cssVar("--border", "#d0d7de"),
+				lineColor: cssVar("--text-dim", "#59636e"),
+				textColor: cssVar("--text", "#1f2328"),
+				primaryTextColor: cssVar("--text", "#1f2328"),
+				nodeBorder: cssVar("--accent", "#0969da"),
+				labelBackground: cssVar("--bg", "#ffffff"),
+				fontFamily: cssVar("--mono", "monospace"),
+				fontSize: "13px",
+			};
+}
+
 let seq = 0;
 
-/** 给 SVG 一个确定的像素宽度（从 viewBox 取），避免移动端被挤压到不可读。 */
+/** Give the root SVG a concrete width so wide diagrams scroll instead of shrink. */
 function preserveSvgWidth(svg) {
 	const match = svg.match(/<svg\b([^>]*)>/i);
 	if (!match) return svg;
@@ -81,13 +91,64 @@ function preserveSvgWidth(svg) {
 	return svg.replace(match[0], `<svg${sizedAttrs} width="${width}" style="${style}">`);
 }
 
+/** Mermaid configuration is global, so initialize and render must be atomic. */
+let renderQueue = Promise.resolve();
+
+function renderSvg(code) {
+	const result = renderQueue.then(async () => {
+		const mermaid = await loadMermaid();
+		const dark = isDarkTheme();
+		mermaid.initialize({
+			startOnLoad: false,
+			securityLevel: "strict",
+			theme: dark ? "dark" : "base",
+			themeVariables: themeVariables(dark),
+		});
+
+		const renderId = `mermaid-fence-${++seq}-${Date.now().toString(36)}`;
+		const holder = document.createElement("div");
+		holder.style.position = "absolute";
+		holder.style.left = "-99999px";
+		holder.style.width = "1000px";
+		holder.dataset.mermaidRender = renderId;
+		document.body.appendChild(holder);
+		try {
+			const { svg } = await mermaid.render(renderId, code, holder);
+			return { dark, svg: preserveSvgWidth(svg) };
+		} finally {
+			holder.remove();
+		}
+	});
+	renderQueue = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	return result;
+}
+
+function applyRenderedSvg(el, rendered) {
+	if (rendered.dark) el.dataset.mermaidDark = "true";
+	else delete el.dataset.mermaidDark;
+	el.innerHTML = rendered.svg;
+}
+
 async function renderMermaid(code) {
-	const mermaid = await loadMermaid();
-	const renderId = `mermaid-fence-${++seq}-${Date.now().toString(36)}`;
-	const { svg } = await mermaid.render(renderId, code);
 	const el = document.createElement("div");
-	el.className = "mermaid-block";
-	el.innerHTML = preserveSvgWidth(svg);
+	el.className = "mermaid-block mermaid-svg";
+	applyRenderedSvg(el, await renderSvg(code));
+
+	let themeRequest = 0;
+	el.addEventListener(THEME_CHANGE_EVENT, () => {
+		const request = ++themeRequest;
+		renderSvg(code)
+			.then((rendered) => {
+				if (request !== themeRequest || !el.isConnected) return;
+				// Replace the SVG synchronously only after its replacement is complete,
+				// preserving the block height and reading position while rendering.
+				applyRenderedSvg(el, rendered);
+			})
+			.catch((err) => console.error("[plugin:mermaid] theme re-render failed:", err));
+	});
 	return el;
 }
 

--- a/scripts/build-mermaid-vendor.mjs
+++ b/scripts/build-mermaid-vendor.mjs
@@ -21,7 +21,7 @@ const { errors } = await build({
 	stdin: {
 		// 入口：mermaid 的 default 导出让浏览器动态 import ./vendor/... 时拿到
 		// 与 npm 相同的 `mermaid` 对象（initialize/render 全量可用）。
-		contents: "import mermaid from \"mermaid\"; export default mermaid;",
+		contents: 'import mermaid from "mermaid"; export default mermaid;',
 		resolveDir: ROOT,
 		sourcefile: "mermaid-vendor-entry.mjs",
 	},

--- a/tests/fence-render-test.mjs
+++ b/tests/fence-render-test.mjs
@@ -49,7 +49,9 @@ process.env.PI_WEB_DATA_DIR = dataDir;
 process.env.PI_CODING_AGENT_DIR = agentDir;
 const CLIENT_ID = "fence-render-client";
 // seed 时发一条用户消息，模型 fastfail 立即返回错误——用户消息本身即时渲染。
-const MERMAID_TEXT = "```mermaid\nflowchart LR\n  A[开始] --> B[结束]\n```\n";
+// 长上下文让主题切换测试能停在真实的非零阅读位置，而不是在列表顶部做平凡断言。
+const READING_CONTEXT = Array.from({ length: 80 }, (_, i) => `${i + 1}. Mermaid theme regression context`).join("\n");
+const MERMAID_TEXT = `${READING_CONTEXT}\n\n\`\`\`mermaid\nflowchart LR\n  A[开始] --> B[结束]\n\`\`\`\n`;
 const PLAIN_TEXT = "```plantuml\nA -> B\n```";
 
 const server = spawn(
@@ -111,9 +113,7 @@ function seedMessage() {
 			}
 			if (msg.type === "snapshot") {
 				const mine = msg.state.messages.filter((m) => {
-					const t = Array.isArray(m.content)
-						? m.content.map((c) => (c && "text" in c ? c.text : "")).join("")
-						: "";
+					const t = Array.isArray(m.content) ? m.content.map((c) => (c && "text" in c ? c.text : "")).join("") : "";
 					return m.role === "user" && t.includes("```mermaid");
 				});
 				if (mine.length > 0) {
@@ -155,9 +155,7 @@ async function main() {
 				const svg = document.querySelector(".mermaid-block svg");
 				const hasSvg = !!svg && svg.getAttribute("width") !== "";
 				// plantuml 无插件认领 → 保持普通代码块（pre > code 含源码，无 svg）
-				const pre = [...document.querySelectorAll(".codeblock pre code")].find((c) =>
-					c.textContent.includes("A -> B"),
-				);
+				const pre = [...document.querySelectorAll(".codeblock pre code")].find((c) => c.textContent.includes("A -> B"));
 				return { hasSvg, plain: !!pre };
 			})
 			.catch(() => ({ hasSvg: false, plain: false }));
@@ -178,6 +176,135 @@ async function main() {
 			.then((t) => t.length > 0),
 	);
 	check("插件 bundle 经 /plugins/mermaid/client/entry.mjs 可达", bundle);
+
+	async function applyTheme(theme) {
+		await page.evaluate(async (id) => {
+			let link = document.getElementById("theme-stylesheet");
+			if (!link) {
+				link = document.createElement("link");
+				link.id = "theme-stylesheet";
+				link.rel = "stylesheet";
+				document.head.appendChild(link);
+			}
+			await new Promise((resolve, reject) => {
+				link.onload = resolve;
+				link.onerror = reject;
+				link.href = `/themes/${id}.css?e2e=${Date.now()}`;
+			});
+			window.dispatchEvent(new CustomEvent("pi-web-ui:theme-change"));
+		}, theme);
+	}
+
+	const initialSvgId = await page.locator(".mermaid-block svg").getAttribute("id");
+	await applyTheme("cyberpunk");
+	await page.waitForFunction((id) => document.querySelector(".mermaid-block svg")?.id !== id, initialSvgId);
+	const beforeThemeSwitch = await page.evaluate(() => {
+		const svg = document.querySelector(".mermaid-block svg");
+		const shape = svg?.querySelector(".node rect, .node polygon, .node path");
+		const list = document.querySelector(".messages");
+		if (list) {
+			list.scrollTop = Math.floor((list.scrollHeight - list.clientHeight) / 2);
+			list.dispatchEvent(new WheelEvent("wheel", { deltaY: -100, bubbles: true }));
+		}
+		window.__mermaidMissingDuringThemeRender = false;
+		window.__mermaidPresenceTimer = window.setInterval(() => {
+			if (!document.querySelector(".mermaid-block svg")) window.__mermaidMissingDuringThemeRender = true;
+		}, 1);
+		return {
+			id: svg?.id,
+			stroke: shape ? getComputedStyle(shape).stroke : null,
+			scrollTop: list?.scrollTop ?? null,
+		};
+	});
+	await sleep(200);
+	await applyTheme("dazzle");
+	await page.waitForFunction((id) => document.querySelector(".mermaid-block svg")?.id !== id, beforeThemeSwitch.id);
+	const afterThemeSwitch = await page.evaluate(() => {
+		clearInterval(window.__mermaidPresenceTimer);
+		const block = document.querySelector(".mermaid-block");
+		const svg = block?.querySelector("svg");
+		const shape = svg?.querySelector(".node rect, .node polygon, .node path");
+		const label = svg?.querySelector(".nodeLabel, text");
+		const list = document.querySelector(".messages");
+		const probe = document.createElement("span");
+		probe.style.color = "var(--accent)";
+		document.body.appendChild(probe);
+		const expectedStroke = getComputedStyle(probe).color;
+		probe.remove();
+		return {
+			id: svg?.id,
+			stroke: shape ? getComputedStyle(shape).stroke : null,
+			expectedStroke,
+			fontSize: label ? getComputedStyle(label).fontSize : null,
+			dark: block?.getAttribute("data-mermaid-dark"),
+			scrollTop: list?.scrollTop ?? null,
+			missingDuringRender: window.__mermaidMissingDuringThemeRender,
+		};
+	});
+	console.log("  [dark theme switch]", JSON.stringify({ beforeThemeSwitch, afterThemeSwitch }));
+	check(
+		"同为深色的主题切换会重新渲染 SVG 并应用新配色",
+		beforeThemeSwitch.id !== afterThemeSwitch.id &&
+			beforeThemeSwitch.stroke !== afterThemeSwitch.stroke &&
+			afterThemeSwitch.stroke === afterThemeSwitch.expectedStroke &&
+			afterThemeSwitch.dark === "true",
+	);
+	check("主题重渲染期间旧 SVG 保持挂载", !afterThemeSwitch.missingDuringRender);
+	check("Mermaid 标签字号为 13px", afterThemeSwitch.fontSize === "13px");
+	check(
+		"主题重渲染保持消息列表阅读位置",
+		beforeThemeSwitch.scrollTop > 0 && beforeThemeSwitch.scrollTop === afterThemeSwitch.scrollTop,
+	);
+
+	await applyTheme("white");
+	await page.waitForFunction((id) => document.querySelector(".mermaid-block svg")?.id !== id, afterThemeSwitch.id);
+	const lightTheme = await page.evaluate(() => {
+		const block = document.querySelector(".mermaid-block");
+		const svg = block?.querySelector("svg");
+		const shape = svg?.querySelector(".node rect, .node polygon, .node path");
+		const probe = document.createElement("span");
+		probe.style.color = "var(--accent)";
+		document.body.appendChild(probe);
+		const expectedStroke = getComputedStyle(probe).color;
+		probe.remove();
+		return {
+			id: svg?.id,
+			stroke: shape ? getComputedStyle(shape).stroke : null,
+			expectedStroke,
+			dark: block?.getAttribute("data-mermaid-dark") ?? null,
+			scrollTop: document.querySelector(".messages")?.scrollTop ?? null,
+		};
+	});
+	console.log("  [light theme switch]", JSON.stringify(lightTheme));
+	check(
+		"深色切换到浅色会重新渲染 SVG 并应用浅色配色",
+		lightTheme.id !== afterThemeSwitch.id &&
+			lightTheme.stroke === lightTheme.expectedStroke &&
+			lightTheme.dark === null &&
+			lightTheme.scrollTop === afterThemeSwitch.scrollTop,
+	);
+
+	// A rejected render must not poison the serialized queue: correcting the
+	// source in the same loaded plugin module must render successfully.
+	const recovery = await page.evaluate(async () => {
+		const mod = await import("/plugins/mermaid/client/entry.mjs?e=1");
+		const render = mod.default.renderers.mermaid;
+		let rejected = false;
+		try {
+			await render("flowchart LR\n  A[[[ broken");
+		} catch {
+			rejected = true;
+		}
+		const el = await render("flowchart LR\n  A[Fixed] --> B[Done]");
+		return {
+			rejected,
+			recovered: !!el?.querySelector("svg"),
+			orphans: document.querySelectorAll("body > [data-mermaid-render]").length,
+		};
+	});
+	console.log("  [invalid -> valid recovery]", JSON.stringify(recovery));
+	check("非法源码修正后同一插件实例可恢复渲染", recovery.rejected && recovery.recovered);
+	check("失败与成功渲染均清理临时 DOM", recovery.orphans === 0);
 
 	// 手动复现一次 renderer 调用：区分「渲染本身失败」vs「管线挂接失败」
 	const manual = await page.evaluate(async () => {

--- a/tests/fence-render-test.mjs
+++ b/tests/fence-render-test.mjs
@@ -236,6 +236,7 @@ async function main() {
 			stroke: shape ? getComputedStyle(shape).stroke : null,
 			expectedStroke,
 			fontSize: label ? getComputedStyle(label).fontSize : null,
+			diagramFontSize: getComputedStyle(document.documentElement).getPropertyValue("--mermaid-font-size").trim(),
 			dark: block?.getAttribute("data-mermaid-dark"),
 			scrollTop: list?.scrollTop ?? null,
 			missingDuringRender: window.__mermaidMissingDuringThemeRender,
@@ -250,7 +251,7 @@ async function main() {
 			afterThemeSwitch.dark === "true",
 	);
 	check("主题重渲染期间旧 SVG 保持挂载", !afterThemeSwitch.missingDuringRender);
-	check("Mermaid 标签字号为 13px", afterThemeSwitch.fontSize === "13px");
+	check("Mermaid 标签字号为 12px", afterThemeSwitch.fontSize === afterThemeSwitch.diagramFontSize);
 	check(
 		"主题重渲染保持消息列表阅读位置",
 		beforeThemeSwitch.scrollTop > 0 && beforeThemeSwitch.scrollTop === afterThemeSwitch.scrollTop,
@@ -318,6 +319,112 @@ async function main() {
 	});
 	console.log("  [manual renderer]", JSON.stringify(manual));
 	check("手动调用 renderer 能产出 SVG", manual.ok && manual.hasSvg);
+
+	const typography = await page.evaluate(async () => {
+		const mod = await import("/plugins/mermaid/client/entry.mjs?e=1");
+		const render = mod.default.renderers.mermaid;
+		const cases = [
+			["sequence", "sequenceDiagram\n Alice->>Bob: Hello\n Bob-->>Alice: Done", "text"],
+			["er", "erDiagram\n CUSTOMER ||--o{ ORDER : places", ".nodeLabel, .edgeLabel"],
+			[
+				"gantt",
+				"gantt\n title Project\n dateFormat YYYY-MM-DD\n section Work\n Task :2026-01-01, 2d",
+				".titleText, .sectionTitle, .taskText",
+			],
+		];
+		const diagramFontSize = getComputedStyle(document.documentElement).getPropertyValue("--mermaid-font-size").trim();
+		const samples = [];
+		for (const [name, code, selector] of cases) {
+			const el = await render(code);
+			document.body.appendChild(el);
+			for (const node of el.querySelectorAll(selector)) {
+				if (node.textContent?.trim()) {
+					samples.push({ name, text: node.textContent.trim().slice(0, 30), size: getComputedStyle(node).fontSize });
+				}
+			}
+			el.remove();
+		}
+		return { diagramFontSize, samples };
+	});
+	console.log("  [diagram typography]", JSON.stringify(typography));
+	check(
+		"各 Mermaid 图型的主要标签字号均为 12px",
+		typography.samples.length > 0 && typography.samples.every((sample) => sample.size === typography.diagramFontSize),
+	);
+
+	// Hold a completed dark render before PluginFenceBlock receives its element,
+	// switch to white, then release it. The host must replay the missed theme
+	// event after mounting instead of leaving the first SVG in the stale palette.
+	const racePage = await browser.newPage();
+	await racePage.route("**/plugins/mermaid/client/entry.mjs?*", async (route) => {
+		const response = await route.fetch();
+		const source = await response.text();
+		const needle = "\t\tmermaid: renderMermaid,";
+		if (!source.includes(needle)) throw new Error("Mermaid renderer export hook not found");
+		const delayed = source.replace(
+			needle,
+			`\t\tmermaid: async (...args) => {
+		\tconst el = await renderMermaid(...args);
+		\twindow.__delayedMermaidInitial = {
+		\t\tid: el.querySelector("svg")?.id,
+		\t\tdark: el.getAttribute("data-mermaid-dark")
+		\t};
+		\tawait new Promise((resolve) => { window.__releaseMermaidRenderer = resolve; });
+		\treturn el;
+		},`,
+		);
+		await route.fulfill({ response, body: delayed });
+	});
+	await racePage.goto(`http://localhost:${PORT}/`, { waitUntil: "domcontentloaded" });
+	await racePage.waitForFunction(() => window.__delayedMermaidInitial, { timeout: 30_000 });
+	await racePage.evaluate(async () => {
+		const link = document.createElement("link");
+		link.id = "theme-stylesheet";
+		link.rel = "stylesheet";
+		await new Promise((resolve, reject) => {
+			link.onload = resolve;
+			link.onerror = reject;
+			link.href = `/themes/white.css?initial-race=${Date.now()}`;
+			document.head.appendChild(link);
+		});
+		window.dispatchEvent(new CustomEvent("pi-web-ui:theme-change"));
+		window.__releaseMermaidRenderer();
+	});
+	await racePage.waitForFunction(
+		() => {
+			const initial = window.__delayedMermaidInitial;
+			const block = document.querySelector(".mermaid-block");
+			const svg = block?.querySelector("svg");
+			return svg?.id && svg.id !== initial.id && !block.hasAttribute("data-mermaid-dark");
+		},
+		{ timeout: 30_000 },
+	);
+	const initialThemeRace = await racePage.evaluate(() => {
+		const block = document.querySelector(".mermaid-block");
+		const svg = block?.querySelector("svg");
+		const shape = svg?.querySelector(".node rect, .node polygon, .node path");
+		const probe = document.createElement("span");
+		probe.style.color = "var(--accent)";
+		document.body.appendChild(probe);
+		const expectedStroke = getComputedStyle(probe).color;
+		probe.remove();
+		return {
+			initial: window.__delayedMermaidInitial,
+			id: svg?.id,
+			dark: block?.getAttribute("data-mermaid-dark") ?? null,
+			stroke: shape ? getComputedStyle(shape).stroke : null,
+			expectedStroke,
+		};
+	});
+	console.log("  [initial render theme race]", JSON.stringify(initialThemeRace));
+	check(
+		"首次渲染期间的主题变化会在元素挂载后补同步",
+		initialThemeRace.initial.dark === "true" &&
+			initialThemeRace.id !== initialThemeRace.initial.id &&
+			initialThemeRace.dark === null &&
+			initialThemeRace.stroke === initialThemeRace.expectedStroke,
+	);
+	await racePage.close();
 
 	await browser.close();
 	console.log(passed >= 3 ? "\nFENCE RENDER E2E PASSED" : "\nFENCE RENDER E2E FAILED");

--- a/web/src/components/PluginFenceBlock.tsx
+++ b/web/src/components/PluginFenceBlock.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { renderFence } from "../plugin-fence";
+import { THEME_CHANGE_EVENT } from "../theme";
 import { CopyButton } from "./copy-button";
 
 /**
@@ -15,7 +16,18 @@ import { CopyButton } from "./copy-button";
  */
 export function PluginFenceBlock({ lang, code }: { lang: string; code: string }) {
 	const holderRef = useRef<HTMLDivElement>(null);
+	const elRef = useRef<HTMLElement | null>(null);
 	const [el, setEl] = useState<HTMLElement | null>(null);
+
+	useEffect(() => {
+		elRef.current = el;
+	}, [el]);
+
+	useEffect(() => {
+		const updateTheme = () => elRef.current?.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT));
+		window.addEventListener(THEME_CHANGE_EVENT, updateTheme);
+		return () => window.removeEventListener(THEME_CHANGE_EVENT, updateTheme);
+	}, []);
 
 	useEffect(() => {
 		let cancelled = false;

--- a/web/src/components/PluginFenceBlock.tsx
+++ b/web/src/components/PluginFenceBlock.tsx
@@ -17,23 +17,29 @@ import { CopyButton } from "./copy-button";
 export function PluginFenceBlock({ lang, code }: { lang: string; code: string }) {
 	const holderRef = useRef<HTMLDivElement>(null);
 	const elRef = useRef<HTMLElement | null>(null);
+	const themeVersionRef = useRef(0);
+	const renderedThemeVersionRef = useRef(new WeakMap<HTMLElement, number>());
 	const [el, setEl] = useState<HTMLElement | null>(null);
 
 	useEffect(() => {
-		elRef.current = el;
-	}, [el]);
-
-	useEffect(() => {
-		const updateTheme = () => elRef.current?.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT));
+		const updateTheme = () => {
+			const version = ++themeVersionRef.current;
+			const current = elRef.current;
+			if (!current) return;
+			current.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT));
+			renderedThemeVersionRef.current.set(current, version);
+		};
 		window.addEventListener(THEME_CHANGE_EVENT, updateTheme);
 		return () => window.removeEventListener(THEME_CHANGE_EVENT, updateTheme);
 	}, []);
 
 	useEffect(() => {
 		let cancelled = false;
+		const requestedThemeVersion = themeVersionRef.current;
 		setEl(null);
 		renderFence(lang, code).then((result) => {
 			if (cancelled) return;
+			if (result) renderedThemeVersionRef.current.set(result, requestedThemeVersion);
 			setEl(result);
 		});
 		return () => {
@@ -43,11 +49,25 @@ export function PluginFenceBlock({ lang, code }: { lang: string; code: string })
 
 	// holder div 渲染完成后把产物挂进去（replaceChildren 兜底防重复挂载）。
 	useEffect(() => {
+		elRef.current = el;
 		const holder = holderRef.current;
 		if (holder) {
 			holder.replaceChildren();
-			if (el) holder.appendChild(el);
+			if (el) {
+				holder.appendChild(el);
+				// A theme change can arrive while renderFence is still pending, before
+				// elRef exists. Catch the new element up only after it is connected so
+				// plugin renderers can atomically replace their mounted output.
+				const renderedVersion = renderedThemeVersionRef.current.get(el) ?? themeVersionRef.current;
+				if (renderedVersion < themeVersionRef.current) {
+					el.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT));
+					renderedThemeVersionRef.current.set(el, themeVersionRef.current);
+				}
+			}
 		}
+		return () => {
+			if (elRef.current === el) elRef.current = null;
+		};
 	}, [el]);
 
 	if (!el) {

--- a/web/src/plugin-loader.ts
+++ b/web/src/plugin-loader.ts
@@ -37,10 +37,7 @@ export interface FenceRenderContext {
 /** 插件把 ```lang 围栏渲染成自定义 DOM 的工厂函数。返回 null 表示不渲染
  *  （回退普通代码块）。可以是任意技术栈——主应用只负责把返回的 DOM 挂进
  *  消息流，不共享 React 实例。 */
-export type FenceRenderer = (
-	code: string,
-	ctx: FenceRenderContext,
-) => HTMLElement | null | Promise<HTMLElement | null>;
+export type FenceRenderer = (code: string, ctx: FenceRenderContext) => HTMLElement | null | Promise<HTMLElement | null>;
 
 export interface PluginViewModule {
 	mount(container: HTMLElement, ctx: PluginViewContext): void | (() => void);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4576,20 +4576,25 @@ span.msg-editor-hint svg {
 	border-color: var(--accent);
 }
 
-/* Mermaid diagrams: own light "paper" card so charts stay readable under both
-   app themes (mermaid always renders with its light base theme, see
-   web/src/components/MermaidBlock.tsx). */
+/* Mermaid diagrams track the active app palette. The renderer plugin bakes the
+   current CSS variables into each SVG and marks dark renders for their elevated
+   panel background (plugins/mermaid/client/entry.mjs). */
 .mermaid-block {
 	position: relative;
 	margin: 10px 0;
 	padding: 12px;
-	background: #ffffff;
+	background: var(--bg);
 	border: 1px solid var(--border);
 	border-radius: 8px;
+	color-scheme: light;
 }
 /* Mermaid sizes its root <svg> to the drawn diagram (inline width/height), so
    small diagrams stay small — do NOT force them to the container width. Only
    oversized renders need scrolling. */
+.mermaid-block[data-mermaid-dark] {
+	background: var(--bg-elev2);
+	color-scheme: dark;
+}
 .mermaid-svg {
 	overflow-x: auto;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -41,6 +41,7 @@
 	--term-bright-cyan: #22d3ee;
 	--term-bright-white: #ffffff;
 	--mono: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, Consolas, monospace;
+	--mermaid-font-size: 12px;
 	--sans:
 		-apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", Roboto,
 		Helvetica, Arial, sans-serif;
@@ -4587,6 +4588,7 @@ span.msg-editor-hint svg {
 	border: 1px solid var(--border);
 	border-radius: 8px;
 	color-scheme: light;
+	font-size: var(--mermaid-font-size);
 }
 /* Mermaid sizes its root <svg> to the drawn diagram (inline width/height), so
    small diagrams stay small — do NOT force them to the container width. Only
@@ -4601,6 +4603,13 @@ span.msg-editor-hint svg {
 .mermaid-svg svg {
 	display: block;
 	margin: 0 auto;
+}
+/* Mermaid hard-codes some diagram titles to 18px and ER foreignObject edge
+   labels inherit the 14px body size. Keep both at the configured Mermaid size
+   while retaining smaller axis/helper labels. */
+.mermaid-svg svg .titleText,
+.mermaid-svg svg foreignObject .edgeLabel {
+	font-size: var(--mermaid-font-size) !important;
 }
 .mermaid-note {
 	font-size: 12px;


### PR DESCRIPTION
## Summary
- derive Mermaid backgrounds, text, borders, and accents from the active UI theme in the pluginized renderer
- re-render mounted diagrams on every live theme change, including dark-to-dark switches
- keep the previous SVG mounted until its replacement is ready so reading position does not jump
- catch up theme changes that arrive while an initial render or source update is still pending
- normalize Mermaid's primary labels and titles to 12px across diagram types
- serialize Mermaid global `initialize()` + `render()` operations and clean up temporary render DOM on success and failure
- preserve raw-code fallback and allow a corrected diagram to render after an earlier parse failure

## Architecture
This branch is rebased onto the Mermaid renderer-plugin architecture introduced in `5c8be7d`. The implementation lives in `plugins/mermaid/client/entry.mjs`; it does not restore the removed `MermaidBlock` component. The generic fence host forwards theme notifications to mounted plugin DOM and records theme versions so elements returned after a theme change receive a catch-up notification. Unrelated renderer plugins are not executed again.

## Verification
- `npm run typecheck`
- `npm test` (38 files, 355 tests)
- `npm run lint` (passes with 5 pre-existing warnings)
- `npm run format:check`
- `npm run build`
- `node tests/fence-render-test.mjs`

Playwright assertions cover local/offline Mermaid loading, dark-to-dark palette changes, dark-to-light palette changes, a delayed initial render that switches to white before the renderer returns, replacement SVG IDs, 12px computed font sizes for flowchart, sequence, ER, and Gantt labels/titles, the previous SVG remaining mounted during async theme rendering, stable non-zero message-list `scrollTop`, invalid-to-valid recovery, serialized-render recovery, and zero orphan render containers.