### PR TITLE
Pick the first-visit language from the browser instead of a fixed default

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -285,8 +285,18 @@ app.get("/api/themes", (_req, res) => {
 });
 // 语言包：核心只随包发布中英，其余按需下载到 <dataDir>/locales/<code>.json。
 // 手工放进去的同名 JSON 也会被识别（离线安装）。PI_WEB_TOKEN 鉴权自动覆盖。
+/**
+ * PI_WEB_LOCALE — the language a first visit falls back to.
+ *
+ * It is a fallback, not an override: an explicit choice, and then the
+ * browser's own languages, come first (web/src/pick-locale.ts). It rides on
+ * /api/locales because the client already asks for that at boot, so naming a
+ * default costs no extra request.
+ */
+const DEFAULT_LOCALE = (process.env.PI_WEB_LOCALE ?? "").trim().toLowerCase() || null;
+
 app.get("/api/locales", (_req, res) => {
-	res.json({ packs: listPacks(DATA_DIR) });
+	res.json({ packs: listPacks(DATA_DIR), defaultLocale: DEFAULT_LOCALE });
 });
 app.get("/api/locales/:code", (req, res) => {
 	const code = String(req.params.code ?? "");

--- a/tests/unit/pick-locale.test.ts
+++ b/tests/unit/pick-locale.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { KNOWN_LOCALES, pickLocale } from "../../web/src/pick-locale.js";
+
+/**
+ * Which language a first visit speaks.
+ *
+ * Today `loadLocale()` returns "zh" when nothing is stored, so everybody who
+ * has never used this instance gets Chinese and has to find the language chip.
+ * The repository already carries eight translations besides zh and en — de,
+ * es, fr, it, ja, ko, pt, ru — and nothing ever picks them on its own.
+ *
+ * So: an explicit choice always wins and is remembered; otherwise the browser
+ * decides, the way every other web application works; and only if the browser
+ * asks for nothing we have does the instance's configured default apply
+ * (PI_WEB_LOCALE), falling back to English.
+ */
+describe("first-visit language", () => {
+	it("an explicit choice wins over everything", () => {
+		expect(pickLocale("it", ["fr-FR", "en"], "de")).toBe("it");
+		// Even one that this build does not know: the pack machinery validates
+		// it later, and dropping it here would silently undo the user's choice.
+		expect(pickLocale("xx", ["fr"], "de")).toBe("xx");
+	});
+
+	it("ignores a stored value that is empty or blank", () => {
+		expect(pickLocale("", ["fr-FR"], "en")).toBe("fr");
+		expect(pickLocale("   ", ["fr-FR"], "en")).toBe("fr");
+		expect(pickLocale(null, ["fr-FR"], "en")).toBe("fr");
+	});
+
+	it("takes the browser's first language it can actually speak", () => {
+		expect(pickLocale(null, ["it-IT", "it", "en-US"], "en")).toBe("it");
+		expect(pickLocale(null, ["nl-NL", "de-DE", "en"], "en")).toBe("de");
+		expect(pickLocale(null, ["en-GB"], "it")).toBe("en");
+	});
+
+	it("understands the regional tags browsers actually send", () => {
+		expect(pickLocale(null, ["zh-CN"], "en")).toBe("zh");
+		expect(pickLocale(null, ["zh-TW"], "en")).toBe("zh");
+		expect(pickLocale(null, ["pt-BR"], "en")).toBe("pt");
+		expect(pickLocale(null, ["ja-JP"], "en")).toBe("ja");
+		expect(pickLocale(null, ["IT-it"], "en")).toBe("it");
+	});
+
+	it("falls back to the instance default, then to English", () => {
+		expect(pickLocale(null, ["nl-NL"], "it")).toBe("it");
+		expect(pickLocale(null, [], "it")).toBe("it");
+		expect(pickLocale(null, [], null)).toBe("en");
+		expect(pickLocale(null, ["nl"], null)).toBe("en");
+	});
+
+	it("does not accept a default the build cannot speak", () => {
+		// A typo in a systemd unit must not leave the interface showing keys.
+		expect(pickLocale(null, [], "xx")).toBe("en");
+	});
+
+	it("knows the locales this build ships", () => {
+		expect([...KNOWN_LOCALES].sort()).toEqual(
+			["de", "en", "es", "fr", "it", "ja", "ko", "pt", "ru", "zh"].sort(),
+		);
+	});
+});

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { appUrl } from "./base-url";
 import { withToken } from "./auth-token";
+import { pickLocale } from "./pick-locale.js";
 
 /** Locale code ("zh" / "en" built in; the rest are downloadable packs, see below). */
 export type Locale = string;
@@ -2042,21 +2043,34 @@ interface I18nContextValue {
 	t: Translate;
 	/** Core + registered downloadable packs (native names, never translated). */
 	packs: { code: string; nativeName: string }[];
-	/** Re-read installed packs from the server (after install/remove). */
-	reloadPacks: () => Promise<void>;
+	/** Re-read installed packs from the server (after install/remove).
+	 *  Returns the instance default (PI_WEB_LOCALE) when the server names one. */
+	reloadPacks: () => Promise<string | null>;
 }
 
 const I18nContext = createContext<I18nContextValue | null>(null);
 
-function loadLocale(): Locale {
+/** What the previous visit stored, if anything. */
+function savedLocale(): string | null {
 	try {
-		const saved = (localStorage.getItem(STORAGE_KEY) ?? "").trim();
 		// zh/en always exist; other codes are validated once packs finish loading.
-		if (saved) return saved;
+		return localStorage.getItem(STORAGE_KEY);
 	} catch {
-		// localStorage unavailable — fall through to the default.
+		return null; // localStorage unavailable
 	}
-	return "zh"; // default: Chinese
+}
+
+/**
+ * The language to start with.
+ *
+ * This used to be "zh" flat, so a first visit spoke Chinese whatever the
+ * browser asked for — and the eight translation packs in this repository were
+ * never chosen by anything. Now the browser decides; the instance default
+ * (PI_WEB_LOCALE) arrives with the pack list a moment later and only applies
+ * if the browser named nothing we speak. See web/src/pick-locale.ts.
+ */
+function loadLocale(): Locale {
+	return pickLocale(savedLocale(), typeof navigator !== "undefined" ? navigator.languages : [], null);
 }
 
 export function LanguageProvider({ children }: { children: ReactNode }) {
@@ -2074,13 +2088,15 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 		}
 	}, []);
 
-	const reloadPacks = useCallback(async () => {
+	const reloadPacks = useCallback(async (): Promise<string | null> => {
 		let list: LocalePackStatus[];
+		let serverDefault: string | null = null;
 		try {
-			const data = await fetchPackJson<{ packs: LocalePackStatus[] }>("/api/locales");
+			const data = await fetchPackJson<{ packs: LocalePackStatus[]; defaultLocale?: string | null }>("/api/locales");
 			list = data.packs ?? [];
+			serverDefault = data.defaultLocale ?? null;
 		} catch {
-			return; // server unreachable / old version — core locales keep working
+			return null; // server unreachable / old version — core locales keep working
 		}
 		await Promise.all(
 			list
@@ -2099,17 +2115,31 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 				}),
 		);
 		setPacksTick((n) => n + 1);
+		return serverDefault;
 	}, []);
 
-	// Boot: load installed packs, then drop a saved locale whose pack is gone.
+	// Boot: load installed packs, apply the instance default when the browser
+	// named nothing we speak, then drop a saved locale whose pack is gone.
 	useEffect(() => {
-		void reloadPacks().then(() => {
+		void reloadPacks().then((serverDefault) => {
+			// Nobody has ever chosen here: the server may name the language this
+			// instance should speak when the browser asks for one we do not have.
+			if (!savedLocale()) {
+				const chosen = pickLocale(null, typeof navigator !== "undefined" ? navigator.languages : [], serverDefault);
+				if (chosen !== localeRef.current) {
+					localeRef.current = chosen;
+					setLocaleState(chosen);
+				}
+			}
 			const cur = localeRef.current;
 			if (cur !== "zh" && cur !== "en" && !PACK_REGISTRY[cur]) {
-				localeRef.current = "zh";
-				setLocaleState("zh");
+				// The pack is not installed on this server. Fall back the same way a
+				// first visit does — not to a fixed language.
+				const fallback = pickLocale(null, typeof navigator !== "undefined" ? navigator.languages : [], serverDefault, ["zh", "en"]);
+				localeRef.current = fallback;
+				setLocaleState(fallback);
 				try {
-					localStorage.setItem(STORAGE_KEY, "zh");
+					localStorage.setItem(STORAGE_KEY, fallback);
 				} catch {
 					// ignore storage errors
 				}

--- a/web/src/pick-locale.ts
+++ b/web/src/pick-locale.ts
@@ -1,0 +1,56 @@
+/**
+ * pick-locale — which language a first visit speaks.
+ *
+ * `loadLocale()` used to return "zh" when nothing was stored, so anybody who
+ * had never used an instance got Chinese and had to find the language chip to
+ * change it. Meanwhile the repository ships eight translations besides the two
+ * core ones — de, es, fr, it, ja, ko, pt, ru — and nothing ever picked them on
+ * its own.
+ *
+ * The order here is the one every other web application uses:
+ *
+ *   1. what this browser chose last time (and an explicit choice is kept even
+ *      if this build does not know the code — the pack machinery validates it
+ *      later, and dropping it here would silently undo the user's decision);
+ *   2. the first of the browser's languages this build can actually speak;
+ *   3. the instance's configured default (PI_WEB_LOCALE), for a deployment
+ *      that wants to name one;
+ *   4. English.
+ *
+ * It is a pure function so the whole order can be tested without a browser.
+ */
+
+/** Locale codes this build can show: the two core ones plus every pack. */
+export const KNOWN_LOCALES = ["zh", "en", "de", "es", "fr", "it", "ja", "ko", "pt", "ru"] as const;
+
+/**
+ * The locale to start with.
+ *
+ * `saved` is what the previous visit stored, `languages` is
+ * `navigator.languages`, `fallback` is the instance default.
+ */
+export function pickLocale(
+	saved: string | null | undefined,
+	languages: readonly string[] | null | undefined,
+	fallback: string | null | undefined,
+	known: readonly string[] = KNOWN_LOCALES,
+): string {
+	const chosen = (saved ?? "").trim();
+	if (chosen) return chosen;
+
+	for (const raw of languages ?? []) {
+		// Browsers send tags like "it-IT", "zh-CN", "pt-BR": try the whole tag,
+		// then its primary subtag, so a regional variant lands on its language.
+		const tag = String(raw ?? "").trim().toLowerCase().replace(/_/g, "-");
+		if (!tag) continue;
+		if (known.includes(tag)) return tag;
+		const primary = tag.split("-")[0];
+		if (primary && known.includes(primary)) return primary;
+	}
+
+	// A default this build cannot speak — a typo in a unit file — must not
+	// leave the interface showing raw keys.
+	const configured = (fallback ?? "").trim().toLowerCase();
+	if (configured && known.includes(configured)) return configured;
+	return "en";
+}


### PR DESCRIPTION
`loadLocale()` returns `"zh"` when nothing is stored, so a first visit is in
Chinese whatever the browser asks for. Meanwhile the repository ships eight
translations besides the core two - de, es, fr, it, ja, ko, pt, ru - and
nothing ever picks them on its own.

This changes the order to the one most web applications use:

1. what this browser chose last time (an explicit choice always wins, and is
   kept even if this build does not know the code - the pack machinery
   validates it a moment later);
2. the first of `navigator.languages` this build can speak, matching the whole
   tag and then its primary subtag, so `zh-CN`, `pt-BR` and `it-IT` land where
   they should;
3. `PI_WEB_LOCALE`, for a deployment that wants to name a default;
4. English.

`PI_WEB_LOCALE` is a fallback, not an override: it applies only when the
browser named nothing available. It rides on `/api/locales`, which the client
already requests at boot, so it costs no extra round trip; a value this build
cannot speak is ignored rather than showing raw keys.

The same fix applies to the other hardcoded `"zh"`: when a saved locale's pack
is not installed on the server, the fallback goes through the same order
instead of jumping to Chinese.

**This does change behaviour for a first visit with nothing stored:** a `zh-CN`
browser still gets Chinese, an `it-IT` browser now gets Italian, and a browser
asking for something with no pack gets English. A deployment that wants Chinese
regardless can set `PI_WEB_LOCALE=zh`. Say the word if you would rather have
this behind a flag that defaults to today's behaviour.

Pure function (`web/src/pick-locale.ts`) with unit tests.

---

Context: this comes from a fork used to run pi-web-ui as the chat inside a site
that releases through one pipeline and shows it to people who are not
developers. Three things did not fit and none of them could be turned off with
configuration; the fork exists to fix that, and every patch in it is written as
a general switch and proposed here, so that if you take it the fork loses a
patch and keeps only configuration. Fork:
https://github.com/devstudiosrl/pi-web-ui (branch `printalo`, register in
`PATCHES.md`).

Happy to change the variable names, the shape, or split this differently.
