### PR TITLE
fix(terminal): raise the Vite build target so vim works in the web terminal / 修复终端里 vim 无法输入

### DIFF
--- a/tests/unit/vite-build-target.test.ts
+++ b/tests/unit/vite-build-target.test.ts
@@ -1,0 +1,46 @@
+/**
+ * 构建目标回归（见 web/vite.config.ts 的 build.target）。
+ *
+ * 背景：Vite 默认 build.target = "modules"（含 es2020），esbuild 会把逻辑赋值
+ * `r ||= {}` 降级成 `void 0 || (r = {})`，同时把只写不读的 `let r;` 声明当成死代码
+ * 删掉 —— 生成的代码在严格模式 ESM 下抛 ReferenceError。xterm 6 的
+ * `requestMode()`（DECRQM 查询处理）正是这个写法，被坑之后 vim 之类会发 DECRQM 的
+ * TUI 一启动就打断终端解析器，表现为「终端里 vim 无法输入」。
+ *
+ * 因此构建目标必须 ≥ es2021（||= 原生支持）。浏览器下限不变：Chrome 85 /
+ * Safari 14 / Firefox 79 起就支持逻辑赋值。
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CONFIG = join(process.cwd(), "web/vite.config.ts");
+const DIST_ASSETS = join(process.cwd(), "web/dist/assets");
+/** 需要降级 ||= 的目标（会触发 esbuild 丢声明的 bug）。 */
+const LOWERING_TARGETS = /^(es5|es6|es2015|es2016|es2017|es2018|es2019|es2020|modules)$/;
+
+describe("web 构建目标", () => {
+	it("显式设置了 build.target", () => {
+		const src = readFileSync(CONFIG, "utf8");
+		expect(src).toMatch(/\btarget:\s*"[^"]+"/);
+	});
+
+	it("target ≥ es2021，避免 ||= 被降级（xterm requestMode 会因此崩）", () => {
+		const src = readFileSync(CONFIG, "utf8");
+		const target = /\btarget:\s*"([^"]+)"/.exec(src)?.[1] ?? "";
+		expect(target).not.toMatch(LOWERING_TARGETS);
+		const year = /^es(\d{4})$/.exec(target)?.[1];
+		if (year) expect(Number(year)).toBeGreaterThanOrEqual(2021);
+	});
+
+	// 构建产物存在时顺带体检：降级后的枚举 IIFE 调用形态一旦出现即为回归。
+	it("构建产物里没有丢声明的 `))(void 0||(x=` 形态", () => {
+		if (!existsSync(DIST_ASSETS)) return; // 未构建（CI 的 vitest 早于 build）时跳过
+		const offenders: string[] = [];
+		for (const file of readdirSync(DIST_ASSETS).filter((f) => f.endsWith(".js"))) {
+			const code = readFileSync(join(DIST_ASSETS, file), "utf8");
+			if (/\)\)\(void 0\|\|\(/.test(code)) offenders.push(file);
+		}
+		expect(offenders).toEqual([]);
+	});
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -15,6 +15,13 @@ export default defineConfig({
 	build: {
 		outDir: join(__dirname, "dist"),
 		emptyOutDir: true,
+		// 构建目标必须 ≥ es2021（逻辑赋值 ||= 的原生支持）。Vite 默认的
+		// "modules"(=es2020) 会让 esbuild 降级 ||=，而 esbuild 降级 + 压缩写只写
+		// 变量时会丢掉声明：`let r; f(r ||= {})` → `f(void 0 || (r = {}))`，严格模式
+		// 下抛 ReferenceError。xterm 6 的 requestMode() 正是这个写法，被坑后 vim 等
+		// 会发 DECRQM 查询的 TUI 一启动就把终端解析器打断，表现为“终端僵住、
+		// 敲什么都没反应”。浏览器下限不变：||= 在 Chrome 85 / Safari 14 / FF 79 已支持。
+		target: "es2022",
 		rollupOptions: {
 			output: {
 				// 手动分包：大体积第三方库拆出主 chunk，利于浏览器缓存——


### PR DESCRIPTION
## Symptom / 问题现象

Opening `vim` in the Web UI terminal freezes it: the screen stops updating and
typing does nothing. The browser console shows an exception thrown from inside
xterm while parsing the terminal output:

```
ReferenceError: i is not defined
    at Aa.requestMode (assets/xterm-*.js)
    at Ra.parse … at Na._innerWrite …
```

在 Web UI 的终端里打开 vim 后终端僵死：画面不再刷新、敲键盘没有任何反应，
控制台里是 xterm 解析输出时抛出的 `ReferenceError: i is not defined`。

## Root cause / 根因

Not the terminal code — the **production bundle**. Vite's default
`build.target` is `"modules"` (es2020), so esbuild lowers the logical
assignment `r ||= {}`; while lowering, it also drops the write-only
declaration:

```js
// source (xterm 6, TerminalCore.requestMode)
let r;
((P) => (P[P.NOT_RECOGNIZED = 0] = "NOT_RECOGNIZED", …))(r ||= {});

// vite build (target es2020) →  the `let` is gone
((g) => (g[g.NOT_RECOGNIZED = 0] = "NOT_RECOGNIZED", …))(void 0 || (i = {}));
```

Assigning to an undeclared binding throws in strict-mode ESM. `requestMode()`
is the DECRQM (`CSI … $p`) handler, which vim queries on startup, so the
exception propagates out of `_innerWrite()` and the terminal stops applying
any further output — including the echo of everything you type.

Minimal repro of the bundler bug (esbuild 0.25.12):

```
$ echo 'export function f(){let r;(P=>(P[P.A=0]="A"))(r||={});return 42}' > t.mjs
$ npx esbuild t.mjs --format=esm --minify --target=es2022
function e(){let t;return(r=>r[r.A=0]="A")(t||={}),42}   ✅
$ npx esbuild t.mjs --format=esm --minify --target=es2020
function e(){return(r=>r[r.A=0]="A")(void 0||(t={})),42} ❌ t is undeclared
```

## Platform scope / 影响范围

**Not macOS-specific — it hits every OS and browser.** The defect lives in the
generated JS bundle, so it affects the published npm package, the Docker image
and any `npm run build` output equally. `npm run dev` is unminified and was
never affected, which is why it is easy to miss during development.

**不是 macOS 特有的问题：所有系统、所有浏览器都会中招**，因为缺陷在打包产物里
（npm 包 / Docker 镜像 / 任何 `npm run build` 的产物）。`npm run dev` 不压缩，
所以开发时看不到。

## Fix / 修复

`web/vite.config.ts`: set `build.target: "es2022"` so `||=` stays native.

The browser floor does not change: logical assignment ships in Chrome 85,
Safari 14 and Firefox 79. Vite's `"modules"` baseline is
chrome87 / edge88 / safari14 / firefox78 — Firefox 78 was the only reason the
lowering happened at all.

## Tests / 验证

- New `tests/unit/vite-build-target.test.ts`: asserts the target is set and
  ≥ es2021, and (when `web/dist` exists) scans the built assets for the
  dropped-declaration pattern. Reverting the config to `es2020` makes it fail.
- Manual end-to-end in Chromium against a real build: open the terminal tab,
  run `vim /tmp/b.txt`, press `i`, type `hello vim input`, `Esc`, `:wq` —
  the text renders, the file is written, and the console has zero errors.
  Before the fix, the exact same script typed into a frozen screen.
- `npm run typecheck` ✅
- `npx vitest run` → 45 files / 405 tests passed ✅
