### PR TITLE
fix(i18n): polish pt-BR strings (markers description + locale list error)

### DIFF
--- a/locales/pt.json
+++ b/locales/pt.json
@@ -735,7 +735,7 @@
     "visionBridgeCurrent": "Modelo de transcrição atual: {model}",
     "visionBridgePromptMode": "Prompt de transcrição",
     "settingsMarkers": "Marcadores",
-    "settingsMarkersDesc": "Permite ao IA alterar estados no corpo do texto com marcações inline [[todo:...]] / [[notify:...]] / [[conv:rename:...]], sem idas e vindas de ferramentas. Desligar globalmente desativa tudo; interruptores de grupo permitem controle fino.",
+    "settingsMarkersDesc": "Permite que a IA altere estados no corpo do texto com marcações inline [[todo:...]] / [[notify:...]] / [[conv:rename:...]], sem idas e voltas de ferramentas. Desligar globalmente desativa tudo; os interruptores de grupo permitem controle fino.",
     "markersEnabled": "Marcadores ativados (global)",
     "markersEnabledDesc": "Desativado = nenhuma orientação de marcador injetada e nenhuma análise (parsing); os marcadores permanecem como texto simples.",
     "markersOffHint": "Globalmente desativado: todos os marcadores desativados — a IA não escreverá marcadores e nenhum efeito colateral será acionado.",
@@ -855,7 +855,7 @@
     "localeDownloading": "Baixando…",
     "localeRemoving": "Removendo…",
     "localeInstallFailed": "Falha no download: {error}",
-    "localeListFailed": "Não foi possível carregar os pacotes: {error}",
+    "localeListFailed": "Não foi possível carregar os pacotes de idioma: {error}",
     "localeRemoveHint": "Você pode baixá-lo novamente quando quiser"
   }
 }


### PR DESCRIPTION
Small polish of two pt-BR strings, thanks again for accepting the
Portuguese translation earlier (now maintained as the `pt` language pack).

- `settingsMarkersDesc`: fixes the agreement error "Permite ao IA" →
  "Permite que a IA altere estados..." (IA is feminine in Portuguese) and
  aligns the marker list with the zh source (todo/notify/conv rename).
- `localeListFailed`: adds "de idioma" to match the English source
  ("language packs").
