### PR TITLE
feat(ui): show project name in browser tab title / 浏览器标题显示项目名

### DIFF
--- a/tests/unit/title-settings.test.ts
+++ b/tests/unit/title-settings.test.ts
@@ -1,0 +1,44 @@
+/**
+ * 标题显示项目名开关的纯函数单测（见 web/src/title-settings.ts）。
+ * 只测 normalizeTitleSettings / projectNameFromCwd —— localStorage 存取在 node 环境
+ * 不可用，load/save 都有 try/catch 兜底，不在单测范围内。
+ */
+import { describe, expect, it } from "vitest";
+import { DEFAULT_TITLE_SETTINGS, normalizeTitleSettings, projectNameFromCwd } from "../../web/src/title-settings.js";
+
+describe("normalizeTitleSettings", () => {
+	it("非对象回退默认（默认关闭）", () => {
+		expect(normalizeTitleSettings(null)).toEqual(DEFAULT_TITLE_SETTINGS);
+		expect(normalizeTitleSettings(undefined)).toEqual(DEFAULT_TITLE_SETTINGS);
+		expect(normalizeTitleSettings("yes")).toEqual(DEFAULT_TITLE_SETTINGS);
+		expect(normalizeTitleSettings(1)).toEqual(DEFAULT_TITLE_SETTINGS);
+	});
+
+	it("保留合法的布尔值", () => {
+		expect(normalizeTitleSettings({ projectName: true })).toEqual({ projectName: true });
+		expect(normalizeTitleSettings({ projectName: false })).toEqual({ projectName: false });
+	});
+
+	it("字段类型错误/缺失回退默认", () => {
+		expect(normalizeTitleSettings({ projectName: "yes" })).toEqual(DEFAULT_TITLE_SETTINGS);
+		expect(normalizeTitleSettings({})).toEqual(DEFAULT_TITLE_SETTINGS);
+		expect(normalizeTitleSettings({ other: true })).toEqual(DEFAULT_TITLE_SETTINGS);
+	});
+});
+
+describe("projectNameFromCwd", () => {
+	it("取末级目录名", () => {
+		expect(projectNameFromCwd("/Users/me/code/pi-web-ui")).toBe("pi-web-ui");
+		expect(projectNameFromCwd("C:\\work\\pi-web-ui")).toBe("pi-web-ui");
+	});
+
+	it("容忍尾随分隔符", () => {
+		expect(projectNameFromCwd("/Users/me/code/pi-web-ui/")).toBe("pi-web-ui");
+		expect(projectNameFromCwd("C:\\work\\pi-web-ui\\\\")).toBe("pi-web-ui");
+	});
+
+	it("空串 / 根目录返回空", () => {
+		expect(projectNameFromCwd("")).toBe("");
+		expect(projectNameFromCwd("/")).toBe("");
+	});
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,6 +42,7 @@ import { fileToProcessedImage, isRasterImage, type ProcessedImage } from "./imag
 import { randomUuid } from "./uuid";
 import { loadSoundSettings, playSound, saveSoundSettings, type SoundKind, type SoundSettings } from "./sounds";
 import { useWideChat } from "./chat-width-settings";
+import { projectNameFromCwd, useProjectTitle } from "./title-settings";
 import { notify } from "./notify";
 import { useTheme } from "./theme";
 
@@ -181,6 +182,13 @@ export function App() {
 			send({ type: "set_settings", quickPhrases: QUICK_PHRASE_DEFAULTS[locale] });
 		}
 	}, [chat.ready, chat.settings, send, locale]);
+	// 浏览器标题：开关开启时显示当前项目（工作目录文件夹名），否则固定应用名。
+	const cwd = chat.state?.cwd ?? "";
+	const projectTitle = useProjectTitle();
+	useEffect(() => {
+		const name = projectTitle ? projectNameFromCwd(cwd) : "";
+		document.title = name ? `${name} — pi-web-ui` : t("docTitle");
+	}, [cwd, projectTitle, t]);
 	const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
 	const [previewFile, setPreviewFile] = useState<PreviewFile | null>(null);
 	/** Full-window file drag in progress (issue #19) — shows the app-wide

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -43,6 +43,7 @@ import {
 } from "../prompt-history";
 import { randomUuid } from "../uuid";
 import { useWideChat, saveChatWidthSettings } from "../chat-width-settings";
+import { useProjectTitle, saveTitleSettings } from "../title-settings";
 import { useT, useI18n } from "../i18n";
 import { QUICK_PHRASE_DEFAULTS } from "../quick-phrases";
 import { DEFAULT_PROMPT_TEMPLATE, PROMPT_TOKENS } from "../../../server/prompt-composer.js";
@@ -237,6 +238,7 @@ export function SettingsModal({ chat, send, terminal, onSwitchToTerminal, onClos
 	const [showFullPrompt, setShowFullPrompt] = useState(false);
 	// 宽屏聊天列开关（纯前端 localStorage，见 chat-width-settings.ts）。
 	const wideChat = useWideChat();
+	const projectTitle = useProjectTitle();
 	// Prompt history settings (纯前端 localStorage，不经过 server).
 	const [phSettings, setPhSettings] = useState(() => loadPromptHistorySettings());
 	const [phCount, setPhCount] = useState(() => {
@@ -1016,6 +1018,12 @@ export function SettingsModal({ chat, send, terminal, onSwitchToTerminal, onClos
 									tip={t("wideChatDesc")}
 									enabled={wideChat}
 									onToggle={() => saveChatWidthSettings({ wide: !wideChat })}
+								/>
+								<ToggleRow
+									title={t("projectTitle")}
+									tip={t("projectTitleDesc")}
+									enabled={projectTitle}
+									onToggle={() => saveTitleSettings({ projectName: !projectTitle })}
 								/>
 							</div>
 						)}

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -832,6 +832,9 @@ const zh = {
 	toolsWrapDesc: "开启：工具调用始终完整展开显示参数和输出；关闭：默认折叠，点击展开",
 	wideChat: "宽屏聊天列",
 	wideChatDesc: "开启：中央列铺满宽度（超宽屏有用）；关闭：保持 860px 上限",
+	projectTitle: "标题显示项目名",
+	projectTitleDesc:
+		"开启：浏览器标签页标题为「项目目录名 — pi-web-ui」，切项目即时更新（多标签页开多个项目时好区分）；关闭：固定显示应用名",
 	terminalBashTakeover: "终端接管 bash",
 	terminalBashTakeoverDesc:
 		"此开关决定 bash 是否覆盖为终端版：关 = 原生 SDK bash（纯进程、不开终端）；开 = 跑进可见终端，且 persist 参数在本开关的基础上决定一次性（false，命令跑完进程退出、输出留档）还是持久（true，shell 状态跨调用保留、静默自动转后台并通知 AI）",
@@ -1773,6 +1776,9 @@ const en: Record<keyof typeof zh, string> = {
 		"On: tool calls always expand fully showing arguments and output; Off: collapsed by default, click to expand",
 	wideChat: "Wide chat column",
 	wideChatDesc: "On: the center column fills the width (useful on ultrawide monitors); Off: keep the 860px cap",
+	projectTitle: "Show project name in title",
+	projectTitleDesc:
+		"On: the browser tab title becomes “<project folder> — pi-web-ui” and updates when you switch projects (handy with several tabs open); Off: always show the app name",
 	terminalBashTakeover: "Terminal-backed bash",
 	terminalBashTakeoverDesc:
 		"This switch decides whether bash is overridden to a terminal version: OFF = native SDK bash (process spawn, no terminal); ON = runs in a visible terminal, where the persist parameter decides (on top of the switch) one-shot (false — process exits when the command finishes, output retained) vs persistent (true — shell state retained across calls, silent commands move to the background and notify the AI)",
@@ -1925,7 +1931,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 
 	useEffect(() => {
 		document.documentElement.lang = locale === "zh" ? "zh-CN" : "en";
-		document.title = locale === "zh" ? zh.docTitle : en.docTitle;
+		// 标题由 App 统一维护（项目名优先，见 App.tsx 的 document.title effect）。
 	}, [locale]);
 
 	const value = useMemo(() => ({ locale, setLocale, t }), [locale, setLocale, t]);

--- a/web/src/title-settings.ts
+++ b/web/src/title-settings.ts
@@ -1,0 +1,87 @@
+/// <reference lib="dom" />
+/**
+ * 浏览器标题显示项目名开关（纯前端 localStorage，不经过 server）。
+ *
+ * - 默认关闭：标题保持 `t("docTitle")`（与旧版本行为一致）。
+ * - 开启后：标题为 `<工作目录文件夹名> — pi-web-ui`，切项目（set_cwd）即时更新。
+ * - normalize/load/projectNameFromCwd 为纯函数，可单测（tests/unit/title-settings.test.ts）。
+ *
+ * 与 chat-width-settings.ts 同构：都是"只影响浏览器端呈现"的偏好，
+ * 没必要进 server 的 settings 快照。
+ */
+
+import { useSyncExternalStore } from "react";
+
+export const TITLE_SETTINGS_KEY = "pi-web-ui:project-title";
+
+export interface TitleSettings {
+	/** 浏览器标题是否显示当前项目名（false = 固定应用名） */
+	projectName: boolean;
+}
+
+export const DEFAULT_TITLE_SETTINGS: TitleSettings = { projectName: false };
+
+/** 规整设置值：非对象 / 字段类型错误一律回退默认值。 */
+export function normalizeTitleSettings(raw: unknown): TitleSettings {
+	if (!raw || typeof raw !== "object") return { ...DEFAULT_TITLE_SETTINGS };
+	const o = raw as Record<string, unknown>;
+	return {
+		projectName: typeof o.projectName === "boolean" ? o.projectName : DEFAULT_TITLE_SETTINGS.projectName,
+	};
+}
+
+/**
+ * 从工作目录取项目名（末级文件夹名）。
+ * 兼容 POSIX / Windows 分隔符，容忍尾随分隔符；根目录 / 空串返回 ""。
+ */
+export function projectNameFromCwd(cwd: string): string {
+	if (!cwd) return "";
+	const trimmed = cwd.replace(/[\\/]+$/, "");
+	const name = trimmed.split(/[\\/]/).pop() ?? "";
+	return name;
+}
+
+/** 读取持久化的开关（localStorage 不可用 / 数据损坏时回退默认关闭）。 */
+export function loadTitleSettings(): TitleSettings {
+	try {
+		const raw = localStorage.getItem(TITLE_SETTINGS_KEY);
+		if (!raw) return { ...DEFAULT_TITLE_SETTINGS };
+		return normalizeTitleSettings(JSON.parse(raw));
+	} catch {
+		return { ...DEFAULT_TITLE_SETTINGS };
+	}
+}
+
+/** 保存并广播变更（localStorage 不可写时静默忽略）。 */
+export function saveTitleSettings(s: TitleSettings): void {
+	const norm = normalizeTitleSettings(s);
+	try {
+		localStorage.setItem(TITLE_SETTINGS_KEY, JSON.stringify(norm));
+	} catch {
+		/* ignore */
+	}
+	cached = norm;
+	for (const l of listeners) l();
+}
+
+// ---- 订阅：单例 listener 集合。----------------------------------------------
+
+let cached: TitleSettings | null = null;
+const listeners = new Set<() => void>();
+
+function subscribe(onStoreChange: () => void): () => void {
+	listeners.add(onStoreChange);
+	return () => {
+		listeners.delete(onStoreChange);
+	};
+}
+
+function getSnapshot(): boolean {
+	if (!cached) cached = loadTitleSettings();
+	return cached.projectName;
+}
+
+/** 标题当前是否显示项目名（设置面板切换后即时生效，无需刷新）。 */
+export function useProjectTitle(): boolean {
+	return useSyncExternalStore(subscribe, getSnapshot);
+}


### PR DESCRIPTION
## Why / 动机

Opening several projects in several browser tabs is a common workflow, but every
tab shows the identical title "pi-web-ui — pi 编码智能体", so you cannot tell
which tab belongs to which project without switching to it. Showing the project
folder name in the tab title (and in the OS window/taskbar entry) makes them
distinguishable at a glance.

在浏览器中同时打开多个项目是常见用法，但每个标签页的标题都是同一个
「pi-web-ui — pi 编码智能体」，不点进去就无法分辨是哪个项目。把项目目录名放进标题
（同时也会体现在窗口/任务栏），一眼就能区分。

## What / 改动

- New opt-in toggle **Settings → Message display → “标题显示项目名 / Show project name in title”**. Off by default: existing behaviour unchanged.
- When on, the title becomes `<project folder> — pi-web-ui`, follows `state.cwd` and updates immediately on `set_cwd`.
- `web/src/title-settings.ts`: pure-frontend localStorage preference, modelled exactly on `chat-width-settings.ts` (normalize / load / save + `useSyncExternalStore` hook). No wire-protocol or server-settings change, so the preference stays per-browser and does not affect other clients.
- `LanguageProvider` no longer sets `document.title`: it is the parent of `App`, so its effect runs later and would overwrite the project name; `App.tsx` is now the single owner (falls back to `t("docTitle")` when the toggle is off).
- i18n keys added for both zh and en.

## Tests / 验证

- `npm run typecheck` ✅
- `npx vitest run tests/unit/title-settings.test.ts` → 6 passed ✅
  (normalize fallbacks + `projectNameFromCwd`: POSIX/Windows separators, trailing separators, root/empty)
- `npx prettier --check` on the touched files ✅
- `oxlint` no new warnings ✅

## Diff size / 改动量

3 files changed (+23 −1) plus 2 new files; the single deleted line is the
`document.title` assignment in `i18n.tsx` described above.
