### PR TITLE
fix(webmail): never drop the password when secret storage fails / 修复邮件插件保存后密码丢失

### DIFF
--- a/plugins/webmail/README.md
+++ b/plugins/webmail/README.md
@@ -30,6 +30,11 @@ auth.json 同级安全模型）：
 
 配置回显脱敏：只返回 `hasPass` 是否存在，密码不回传浏览器。
 
+密码优先存宿主的加密机密（`host.secrets`，AES-256-GCM →
+`<pluginDir>/secrets.bin`），写入成功后 config.json 里的 `pass` 为空。
+旧版宿主没有机密设施、或机密写盘失败（目录只读 / 磁盘满）时，密码会
+回退为明文写进 config.json 并提示一次——宁可明文，也不能保存后丢密码。
+
 ## 安装 / 卸载 / 更新
 
 ```bash

--- a/plugins/webmail/index.mjs
+++ b/plugins/webmail/index.mjs
@@ -54,8 +54,8 @@ async function loadConfig(dir) {
 		return {
 			...structuredClone(DEFAULT_CONFIG),
 			...parsed,
-			imap: { ...DEFAULT_CONFIG.imap, ...(parsed.imap ?? {}) },
-			smtp: { ...DEFAULT_CONFIG.smtp, ...(parsed.smtp ?? {}) },
+			imap: { ...DEFAULT_CONFIG.imap, ...parsed.imap },
+			smtp: { ...DEFAULT_CONFIG.smtp, ...parsed.smtp },
 		};
 	} catch {
 		return structuredClone(DEFAULT_CONFIG);
@@ -100,13 +100,41 @@ export default {
 		// ------------------------------------------------------------------
 		// 配置与状态
 		// ------------------------------------------------------------------
-		// 机密存储：密码走宿主 host.secrets（AES-256-GCM 加密，明文绝不落盘）；
-		// 旧版宿主无此设施时回退旧的明文 config.json 行为。首次启动把历史
-		// 明文密码一次性迁入机密并从文件剥离。
+		// 机密存储：密码优先走宿主 host.secrets（AES-256-GCM 加密）；旧版宿主无此
+		// 设施、或写入失败（目录只读 / 磁盘满）时回退旧的明文 config.json 行为。
+		// 关键不变式：密码只要没确认存进机密，就绝不从内存/配置文件里抹掉——
+		// 否则会出现“保存后密码消失、IMAP 报 No password configured”。
 		const sec = host.secrets;
+		/** 机密写入是否降级到明文（只提示一次，不刷屏）。 */
+		let secretsDegradedWarned = false;
 
-		/** 从 config.json 读非敏感字段后：剥离文件里的历史明文密码入机密、
-		 *  再用机密回填内存副本（内存需要真实密码供 IMAP/SMTP 连接）。 */
+		/** 写机密并回读校验：宿主的 set() 写盘失败时只记日志不抛错，
+		 *  只有回读到相同值才能确认真的存住了。失败返回 false → 调用方保留明文。 */
+		function storeSecret(name, value) {
+			if (!sec?.set || !value) return false;
+			try {
+				sec.set(name, String(value));
+				return sec.get?.(name) === String(value);
+			} catch (err) {
+				host.log(`机密写入失败 ${name}:`, err?.message ?? err);
+				return false;
+			}
+		}
+
+		/** 机密不可用时提醒一次：密码仍会保存，但是明文存在 config.json。 */
+		function warnSecretsDegraded() {
+			if (secretsDegradedWarned) return;
+			secretsDegradedWarned = true;
+			host.log("加密存储不可用，密码以明文保存在 config.json");
+			host.notify(
+				"warning",
+				"📬 邮件插件：加密存储不可用，密码已以明文保存在 config.json（功能不受影响）",
+				"Webmail: encrypted storage unavailable — the password was saved as plain text in config.json (functionality unaffected)",
+			);
+		}
+
+		/** 从 config.json 读非敏感字段后：把历史明文密码迁入机密（确认成功才从
+		 *  文件里剥离），再用机密回填内存副本（内存需要真实密码供 IMAP/SMTP 连接）。 */
 		async function loadConfigSecure() {
 			const cfg = await loadConfig(host.dir);
 			if (sec?.set) {
@@ -116,10 +144,13 @@ export default {
 					["smtp", "smtp_pass"],
 				]) {
 					const legacy = cfg?.[sect]?.pass;
-					if (legacy) {
-						try { sec.set(secretName, String(legacy)); } catch {}
+					if (!legacy) continue;
+					// 校验通过才能剥离明文，否则迁移会把唯一的密码删掉。
+					if (storeSecret(secretName, legacy)) {
 						cfg[sect].pass = "";
 						migrated = true;
+					} else {
+						warnSecretsDegraded();
 					}
 				}
 				if (migrated) {
@@ -179,24 +210,25 @@ export default {
 		}
 
 		async function applyConfig(next) {
-			if (sec?.set) {
-				// 密码语义：留空(undefined/"") = 沿用已存；有值 = 更新。配置文件
-				// 与notice均不落明文——机密只进 host.secrets。
-				if (next.imap.pass) {
-					try { sec.set("imap_pass", String(next.imap.pass)); } catch {}
-					next.imap.pass = "";
-				}
-				if (next.smtp.pass) {
-					try { sec.set("smtp_pass", String(next.smtp.pass)); } catch {}
-					next.smtp.pass = "";
-				}
-			} else {
-				// 旧宿主兜底：沿用旧明文行为（留空沿用已存值）
-				next.imap.pass = next.imap.pass || st.config?.imap?.pass || "";
-				next.smtp.pass = next.smtp.pass || st.config?.smtp?.pass || "";
+			// 1) 密码语义：留空(undefined/"") = 沿用已存（内存 → 机密）；有值 = 更新。
+			next.imap.pass = next.imap.pass || st.config?.imap?.pass || sec?.get?.("imap_pass") || "";
+			next.smtp.pass = next.smtp.pass || st.config?.smtp?.pass || sec?.get?.("smtp_pass") || "";
+			// 2) 落盘副本：确认写进机密的密码才从 config.json 剥离；机密不可用/写失败
+			//    时保留明文（旧宿主行为）——宁可明文，不能丢密码。
+			const onDisk = structuredClone(next);
+			let degraded = false;
+			for (const [sect, secretName] of [
+				["imap", "imap_pass"],
+				["smtp", "smtp_pass"],
+			]) {
+				if (!next[sect].pass) continue;
+				if (storeSecret(secretName, next[sect].pass)) onDisk[sect].pass = "";
+				else degraded = true;
 			}
-			st.config = await rehydrate(next);
-			await saveConfig(host.dir, next);
+			if (degraded && sec?.set) warnSecretsDegraded();
+			// 3) 内存副本始终持有真实密码（IMAP/SMTP 连接靠它）。
+			st.config = next;
+			await saveConfig(host.dir, onDisk);
 			if (!st.depsOk && next.imap?.host) installDeps(true); // 刚配置好账号但缺依赖 → 自动补装
 			restartPoller();
 			await refreshAiTools();
@@ -728,8 +760,8 @@ export default {
 							await applyConfig({
 								...structuredClone(DEFAULT_CONFIG),
 								...msg.config,
-								imap: { ...DEFAULT_CONFIG.imap, ...(msg.config?.imap ?? {}) },
-								smtp: { ...DEFAULT_CONFIG.smtp, ...(msg.config?.smtp ?? {}) },
+								imap: { ...DEFAULT_CONFIG.imap, ...msg.config?.imap },
+								smtp: { ...DEFAULT_CONFIG.smtp, ...msg.config?.smtp },
 							});
 							host.sendTo(from, { kind: "result", ok: true, action: "save_config" });
 							host.notify("info", "📬 邮箱配置已保存并生效");

--- a/tests/unit/webmail-secrets.test.ts
+++ b/tests/unit/webmail-secrets.test.ts
@@ -1,0 +1,198 @@
+/**
+ * webmail 插件密码持久化回归（见 plugins/webmail/index.mjs）。
+ *
+ * 修复前：applyConfig 无条件把密码写进 host.secrets 后从内存里抹掉；宿主机密写盘
+ * 失败（目录只读/磁盘满，PluginSecrets.set 只 console.error 不抛错）时密码既没进
+ * 机密也没留在配置里 —— 表现为「保存后设置里密码没了 + IMAP 报 No password
+ * configured」。本测试锁定三条不变式：
+ *   1. 机密可用：密码存机密，config.json 不落明文；
+ *   2. 机密写入失败：回退明文落盘，绝不丢密码；
+ *   3. 二次保存留空 = 沿用已存密码。
+ *
+ * 插件在缺依赖时会自动 npm install：这里把 npm 指向不可用 registry + offline，
+ * 让子进程立刻失败（无网络访问），并在断言后 deactivate 一并回收。
+ */
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+
+const PLUGIN = pathToFileURL(join(process.cwd(), "plugins/webmail/index.mjs")).href;
+
+// 让插件的自动依赖安装立刻失败：不联网、不污染 CI。
+process.env.npm_config_offline = "true";
+process.env.npm_config_registry = "http://127.0.0.1:9/";
+process.env.npm_config_audit = "false";
+process.env.npm_config_fund = "false";
+
+/** 插件回传的脱敏配置分节（只断言用得到的字段）。 */
+interface PublicSection {
+	user: string;
+	hasPass: boolean;
+}
+interface PublicState {
+	configured: boolean;
+	config: { imap: PublicSection; smtp: PublicSection };
+}
+interface PluginMessage {
+	kind?: string;
+	state?: PublicState;
+}
+/** config.json 落盘形态（只关心密码字段）。 */
+interface StoredConfig {
+	imap?: { pass?: string };
+	smtp?: { pass?: string };
+}
+/** 视图 → 插件的消息。 */
+interface ViewMessage {
+	action: string;
+	config?: unknown;
+}
+type PluginModule = { default: { activate: (host: unknown) => () => void } };
+
+interface Harness {
+	send: (msg: ViewMessage) => void;
+	state: () => PublicState | null;
+	configFile: () => StoredConfig | null;
+	stop: () => void;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** 起一个插件实例：dir/secrets 由调用方提供，可跨实例复用以模拟重启。 */
+async function activate(dir: string, secrets: Map<string, string>, failSecretWrites = false): Promise<Harness> {
+	const mod = (await import(PLUGIN)) as PluginModule;
+	const sent: PluginMessage[] = [];
+	let handler: ((msg: ViewMessage, from?: string) => void) | null = null;
+	const host = {
+		dir,
+		log: () => {},
+		notify: () => {},
+		broadcast: (p: PluginMessage) => sent.push(p),
+		sendTo: (_clientId: string, p: PluginMessage) => sent.push(p),
+		onMessage: (h: (msg: ViewMessage, from?: string) => void) => {
+			handler = h;
+			return () => {};
+		},
+		onToolEvent: () => () => {},
+		onAttach: () => () => {},
+		onCwdChange: () => () => {},
+		registerAgentTool: () => () => {},
+		registerBackgroundTask: () => ({ unregister() {} }),
+		storage: { get: () => undefined, set() {}, delete() {}, all: () => ({}) },
+		secrets: {
+			set: (n: string, v: string) => {
+				if (failSecretWrites) return; // 静默失败：与宿主写盘失败同形
+				secrets.set(n, String(v));
+			},
+			get: (n: string) => secrets.get(n),
+			has: (n: string) => secrets.has(n),
+			delete: (n: string) => secrets.delete(n),
+			list: () => [...secrets.keys()],
+		},
+	};
+	const dispose = mod.default.activate(host);
+	await sleep(120);
+	return {
+		send: (msg) => handler?.(msg, "c1"),
+		state: () => {
+			for (let i = sent.length - 1; i >= 0; i--) {
+				const m = sent[i];
+				if (m?.kind === "state" && m.state) return m.state;
+			}
+			return null;
+		},
+		configFile: () => {
+			const f = join(dir, "config.json");
+			return existsSync(f) ? (JSON.parse(readFileSync(f, "utf8")) as StoredConfig) : null;
+		},
+		stop: () => dispose(),
+	};
+}
+
+function fullConfig(pass?: string): unknown {
+	const imap = { host: "imap.example.com", port: 993, tls: true, user: "u@example.com", ...(pass ? { pass } : {}) };
+	const smtp = {
+		host: "smtp.example.com",
+		port: 465,
+		tls: true,
+		user: "u@example.com",
+		from: "u@example.com",
+		...(pass ? { pass } : {}),
+	};
+	return { imap, smtp, pollSec: 60, notifyEnabled: true, aiEnabled: false };
+}
+
+const dirs: string[] = [];
+function tempDir(): string {
+	const d = mkdtempSync(join(tmpdir(), "webmail-test-"));
+	dirs.push(d);
+	return d;
+}
+
+afterAll(() => {
+	for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+describe("webmail 密码持久化", () => {
+	it("机密可用：密码入机密、config.json 不落明文、重启后仍在", async () => {
+		const dir = tempDir();
+		const secrets = new Map<string, string>();
+		let h = await activate(dir, secrets);
+		h.send({ action: "save_config", config: fullConfig("SECRET123") });
+		await sleep(200);
+		h.send({ action: "get_state" });
+		await sleep(50);
+
+		expect(h.state()?.config?.imap?.hasPass).toBe(true);
+		expect(h.configFile()?.imap?.pass).toBe(""); // 明文不落盘
+		expect(secrets.get("imap_pass")).toBe("SECRET123");
+		h.stop();
+
+		// 重启：机密回填内存副本
+		h = await activate(dir, secrets);
+		h.send({ action: "get_state" });
+		await sleep(50);
+		expect(h.state()?.config?.imap?.hasPass).toBe(true);
+		h.stop();
+	});
+
+	it("机密写入失败：回退明文落盘，密码不丢（修复前会丢）", async () => {
+		const dir = tempDir();
+		const secrets = new Map<string, string>();
+		let h = await activate(dir, secrets, true);
+		h.send({ action: "save_config", config: fullConfig("SECRET123") });
+		await sleep(200);
+		h.send({ action: "get_state" });
+		await sleep(50);
+
+		expect(h.state()?.config?.imap?.hasPass).toBe(true);
+		expect(h.configFile()?.imap?.pass).toBe("SECRET123"); // 宁可明文，不能丢
+		expect(h.configFile()?.smtp?.pass).toBe("SECRET123");
+		h.stop();
+
+		// 重启后依然可用（否则 IMAP 会报 No password configured）
+		h = await activate(dir, secrets, true);
+		h.send({ action: "get_state" });
+		await sleep(50);
+		expect(h.state()?.config?.imap?.hasPass).toBe(true);
+		h.stop();
+	});
+
+	it("二次保存留空 = 沿用已存密码", async () => {
+		const dir = tempDir();
+		const secrets = new Map<string, string>();
+		const h = await activate(dir, secrets);
+		h.send({ action: "save_config", config: fullConfig("SECRET123") });
+		await sleep(200);
+		h.send({ action: "save_config", config: fullConfig() }); // 密码框留空
+		await sleep(200);
+		h.send({ action: "get_state" });
+		await sleep(50);
+
+		expect(h.state()?.config?.imap?.hasPass).toBe(true);
+		expect(secrets.get("imap_pass")).toBe("SECRET123");
+		h.stop();
+	});
+});


### PR DESCRIPTION
## Symptom / 问题现象

Saving the webmail account settings could silently drop the password: the
settings form came back with an empty password field and every IMAP connection
failed with ImapFlow's `No password configured`.

保存 webmail 邮箱设置后密码丢失：设置面板里密码变回空，IMAP 连接一直报
ImapFlow 的 `No password configured`。

## Root cause / 根因

`applyConfig()` wrote the password into `host.secrets` and then cleared it from
the in-memory config **unconditionally**:

```js
if (next.imap.pass) {
	try { sec.set("imap_pass", String(next.imap.pass)); } catch {}
	next.imap.pass = "";   // ← cleared even when the write never landed
}
```

The host's `PluginSecrets.set()` does not throw when the write fails
(read-only plugin dir, full disk, …) — it only `console.error`s — so the
plugin's `try/catch` cannot see the failure. The password then existed nowhere:
not in `secrets.bin`, not in `config.json`, not in memory.

`loadConfigSecure()` had the same one-way migration: it stripped the legacy
plain-text password out of `config.json` even when the secret write had not
actually succeeded, which permanently destroyed the only copy on the next
restart.

`applyConfig()` 把密码写进 `host.secrets` 后**无条件**从内存清空，而宿主的
`PluginSecrets.set()` 写盘失败时只 `console.error`、不抛错，插件的 `try/catch`
根本感知不到失败 —— 密码于是 `secrets.bin`、`config.json`、内存三处皆无。
历史明文迁移是同样的单向逻辑，机密没写成也会把 `config.json` 里唯一的明文密码删掉。

## Fix / 修复

- `storeSecret(name, value)`: write, then **read back and compare**; only a
  verified round-trip counts as stored.
- `applyConfig()`: the in-memory config always keeps the real password;
  `config.json` is stripped **only** when the secret write is verified,
  otherwise the password falls back to the legacy plain-text file (plain text
  beats losing the credential) and the user is warned once via `host.notify`.
- The legacy plain-text migration strips the file copy only after the same
  verification.
- Bonus: on the healthy path the plaintext no longer leaks into `config.json`.
  Before this PR `saveConfig()` received the object that `rehydrate()` had just
  refilled, so the password was written back in clear text even when secrets
  worked.

## Tests / 验证

New `tests/unit/webmail-secrets.test.ts` (offline, no network, temp dirs) locks
three invariants:

1. secrets available → password stored encrypted, `config.json` has `pass: ""`,
   survives a restart;
2. secret writes failing → password falls back to plain text in `config.json`,
   never lost, survives a restart;
3. saving again with an empty password field keeps the stored password.

Against the pre-fix plugin, cases 1 and 2 fail (`expected 'SECRET123' to be ''`
and `expected false to be true`); with the fix all three pass.

- `npm run typecheck` ✅
- `npx vitest run` → 42 files / 390 tests passed ✅

## Compatibility / 兼容性

No protocol or host-API change; existing encrypted secrets keep working, and
setups that already store the password in plain text keep working as before.
