### PR TITLE
fix: eliminate all forks from server hot paths — uv_spawn error-pipe deadlock on Android/Termux

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -13,7 +13,7 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, rmSync, statSync, mkdirSync, watch } from "node:fs";
-import { basename, dirname, join, resolve, sep } from "node:path";
+import { basename, delimiter, dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
 	createAgentSessionFromServices,
@@ -2082,63 +2082,32 @@ export class ClientSession {
 	 * probe). Cached machine-wide (same binary for every client) for 10s —
 	 * the check is only rerun after install or when the cache expires.
 	 *
-	 * The probe runs ASYNCHRONOUSLY in the background: this getter serves the
-	 * last known value and never blocks the event loop. It previously used
-	 * spawnSync here, which could deadlock the whole server on Android/Termux:
-	 * fork() inside a multi-threaded process (websocket handlers + snapshot
-	 * serialization are active) occasionally left the forked child stuck
-	 * between fork and exec (futex_wait) while the blocked main thread sat in
-	 * spawnSync's pipe_read — the server kept running but stopped accepting
-	 * connections. Observed reproducibly on Android/Termux (Node 26).
+	 * The probe is FORK-FREE: it scans PATH for the pi executable instead of
+	 * spawning `pi --version`. Do not reintroduce a spawn here — ANY fork on
+	 * the main thread of this multi-threaded server can deadlock the whole
+	 * process on Android/Termux (issue #78): libuv's uv_spawn blocks its
+	 * caller reading the child's error pipe, and that pipe never closes when
+	 * the forked child deadlocks between fork and exec. This applies to
+	 * asynchronous spawns too — the previous async probe reproduced the hang.
 	 */
 	private static piCliProbe: { at: number; installed: boolean } | null = null;
-	private static piCliProbePending = false;
 	private static readonly PI_CLI_PROBE_TTL_MS = 10_000;
 
 	private isPiCliInstalled(): boolean {
 		const now = Date.now();
 		const cached = ClientSession.piCliProbe;
 		if (cached && now - cached.at < ClientSession.PI_CLI_PROBE_TTL_MS) return cached.installed;
-		ClientSession.refreshPiCliProbe();
-		return cached?.installed ?? false;
+		const installed = ClientSession.piCliOnPath();
+		ClientSession.piCliProbe = { at: now, installed };
+		return installed;
 	}
 
-	private static refreshPiCliProbe(): void {
-		if (ClientSession.piCliProbePending) return;
-		ClientSession.piCliProbePending = true;
-		let proc: ReturnType<typeof spawn>;
-		try {
-			proc = spawn("pi", ["--version"], {
-				stdio: "ignore",
-				// Windows: `pi` resolves to a pi.cmd shim — spawn can only
-				// exec those through a shell (else ENOENT).
-				shell: process.platform === "win32",
-			});
-		} catch {
-			ClientSession.piCliProbe = { at: Date.now(), installed: false };
-			ClientSession.piCliProbePending = false;
-			return;
+	private static piCliOnPath(): boolean {
+		const dirs = (process.env.PATH ?? "").split(delimiter);
+		for (const dir of dirs) {
+			if (dir && existsSync(join(dir, "pi"))) return true;
 		}
-		const finish = (installed: boolean) => {
-			ClientSession.piCliProbe = { at: Date.now(), installed };
-			ClientSession.piCliProbePending = false;
-		};
-		const timer = setTimeout(() => {
-			try {
-				proc.kill();
-			} catch {
-				/* already exited */
-			}
-			finish(false);
-		}, 5000);
-		proc.on("error", () => {
-			clearTimeout(timer);
-			finish(false);
-		});
-		proc.on("close", (code) => {
-			clearTimeout(timer);
-			finish(code === 0);
-		});
+		return false;
 	}
 
 	private static invalidatePiCliProbe(): void {

--- a/server/dsh/runtime/runtime-root.mjs
+++ b/server/dsh/runtime/runtime-root.mjs
@@ -66,18 +66,24 @@ export async function resolveRuntimeBase() {
 		const base = runtimeBaseFor(adjacent);
 		if (base) return base;
 	}
+	// PATCHED (pi-web-ui #78 / Android-Termux deadlock): this used to run
+	// spawnSync("npm", ["root", "-g"]) as a last resort — a synchronous fork
+	// inside a multi-threaded process, which can deadlock on Android/Termux
+	// (child stuck between fork and exec while the caller blocks on libuv's
+	// spawn error pipe). Compute the npm global root without spawning instead.
 	try {
-		const { spawnSync } = await import("node:child_process");
-		const res = spawnSync(process.platform === "win32" ? "npm" : "npm", ["root", "-g"], {
-			encoding: "utf8",
-			timeout: 15_000,
-			windowsHide: true,
-			...(process.platform === "win32" ? { shell: true } : {}),
-		});
-		const root = String(res.stdout ?? "").trim();
-		if (root) {
-			const base = runtimeBaseFor(root);
-			if (base) return base;
+		const prefixCandidates = [
+			process.env.NPM_CONFIG_PREFIX,
+			process.env.npm_config_prefix,
+			join(dirname(process.execPath), ".."),
+		];
+		for (const prefix of prefixCandidates) {
+			if (!prefix) continue;
+			for (const root of [join(prefix, "lib", "node_modules"), join(prefix, "node_modules")]) {
+				if (!existsSync(root)) continue;
+				const base = runtimeBaseFor(root);
+				if (base) return base;
+			}
 		}
 	} catch {
 		/* fall through */

--- a/server/update-check.ts
+++ b/server/update-check.ts
@@ -7,9 +7,8 @@
  * (and an injected pi-core probe); ClientSession only wires it to the wire
  * protocol.
  */
-import { spawn } from "node:child_process";
-import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { readdirSync, readFileSync, realpathSync, existsSync } from "node:fs";
+import { delimiter, dirname, join } from "node:path";
 
 const PI_CORE_PACKAGE = "@earendil-works/pi-coding-agent";
 
@@ -173,65 +172,62 @@ function readLocalPackage(dir: string): LocalPackage | null {
 const PI_PROBE_TTL_MS = 10_000;
 
 let piCoreProbe: { at: number; version: string | null } | null = null;
-let piCoreProbePending = false;
 
-function refreshPiCoreProbe(): void {
-	if (piCoreProbePending) return;
-	piCoreProbePending = true;
-	let proc: ReturnType<typeof spawn>;
-	try {
-		proc = spawn("pi", ["--version"], {
-			stdio: ["ignore", "pipe", "pipe"],
-			// Windows: `pi` resolves to a pi.cmd shim — spawn can only
-			// exec those through a shell (else ENOENT).
-			shell: process.platform === "win32",
-		});
-	} catch {
-		piCoreProbe = { at: Date.now(), version: null };
-		piCoreProbePending = false;
-		return;
+/** Locate the pi CLI on PATH without spawning anything. */
+function piCliOnPath(): string | null {
+	const dirs = (process.env.PATH ?? "").split(delimiter);
+	for (const dir of dirs) {
+		if (!dir) continue;
+		const candidate = join(dir, "pi");
+		if (existsSync(candidate)) return candidate;
 	}
-	let out = "";
-	const finish = (version: string | null) => {
-		piCoreProbe = { at: Date.now(), version };
-		piCoreProbePending = false;
-	};
-	const timer = setTimeout(() => {
-		try {
-			proc.kill();
-		} catch {
-			/* already exited */
+	return null;
+}
+
+/**
+ * Read the pi core version from disk: resolve the `pi` bin (typically a
+ * symlink into <global>/node_modules/<pkg>/dist/bundle/cli.js) and walk up to
+ * its package.json. FORK-FREE by design — see the note on defaultProbePiCore.
+ */
+function readPiCoreVersionFromDisk(): string | null {
+	const bin = piCliOnPath();
+	if (!bin) return null;
+	try {
+		let dir = dirname(realpathSync(bin));
+		for (let i = 0; i < 8; i++) {
+			const pkgPath = join(dir, "package.json");
+			if (existsSync(pkgPath)) {
+				try {
+					const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { name?: string; version?: string };
+					if (pkg.name === PI_CORE_PACKAGE && pkg.version) return pkg.version;
+				} catch {
+					/* unreadable package.json — keep walking */
+				}
+			}
+			const parent = dirname(dir);
+			if (parent === dir) break;
+			dir = parent;
 		}
-		finish(null);
-	}, 5000);
-	proc.stdout?.on("data", (d: Buffer) => (out += d.toString()));
-	proc.on("error", () => {
-		clearTimeout(timer);
-		finish(null);
-	});
-	proc.on("close", (code) => {
-		clearTimeout(timer);
-		finish(code === 0 ? parsePiVersionOutput(out) : null);
-	});
+	} catch {
+		/* ignore */
+	}
+	return null;
 }
 
 /**
  * Default pi core probe: run the globally installed `pi --version`, memoized
  * machine-wide for PI_PROBE_TTL_MS so repeated collectTargets calls never
- * re-probe. Serves the last known value and refreshes ASYNCHRONOUSLY in the
- * background — never blocks the event loop. (It previously used spawnSync
- * here, which can deadlock the whole server on Android/Termux: fork() in a
- * multi-threaded process occasionally leaves the forked child stuck between
- * fork and exec while the main thread sits in spawnSync's pipe_read. Mirrors
- * ClientSession.isPiCliInstalled(); Windows resolves `pi` to a pi.cmd shim
- * that only execs through a shell.)
+ * re-probe. Reads the version from disk (pi bin → realpath → package.json)
+ * instead of spawning `pi --version`. FORK-FREE by design — see the note on
+ * defaultProbePiCore.
  */
 export function defaultProbePiCore(): string | null {
 	const now = Date.now();
 	const cached = piCoreProbe;
 	if (cached && now - cached.at < PI_PROBE_TTL_MS) return cached.version;
-	refreshPiCoreProbe();
-	return cached?.version ?? null;
+	const version = readPiCoreVersionFromDisk();
+	piCoreProbe = { at: now, version };
+	return version;
 }
 
 /**


### PR DESCRIPTION
Fixes the remaining hang from #78 / #79 (see the forensic conclusion comment there).

## Root cause (recap)

`libuv`'s `uv_spawn` **blocks its caller reading the child's error pipe** until the child execs or dies. On Android/Termux, `fork()` inside the multi-threaded server (websocket handlers, snapshot serializer, V8 workers) occasionally deadlocks the child **between fork and exec** (inherited lock) — the error pipe never closes, and the thread that called `spawn()` hangs forever. The event loop is dead from that moment: the process is alive but the server stops accepting connections.

Key evidence (aarch64 `/proc` forensics during a hang): main thread in `read()` (syscall 63) on the error pipe of a child with 1 thread in `futex_wait`, pre-exec cmdline, `/dev/null` stdio matching the `pi --version` probe (`stdio: "ignore"`).

Important: this applies to **async spawns too** — #79's async probe still hung the server the same way, because the blocking read happens inside `uv_spawn` regardless of API.

## Change — zero forks on server hot paths

1. **`ClientSession.isPiCliInstalled()`**: PATH scan (`existsSync(join(dir, "pi")))`) instead of spawning `pi --version` every 10 s. TTL cache + invalidation semantics unchanged.
2. **`update-check.defaultProbePiCore()`**: pi core version read **from disk** — locate the `pi` bin via PATH, `realpath`, walk up to its `package.json` (`@earendil-works/pi-coding-agent` → `version`). No process spawned.
3. **DSH runtime resolver** (`server/dsh/runtime/runtime-root.mjs`): the `spawnSync("npm", ["root", "-g"])` fallback is replaced by a computed npm-prefix lookup (`NPM_CONFIG_PREFIX` / `npm_config_prefix` / `dirname(execPath)/../lib/node_modules`, validated with `existsSync`).

## Testing

- `npm run typecheck` — passes
- `npx vitest run tests/unit/update-check.test.ts` — 19/19
- On-device (Android/Termux, Pixel 10 Pro, Node 26.3.1): server smoke test healthy; a health endpoint now resolves the pi core version via the disk-read path; **~24 h hang-free** with the watchdog clean (previously 8 hangs in 2 days).

Caveat: the runtime resolver's sync spawn ran inside the launcher child, so it was not itself the server-hang source — including it here because it's the same hazard class in the same platform context, and the launcher now forks at most once (its own async spawn by the client).
