### PR TITLE
style(prettier): format 5 files failing format:check

### DIFF
--- a/server/i18n.ts
+++ b/server/i18n.ts
@@ -100,13 +100,7 @@ export function getServerString(lang: ServerLang, key: string): string | undefin
  *   pick(lang, `剩${n}个`, `${n} left`, "k.items.left", { n })
  *   → table: `"残り{n}件"`. Slots missing from `vars` stay literal.
  */
-export function pick(
-	lang: ServerLang,
-	zh: string,
-	en: string,
-	key?: string,
-	vars?: Record<string, unknown>,
-): string {
+export function pick(lang: ServerLang, zh: string, en: string, key?: string, vars?: Record<string, unknown>): string {
 	if (isZh(lang)) return zh;
 	if (key) {
 		const hit = getServerString(lang, key);

--- a/server/locales.ts
+++ b/server/locales.ts
@@ -15,11 +15,7 @@
  */
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import {
-	extractServerStrings,
-	registerServerStrings,
-	unregisterServerStrings,
-} from "./i18n.js";
+import { extractServerStrings, registerServerStrings, unregisterServerStrings } from "./i18n.js";
 
 export interface LocalePackMeta {
 	code: string;

--- a/tests/unit/locales-server.test.ts
+++ b/tests/unit/locales-server.test.ts
@@ -72,7 +72,13 @@ describe("locales", () => {
 			mkdirSync(dirname(packPath(dir, "ja")), { recursive: true });
 			writeFileSync(
 				packPath(dir, "ja"),
-				JSON.stringify({ code: "ja", nativeName: "日本語", version: "x", strings: { ok: "OK" }, serverStrings: { "k.1": "あ" } }),
+				JSON.stringify({
+					code: "ja",
+					nativeName: "日本語",
+					version: "x",
+					strings: { ok: "OK" },
+					serverStrings: { "k.1": "あ" },
+				}),
 			);
 			writeFileSync(packPath(dir, "pt"), JSON.stringify({ code: "pt", strings: { ok: "OK" } }));
 			writeFileSync(packPath(dir, "de"), "{broken");

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -495,36 +495,38 @@ export function TopBar({
 							<span className="chip-sub">v{chat.appVersion ?? chat.update?.current ?? "…"}</span>
 						</span>
 					) : (
-					<Dropdown
-						trigger={
-							<>
-								<FiDownload />
-								<span className="chip-sub">v{chat.update?.current ?? "…"}</span>
-								{chat.update && !chat.update.upToDate && (
-									<span
-										className="update-dot"
-										title={t("updateAvailable", {
-											version: chat.update.latest ?? "",
-										})}
-									/>
-								)}
-								{updatesCount > 0 && <span className="update-badge">{t("updatesAllBadge", { n: updatesCount })}</span>}
-							</>
-						}
-						open={updateOpen}
-						onOpenChange={(v) => {
-							setUpdateOpen(v);
-							if (v) {
-								send({ type: "check_update" });
-								send({ type: "check_updates_all" });
+						<Dropdown
+							trigger={
+								<>
+									<FiDownload />
+									<span className="chip-sub">v{chat.update?.current ?? "…"}</span>
+									{chat.update && !chat.update.upToDate && (
+										<span
+											className="update-dot"
+											title={t("updateAvailable", {
+												version: chat.update.latest ?? "",
+											})}
+										/>
+									)}
+									{updatesCount > 0 && (
+										<span className="update-badge">{t("updatesAllBadge", { n: updatesCount })}</span>
+									)}
+								</>
 							}
-						}}
-						fit
-					>
-						<div className="dd-header">{t("update")}</div>
-						{renderUpdateBody()}
-						{renderAllUpdatesBody()}
-					</Dropdown>
+							open={updateOpen}
+							onOpenChange={(v) => {
+								setUpdateOpen(v);
+								if (v) {
+									send({ type: "check_update" });
+									send({ type: "check_updates_all" });
+								}
+							}}
+							fit
+						>
+							<div className="dd-header">{t("update")}</div>
+							{renderUpdateBody()}
+							{renderAllUpdatesBody()}
+						</Dropdown>
 					)}
 
 					<a

--- a/web/src/use-chat.ts
+++ b/web/src/use-chat.ts
@@ -256,7 +256,15 @@ type Action =
 	| { type: "tool_status"; status: ToolStatus }
 	| { type: "notice"; notice: Notice }
 	| { type: "dismiss_notice"; id: number }
-	| { type: "ready"; serverVersion: string; protocolVersion?: number; engine?: string; appVersion?: string; managed?: boolean; tabs?: string[] }
+	| {
+			type: "ready";
+			serverVersion: string;
+			protocolVersion?: number;
+			engine?: string;
+			appVersion?: string;
+			managed?: boolean;
+			tabs?: string[];
+	  }
 	| { type: "sessions"; sessions: SessionSummary[] }
 	| {
 			type: "conversations";


### PR DESCRIPTION
Upstream main is red since Sep 8: `npm run format:check` fails on 5 files. This applies the prettier pass so CI goes green. Pure formatting, no behavior change.

Files: `server/i18n.ts`, `server/locales.ts`, `web/src/components/TopBar.tsx`, `web/src/use-chat.ts`, `tests/unit/locales-server.test.ts`.

Test: `format:check` passes; `typecheck` green; `locales-server` 7 tests pass.
