### PR TITLE
PI_WEB_TABS: choose which tabs an instance offers

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -36,6 +36,7 @@ import { startControlServer } from "./control-socket.js";
 import { scheduleUploadCleanup } from "./uploads.js";
 import { ensureWindowsBash, windowsBashDir } from "./ensure-bash.js";
 import { listThemes, resolveThemeFile } from "./themes.js";
+import { parseTabs, tabsRefusal } from "./tabs.js";
 import { installPack, isKnownPack, listPacks, readPackFile, removePack } from "./locales.js";
 import {
 	PluginManager,
@@ -196,6 +197,9 @@ if (AUTH_TOKEN) {
 
 /** 引擎选择：PI_WEB_ENGINE=pi|dsh（默认 pi）。重启生效。 */
 const ENGINE: "pi" | "dsh" = process.env.PI_WEB_ENGINE === "dsh" ? "dsh" : "pi";
+
+/** PI_WEB_TABS: the tabs this instance offers. null = all of them, as before. */
+const TABS = parseTabs();
 
 app.get("/api/health", (_req, res) => {
 	res.json({ ok: true, piVersion: VERSION, cwd: CWD, pid: process.pid, engine: ENGINE });
@@ -864,6 +868,14 @@ wss.on("connection", (ws) => {
 			pending.push(msg);
 			return;
 		}
+		// A tab this instance does not offer is refused here, on the server:
+		// hiding it in the client would still leave the message reachable to
+		// anything that can open the socket. See server/tabs.ts.
+		const refusal = tabsRefusal(msg.type, TABS);
+		if (refusal) {
+			send({ type: "notice", level: "error", text: refusal });
+			return;
+		}
 		switch (msg.type) {
 			case "prompt":
 				void cs.prompt(msg.text, msg.attachments, msg.queue);
@@ -1215,6 +1227,7 @@ wss.on("connection", (ws) => {
 						serverVersion: VERSION,
 						protocolVersion: PROTOCOL_VERSION,
 						engine: ENGINE,
+						tabs: TABS ? [...TABS] : undefined,
 					});
 					// Plugin catalog: re-scan + activate new dirs on every attach so
 					// freshly dropped plugins show up without a server restart.

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -1125,6 +1125,10 @@ export type ServerMessage =
 			 *  compares it against its own copy — a mismatch means the page was
 			 *  loaded before an app update and must be refreshed. */
 			protocolVersion?: number;
+			/** PI_WEB_TABS — the tabs this instance offers; absent means all of
+			 *  them. The client does not draw the others and the server refuses
+			 *  their messages (server/tabs.ts). */
+			tabs?: string[];
 	  }
 	| { type: "snapshot"; state: UiState }
 	| {

--- a/server/tabs.ts
+++ b/server/tabs.ts
@@ -1,0 +1,89 @@
+/**
+ * tabs — choose what an instance offers.
+ *
+ * pi-web-ui shows Chat, Terminal, Git, Search, Background tasks and Settings,
+ * always, plus a tab per installed plugin. On the machine you are working on
+ * that is the point of the tool. Exposed to other people it is not: Terminal
+ * opens a shell as the server's user, and Git shows the working copy with
+ * commit and diff a click away. Today there is no way to leave those out.
+ *
+ * `PI_WEB_TABS=chat,search,settings` is that way. Absent — the default —
+ * means every tab, so nothing changes for anybody who does not set it.
+ *
+ * The rule that shapes the whole thing: **a hidden tab whose messages the
+ * server still accepts is a hidden tab, not a disabled one.** Anything that
+ * can open the WebSocket can send `terminal_create`. So the client stops
+ * drawing them and the server stops answering them, and the second half is the
+ * one that matters.
+ *
+ * Chat is never off: it is the application.
+ */
+
+/** Every tab that can be listed. `chat` is always on and is listed for symmetry. */
+export const ALL_TABS = ["chat", "terminal", "git", "search", "tasks", "settings", "plugins"] as const;
+
+export type Tab = (typeof ALL_TABS)[number];
+
+/**
+ * The messages each tab owns exclusively.
+ *
+ * Only exclusive ones: `abort_bash` stops the agent's own bash tool inside a
+ * chat answer, not a terminal the user opened, so it is not listed — turning
+ * off the Terminal tab must not change what the agent can do in a conversation.
+ *
+ * `run_command` is listed under terminal because it starts a process in one:
+ * leaving it out would take the tab away and leave the shell reachable, which
+ * is exactly the failure this module exists to prevent.
+ */
+const OWNED: Partial<Record<Tab, readonly string[]>> = {
+	terminal: ["terminal_create", "terminal_input", "terminal_resize", "terminal_kill", "rename_terminal", "run_command"],
+	git: ["scm_status", "scm_history", "scm_filediff", "scm_commit"],
+	tasks: ["list_bg_servers", "kill_background_server", "kill_background_servers"],
+	search: ["search_files", "search_sessions"],
+};
+
+/**
+ * The allow-list, or null when there is none.
+ *
+ * Case and spaces are forgiven because this is written by hand in a systemd
+ * unit or a compose file. Unknown names are kept rather than rejected: a
+ * plugin tab, or a tab a later version adds, should not make the server fail
+ * to start.
+ */
+export function parseTabs(env: NodeJS.ProcessEnv = process.env): Set<string> | null {
+	const raw = (env.PI_WEB_TABS ?? "").trim();
+	if (!raw) return null;
+	const tabs = new Set(
+		raw
+			.split(",")
+			.map((t) => t.trim().toLowerCase())
+			.filter(Boolean),
+	);
+	if (tabs.size === 0) return null;
+	tabs.add("chat");
+	return tabs;
+}
+
+/** Whether a tab is offered. No list means every tab. */
+export function isTabAllowed(tab: string, tabs: Set<string> | null): boolean {
+	if (!tabs) return true;
+	if (tab === "chat") return true;
+	return tabs.has(tab.toLowerCase());
+}
+
+/**
+ * The reason to refuse a message, or null when it may proceed.
+ *
+ * Returning the sentence rather than a boolean keeps the call site one line and
+ * puts the explanation next to the rule: the user sees why, instead of a
+ * message that vanishes.
+ */
+export function tabsRefusal(type: string, tabs: Set<string> | null): string | null {
+	if (!tabs) return null;
+	for (const [tab, messages] of Object.entries(OWNED) as [Tab, readonly string[]][]) {
+		if (!messages.includes(type)) continue;
+		if (isTabAllowed(tab, tabs)) return null;
+		return `The ${tab} tab is not enabled on this instance (PI_WEB_TABS).`;
+	}
+	return null;
+}

--- a/tests/unit/tabs.test.ts
+++ b/tests/unit/tabs.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { ALL_TABS, isTabAllowed, parseTabs, tabsRefusal } from "../../server/tabs.js";
+
+/**
+ * PI_WEB_TABS — choose what an instance offers.
+ *
+ * Terminal opens a shell as the server's user; Git shows the working copy with
+ * commit and diff a click away. On your own machine that is the point of the
+ * tool. Exposed to other people — reviewers, colleagues, anybody who reaches
+ * the page — they are not features, they are a shell and a repository handed
+ * out over HTTP, and there is no way to turn them off today.
+ *
+ * Absent variable means every tab, exactly as now: nobody who does not set it
+ * sees any change.
+ *
+ * The rule that shapes this: a hidden tab whose messages the server still
+ * accepts is a hidden tab, not a disabled one. Anything that can open the
+ * socket can send `terminal_create`.
+ */
+describe("tab allow-list", () => {
+	it("absent means everything, like today", () => {
+		expect(parseTabs({})).toBeNull();
+		expect(parseTabs({ PI_WEB_TABS: "" })).toBeNull();
+		expect(parseTabs({ PI_WEB_TABS: "   " })).toBeNull();
+		for (const tab of ALL_TABS) expect(isTabAllowed(tab, null), tab).toBe(true);
+	});
+
+	it("reads a list the way people write it", () => {
+		const t = parseTabs({ PI_WEB_TABS: " chat , Search,settings " });
+		expect([...(t as Set<string>)].sort()).toEqual(["chat", "search", "settings"]);
+	});
+
+	it("chat is never off: it is the application", () => {
+		const t = parseTabs({ PI_WEB_TABS: "settings" });
+		expect(isTabAllowed("chat", t)).toBe(true);
+		expect(isTabAllowed("terminal", t)).toBe(false);
+	});
+
+	it("refuses the messages of the tabs that are off", () => {
+		const t = parseTabs({ PI_WEB_TABS: "chat,search,settings" });
+		for (const type of ["terminal_create", "terminal_input", "terminal_kill", "rename_terminal", "run_command"]) {
+			expect(tabsRefusal(type, t), type).toMatch(/terminal/i);
+		}
+		for (const type of ["scm_status", "scm_history", "scm_filediff", "scm_commit"]) {
+			expect(tabsRefusal(type, t), type).toMatch(/git/i);
+		}
+		for (const type of ["list_bg_servers", "kill_background_server", "kill_background_servers"]) {
+			expect(tabsRefusal(type, t), type).toBeTruthy();
+		}
+	});
+
+	it("leaves the allowed tabs alone", () => {
+		const t = parseTabs({ PI_WEB_TABS: "chat,search,settings" });
+		for (const type of ["prompt", "get_state", "search_files", "search_sessions", "get_settings", "set_settings"]) {
+			expect(tabsRefusal(type, t), type).toBeNull();
+		}
+	});
+
+	it("refuses nothing at all when no list is set", () => {
+		for (const type of ["terminal_create", "scm_commit", "list_bg_servers", "search_files"]) {
+			expect(tabsRefusal(type, null), type).toBeNull();
+		}
+	});
+
+	/*
+	 * The terminal is the one that matters most: run_command starts a process
+	 * too, and forgetting it would leave the shell reachable with the tab gone.
+	 */
+	it("run_command counts as terminal, because it starts a process there", () => {
+		const t = parseTabs({ PI_WEB_TABS: "chat" });
+		expect(tabsRefusal("run_command", t)).toMatch(/terminal/i);
+	});
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -195,7 +195,15 @@ export function App() {
 	 *  drop overlay; drop anywhere attaches, the input bar keeps priority via
 	 *  its own stopPropagation handlers. */
 	const [appDragOver, setAppDragOver] = useState(false);
-	const [view, setView] = useState<ViewName>("chat");
+	const [viewChosen, setView] = useState<ViewName>("chat");
+	/* PI_WEB_TABS: a tab this instance does not offer cannot be shown, even if
+	   something else asks for it — a plugin firing pi-web-ui:plugin-run-command,
+	   or a panel's "open this in a terminal" button. The server refuses those
+	   messages anyway, so the pane would sit there empty. No list means every
+	   tab, which is the default. */
+	const tabOn = (tab: string) => !chat.tabs || tab === "chat" || chat.tabs.includes(tab);
+	const viewTab = viewChosen.startsWith("plugin:") ? "plugins" : viewChosen;
+	const view: ViewName = tabOn(viewTab) ? viewChosen : "chat";
 	// 已安装且未在设置面板禁用的插件（决定 tab 与视图加载）。
 	const enabledPlugins = useMemo(
 		() => chat.plugins.filter((p) => !chat.settings?.disabledPlugins?.includes(p.id)),

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -182,6 +182,12 @@ export function TopBar({
 	};
 
 	// Shared by the desktop update dropdown and the mobile "⋯" panel.
+	/* PI_WEB_TABS: an instance can be set up to offer only some tabs — the
+	   server refuses the messages of the others anyway (server/tabs.ts), so
+	   drawing them would only offer an action that comes back refused. No list
+	   means every tab, which is the default. */
+	const tabOn = (tab: string) => !chat.tabs || tab === "chat" || chat.tabs.includes(tab);
+
 	const allUpdates = chat.updatesAll ?? [];
 	// Pure errors don't count as "updates" — they're shown as failed rows.
 	const updatesCount = allUpdates.filter((i) => !i.upToDate && !i.error).length;
@@ -327,27 +333,31 @@ export function TopBar({
 						<FiMessageSquare />
 						<span>{t("chat")}</span>
 					</button>
-					<button
-						type="button"
-						role="tab"
-						aria-selected={view === "terminal"}
-						className={view === "terminal" ? "active" : ""}
-						onClick={() => onViewChange("terminal")}
-					>
-						<FiTerminal />
-						<span>{t("terminal")}</span>
-					</button>
-					<button
-						type="button"
-						role="tab"
-						aria-selected={view === "git"}
-						className={view === "git" ? "active" : ""}
-						onClick={() => onViewChange("git")}
-					>
-						<FiGitBranch />
-						<span>{t("scmTab")}</span>
-					</button>
-					{plugins
+					{tabOn("terminal") && (
+						<button
+							type="button"
+							role="tab"
+							aria-selected={view === "terminal"}
+							className={view === "terminal" ? "active" : ""}
+							onClick={() => onViewChange("terminal")}
+						>
+							<FiTerminal />
+							<span>{t("terminal")}</span>
+						</button>
+					)}
+					{tabOn("git") && (
+						<button
+							type="button"
+							role="tab"
+							aria-selected={view === "git"}
+							className={view === "git" ? "active" : ""}
+							onClick={() => onViewChange("git")}
+						>
+							<FiGitBranch />
+							<span>{t("scmTab")}</span>
+						</button>
+					)}
+					{(tabOn("plugins") ? plugins : [])
 						.filter((p) => p.view !== false)
 						.map((p) => {
 							const tip = p.error ? `${p.name}: ${p.error}` : p.description ? `${p.name} — ${p.description}` : p.name;
@@ -372,22 +382,28 @@ export function TopBar({
 				    input row; sound/lang/update/github fold into "⋯" below). */}
 				<div className="topbar-desktop">
 					{/* Global search — sessions / projects / workspace files. */}
-					<button type="button" className="chip" title={t("searchGlobalTip")} onClick={onOpenGlobalSearch}>
-						<FiSearch />
-						<span className="chip-sub">{t("searchGlobal")}</span>
-					</button>
+					{tabOn("search") && (
+						<button type="button" className="chip" title={t("searchGlobalTip")} onClick={onOpenGlobalSearch}>
+							<FiSearch />
+							<span className="chip-sub">{t("searchGlobal")}</span>
+						</button>
+					)}
 					{/* Background tasks — AI-started servers still listening. Always shown
 					    so the list survives the conversation that started them (badge = count). */}
-					<button type="button" className="chip bg-task-chip" data-tip={t("bgTasksTip")} onClick={onOpenBgTasks}>
-						<FiLayers />
-						<span className="chip-sub">{t("bgTasks")}</span>
-						{chat.bgServers.length > 0 && <span className="bg-task-badge">{chat.bgServers.length}</span>}
-					</button>
+					{tabOn("tasks") && (
+						<button type="button" className="chip bg-task-chip" data-tip={t("bgTasksTip")} onClick={onOpenBgTasks}>
+							<FiLayers />
+							<span className="chip-sub">{t("bgTasks")}</span>
+							{chat.bgServers.length > 0 && <span className="bg-task-badge">{chat.bgServers.length}</span>}
+						</button>
+					)}
 
-					<button type="button" className="chip" title={t("settingsTitle")} onClick={onOpenSettings}>
-						<FiSettings />
-						<span className="chip-sub">{t("settings")}</span>
-					</button>
+					{tabOn("settings") && (
+						<button type="button" className="chip" title={t("settingsTitle")} onClick={onOpenSettings}>
+							<FiSettings />
+							<span className="chip-sub">{t("settings")}</span>
+						</button>
+					)}
 
 					<Dropdown
 						trigger={

--- a/web/src/use-chat.ts
+++ b/web/src/use-chat.ts
@@ -77,6 +77,9 @@ export interface ChatState {
 	serverVersion?: string;
 	/** 引擎标识（pi | dsh）—— ready 消息携带，底栏显示徽标。 */
 	engine?: string;
+	/** PI_WEB_TABS on the server: the tabs this instance offers. Undefined
+	 *  means all of them, which is the default. */
+	tabs?: string[];
 	/** Persisted session list for the left panel. */
 	sessions: SessionSummary[];
 	/** Open conversations (each runs its own session in parallel). */
@@ -228,7 +231,7 @@ type Action =
 	| { type: "tool_status"; status: ToolStatus }
 	| { type: "notice"; notice: Notice }
 	| { type: "dismiss_notice"; id: number }
-	| { type: "ready"; serverVersion: string; protocolVersion?: number; engine?: string }
+	| { type: "ready"; serverVersion: string; protocolVersion?: number; engine?: string; tabs?: string[] }
 	| { type: "sessions"; sessions: SessionSummary[] }
 	| {
 			type: "conversations";
@@ -489,6 +492,7 @@ function reducer(state: ChatState, action: Action): ChatState {
 				...state,
 				serverVersion: action.serverVersion,
 				engine: action.engine,
+				tabs: action.tabs,
 				ready: true,
 				// Old page + new server (or the reverse) after an in-place update:
 				// WS handling on either side may be stale — banner asks for refresh.
@@ -920,6 +924,7 @@ export function useChat() {
 						serverVersion: msg.serverVersion,
 						protocolVersion: msg.protocolVersion,
 						engine: msg.engine,
+						tabs: msg.tabs,
 					});
 					// Ensure a fresh snapshot on (re)connect.
 					ws.send(JSON.stringify({ type: "get_state" } satisfies ClientMessage));


### PR DESCRIPTION
`PI_WEB_TABS=chat,search,settings` limits what an instance offers. Absent -
the default - means every tab, so nothing changes for anybody who does not set
it.

**Why.** Terminal opens a shell as the server's user; Git shows the working
copy with commit and diff a click away. On your own machine that is the point
of the tool. Exposed to other people it is a shell and a repository handed out
over HTTP, and today the only choices are "expose everything" or "fork it".

**What it does.** The client stops drawing the excluded tabs, **and the server
refuses the messages they own** - `terminal_*` and `run_command`, `scm_*`, the
background-server ones, the two search ones - with a notice naming the tab that
is off. A hidden tab whose messages the server still accepts is a hidden tab,
not a disabled one.

Two details worth reviewing:

- `abort_bash` is deliberately **not** listed: it stops the agent's own bash
  tool inside an answer, not a terminal the user opened, so turning off the
  Terminal tab does not change what the agent can do in a conversation.
- `run_command` **is** listed under `terminal`, because it starts a process in
  one; leaving it out would take the tab away and leave the shell reachable.

Unknown names in the list are kept rather than rejected, so a plugin tab or a
tab a later version adds cannot stop the server from starting. Chat is never
off.

Pure module (`server/tabs.ts`) with unit tests.

---

Context: this comes from a fork used to run pi-web-ui as the chat inside a site
that releases through one pipeline and shows it to people who are not
developers. Three things did not fit and none of them could be turned off with
configuration; the fork exists to fix that, and every patch in it is written as
a general switch and proposed here, so that if you take it the fork loses a
patch and keeps only configuration. Fork:
https://github.com/devstudiosrl/pi-web-ui (branch `printalo`, register in
`PATCHES.md`).

Happy to change the variable names, the shape, or split this differently.
