### PR TITLE
fix(model-admin): 保存服务商时保留 models.json 中 UI 不认识的字段

### DIFF
--- a/server/model-admin.ts
+++ b/server/model-admin.ts
@@ -72,6 +72,62 @@ function stripJsonComments(src: string): string {
 	return out;
 }
 
+/** Merge a UI-submitted provider config into the existing models.json entry.
+ *
+ * 表单（`UiProviderConfig`）只承载 UI 认识的字段：provider 级 name/api/baseUrl/
+ * apiKey/authHeader，模型级 id/name/reasoning/input/contextWindow/maxTokens。
+ * models.json 里还可能有 UI 不认识的字段——provider 级 headers（浏览器拿不到，
+ * 见 listModelsConfig）、模型级 api/baseUrl/cost/compat/thinkingLevelMap（手写或
+ * 脚本写入，pi-ai 靠它们决定请求地址与推理格式）。按表单整体重建条目会把这些字段
+ * 静默抹掉，可能把可用的配置改坏：模型级 baseUrl 丢失后会回退到对该 api 适配器
+ * 无效的地址（例如 opencode-go 的 anthropic baseUrl），请求直接打到不存在的路径。
+ *
+ * 所以这里以已有条目为底、表单字段覆盖：表单没提到的字段原样保留，表单清空的可选
+ * 字段才真正删除；`models` 仍是「表单即全集」——表单里删掉的 id 会被移除。
+ */
+export function mergeProviderConfigEntry(
+	prevEntry: Record<string, unknown> | undefined,
+	config: UiProviderConfig,
+	models: UiModelConfigEntry[],
+): Record<string, unknown> {
+	const prevModels = new Map<string, Record<string, unknown>>();
+	if (Array.isArray(prevEntry?.models)) {
+		for (const entry of prevEntry.models) {
+			if (!entry || typeof entry !== "object") continue;
+			const id = (entry as { id?: unknown }).id;
+			if (typeof id === "string" && id.trim()) prevModels.set(id.trim(), entry as Record<string, unknown>);
+		}
+	}
+	const mergedModels = models.map((model) => {
+		// 旧条目同 id 的字段（api/baseUrl/cost/compat/…）先铺底，表单字段覆盖。
+		const merged: Record<string, unknown> = { ...(prevModels.get(model.id) ?? {}), id: model.id };
+		if (model.name?.trim()) merged.name = model.name.trim();
+		else delete merged.name;
+		if (model.reasoning) merged.reasoning = true;
+		else delete merged.reasoning;
+		if (model.input?.length) merged.input = model.input;
+		else delete merged.input;
+		if (model.contextWindow) merged.contextWindow = Number(model.contextWindow);
+		else delete merged.contextWindow;
+		if (model.maxTokens) merged.maxTokens = Number(model.maxTokens);
+		else delete merged.maxTokens;
+		return merged;
+	});
+
+	const mergedEntry: Record<string, unknown> = { ...prevEntry };
+	const apply = (key: string, value: unknown): void => {
+		if (value === undefined) delete mergedEntry[key];
+		else mergedEntry[key] = value;
+	};
+	apply("name", config.name?.trim() || undefined);
+	apply("api", config.api?.trim() || undefined);
+	apply("baseUrl", config.baseUrl?.trim() || undefined);
+	apply("apiKey", config.apiKey?.trim() || undefined);
+	apply("authHeader", config.authHeader ? true : undefined);
+	mergedEntry.models = mergedModels;
+	return mergedEntry;
+}
+
 /** Numeric metadata value (NaN/string "unknown" → undefined). */
 function numMeta(v: unknown): number | undefined {
 	return typeof v === "number" && Number.isFinite(v) ? v : undefined;
@@ -1181,18 +1237,9 @@ export class ModelAdminService {
 		}
 		try {
 			const { providers } = this.readModelsConfig();
-			// headers never reach the browser, so the incoming config can't carry
-			// them — preserve the previously stored values when they are absent.
-			const prevHeaders = providers[pid]?.headers;
-			providers[pid] = {
-				...(config.name?.trim() ? { name: config.name.trim() } : {}),
-				...(config.api?.trim() ? { api: config.api.trim() } : {}),
-				...(config.baseUrl?.trim() ? { baseUrl: config.baseUrl.trim() } : {}),
-				...(config.apiKey?.trim() ? { apiKey: config.apiKey.trim() } : {}),
-				...(config.authHeader ? { authHeader: true } : {}),
-				...(prevHeaders && Object.keys(prevHeaders).length > 0 ? { headers: prevHeaders } : {}),
-				models,
-			};
+			// 合并而不是重建：UI 认识之外的字段（provider 级 headers、模型级 api/
+			// baseUrl/cost/compat/thinkingLevelMap）必须原样保留，见 mergeProviderConfigEntry。
+			providers[pid] = mergeProviderConfigEntry(providers[pid], config, models);
 			mkdirSync(this.host.agentDir, { recursive: true });
 			writeFileSync(this.modelsConfigPath(), JSON.stringify({ providers }, null, 2) + "\n");
 

--- a/tests/unit/model-admin-merge.test.ts
+++ b/tests/unit/model-admin-merge.test.ts
@@ -1,0 +1,182 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { ModelAdminService, mergeProviderConfigEntry, type ModelAdminHost } from "../../server/model-admin.js";
+import type { ServerMessage, UiModelConfigEntry, UiProviderConfig } from "../../server/protocol.js";
+
+/** 表单带上的模型行（UI 只认识这几个字段）。 */
+function formModel(id: string, overrides: Partial<UiModelConfigEntry> = {}): UiModelConfigEntry {
+	return { id, ...overrides };
+}
+
+function formConfig(models: UiModelConfigEntry[], overrides: Partial<UiProviderConfig> = {}): UiProviderConfig {
+	return { providerId: "opencode-go", api: "openai-completions", models, ...overrides };
+}
+
+/** 覆盖内置 provider 的 models.json 条目：模型级 api/baseUrl/cost/compat 都是 UI 不认识的字段。 */
+const storedOverrideEntry = {
+	api: "openai-completions",
+	baseUrl: "https://opencode.ai/zen/go/v1",
+	headers: { "X-Test": "1" },
+	models: [
+		{
+			id: "deepseek-flash",
+			name: "DeepSeek V4.1 Flash",
+			api: "openai-completions",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			cost: { input: 0.22, output: 0.66, cacheRead: 0.007, cacheWrite: 0 },
+			compat: { thinkingFormat: "deepseek" },
+			thinkingLevelMap: { low: "low", high: "high" },
+			contextWindow: 1000000,
+			maxTokens: 384000,
+		},
+	],
+};
+
+describe("mergeProviderConfigEntry", () => {
+	it("没有旧条目时，产出与旧实现一致的条目形状", () => {
+		const rows = [
+			formModel("m1", { name: "M1", reasoning: true, input: ["text"], contextWindow: 1000, maxTokens: 100 }),
+		];
+		const merged = mergeProviderConfigEntry(undefined, formConfig(rows, { baseUrl: "https://example.test/v1" }), rows);
+		expect(merged).toEqual({
+			api: "openai-completions",
+			baseUrl: "https://example.test/v1",
+			models: [{ id: "m1", name: "M1", reasoning: true, input: ["text"], contextWindow: 1000, maxTokens: 100 }],
+		});
+	});
+
+	it("provider 级未知字段原样保留（headers 及任意自定义键）", () => {
+		const prev = {
+			apiKey: "stored",
+			headers: { Authorization: "Bearer secret" },
+			extraField: { nested: true },
+			models: [{ id: "m1" }],
+		};
+		const merged = mergeProviderConfigEntry(prev, formConfig([formModel("m1")]), [formModel("m1")]);
+		expect(merged.headers).toEqual({ Authorization: "Bearer secret" });
+		expect(merged.extraField).toEqual({ nested: true });
+		// apiKey 是表单字段（listModelsConfig 会下发、表单回填）：表单没带即按清空处理，
+		// 与旧实现一致；显式清除密钥走 clear_provider_api_key。
+		expect("apiKey" in merged).toBe(false);
+	});
+
+	it("模型级未知字段原样保留（覆盖内置 provider 的场景）", () => {
+		const rows = [
+			formModel("deepseek-flash", {
+				name: "DeepSeek V4.1 Flash",
+				reasoning: true,
+				contextWindow: 1000000,
+				maxTokens: 384000,
+			}),
+		];
+		const merged = mergeProviderConfigEntry(storedOverrideEntry, formConfig(rows), rows);
+		expect(merged.models).toEqual([{ ...storedOverrideEntry.models[0], reasoning: true }]);
+	});
+
+	it("表单字段覆盖旧值（含数字字段归一）", () => {
+		const prev = {
+			name: "旧名字",
+			baseUrl: "https://old.test/v1",
+			models: [{ id: "m1", name: "旧模型名", contextWindow: 1000, maxTokens: 10, cost: { input: 1 } }],
+		};
+		const rows = [formModel("m1", { name: "新模型名", contextWindow: 2000, maxTokens: 20 })];
+		const merged = mergeProviderConfigEntry(
+			prev,
+			formConfig(rows, { name: "新名字", baseUrl: "https://new.test/v1" }),
+			rows,
+		);
+		expect(merged.name).toBe("新名字");
+		expect(merged.baseUrl).toBe("https://new.test/v1");
+		expect(merged.models).toEqual([
+			{ id: "m1", name: "新模型名", contextWindow: 2000, maxTokens: 20, cost: { input: 1 } },
+		]);
+	});
+
+	it("表单清空的可选字段被删除，不残留旧值", () => {
+		const prev = {
+			models: [
+				{
+					id: "m1",
+					name: "旧模型名",
+					reasoning: true,
+					input: ["text", "image"],
+					contextWindow: 1000,
+					maxTokens: 100,
+					compat: { thinkingFormat: "deepseek" },
+				},
+			],
+		};
+		const merged = mergeProviderConfigEntry(prev, formConfig([formModel("m1")]), [formModel("m1")]);
+		expect(merged.models).toEqual([{ id: "m1", compat: { thinkingFormat: "deepseek" } }]);
+	});
+
+	it("models 是「表单即全集」：删掉的 id 移除，新 id 追加", () => {
+		const prev = {
+			models: [
+				{ id: "keep", cost: { input: 1 } },
+				{ id: "drop", cost: { input: 2 } },
+			],
+		};
+		const rows = [formModel("keep"), formModel("added", { reasoning: true })];
+		const merged = mergeProviderConfigEntry(prev, formConfig(rows), rows);
+		expect(merged.models).toEqual([
+			{ id: "keep", cost: { input: 1 } },
+			{ id: "added", reasoning: true },
+		]);
+	});
+
+	it("容忍旧条目里的脏数据（非对象 / 缺 id / 空白 id）", () => {
+		const prev = { models: [null, "oops", { name: "无 id" }, { id: "   " }, { id: "ok" }] };
+		const rows = [formModel("ok", { name: "OK" })];
+		const merged = mergeProviderConfigEntry(prev, formConfig(rows), rows);
+		expect(merged.models).toEqual([{ id: "ok", name: "OK" }]);
+	});
+});
+
+describe("ModelAdminService.saveModelConfig", () => {
+	it("保存后 models.json 里 UI 不认识的字段仍在（旧实现会静默丢弃）", async () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-web-ui-model-admin-"));
+		const configPath = join(agentDir, "models.json");
+		writeFileSync(configPath, JSON.stringify({ providers: { "opencode-go": storedOverrideEntry } }, null, 2) + "\n");
+
+		const notices: ServerMessage[] = [];
+		const host = {
+			agentDir,
+			emit: (msg: ServerMessage) => {
+				notices.push(msg);
+			},
+			flushSnapshot: () => {},
+			isDisposed: () => false,
+			modelRuntime: () => ({ refresh: async () => {}, setRuntimeApiKey: async () => {} }) as unknown as ModelRuntime,
+			invalidatePiConfig: () => {},
+			pushModels: async () => {},
+		} satisfies ModelAdminHost;
+
+		try {
+			const service = new ModelAdminService(host);
+			const rows = [
+				formModel("deepseek-flash", {
+					name: "DeepSeek V4.1 Flash",
+					reasoning: true,
+					contextWindow: 1000000,
+					maxTokens: 384000,
+				}),
+			];
+			await service.saveModelConfig("opencode-go", formConfig(rows));
+
+			const written = JSON.parse(readFileSync(configPath, "utf8")) as {
+				providers: Record<string, Record<string, unknown>>;
+			};
+			const entry = written.providers["opencode-go"];
+			// provider 级 headers（浏览器拿不到）与模型级 api/baseUrl/cost/compat 必须存活。
+			expect(entry.headers).toEqual({ "X-Test": "1" });
+			expect(entry.models).toEqual([{ ...storedOverrideEntry.models[0], reasoning: true }]);
+			expect(notices.some((msg) => msg.type === "notice")).toBe(true);
+		} finally {
+			rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
Fixes #106

## 问题

「设置 → 模型/服务商」里点保存时，`saveModelConfig()` 按表单字段白名单**重建** models.json 条目，UI 表单承载不了的字段被静默删除：

- provider 级：`headers` 之外的自定义键；
- 模型级：`api` / `baseUrl` / `cost` / `compat` / `thinkingLevelMap`（`UiModelConfigEntry` 只声明了 `id/name/reasoning/input/contextWindow/maxTokens`）。

`models.json` 是 pi 的配置真源（可手写、可由脚本写入），字段集比 UI 表单大。丢失模型级 `baseUrl` 会让 pi-ai 回退到 provider 级 baseUrl，opencode-go 这类 provider 的回退值不带 `/v1`，请求就打到了不存在的路径（opencode.ai 官网的 404 HTML）。原代码只对 `headers` 做了特判保留，说明这类丢失是已知的；本 PR 把它推广到"所有 UI 不认识的字段"。

## 改动

- 新增纯函数 `mergeProviderConfigEntry(prevEntry, config, models)`（`server/model-admin.ts`，导出以便单测）：
  - provider 级：以磁盘上旧条目为底 → 表单字段覆盖 → 表单没带的已知字段删除（保持原有"清空即删除"语义）；
  - 模型级：按 `id` 与旧条目合并，旧条目同 id 的未知字段（`api`/`baseUrl`/`cost`/`compat`/`thinkingLevelMap`/…）保留，表单字段覆盖；
  - `models` 仍是"表单即全集"：表单里删掉的 id 被移除，新 id 追加；
  - `headers` 的特判被通用逻辑吸收（少一个特例）。
- `saveModelConfig()` 由"重建条目"改为调用该函数（净 -12/+59 行，无协议/前端改动）。

## 测试

新增 `tests/unit/model-admin-merge.test.ts`（8 例）：

- 无旧条目时的产出与旧实现一致（防回归快照）；
- provider 级未知字段（`headers` + 任意自定义键）保留；
- 模型级未知字段（`api/baseUrl/cost/compat/thinkingLevelMap`）保留；
- 表单字段覆盖旧值（含数字归一）；
- 表单清空的可选字段被删除；
- `models` 集合语义（删 id / 加 id）；
- 旧条目脏数据（`null`/字符串/缺 id）不崩；
- **服务级回归**：临时 agentDir + 假 host，`saveModelConfig` 落盘后断言未知字段仍在（该用例在改动前**失败**：`expected [ { id: 'deepseek-flash', …(4) } ] to deeply equal [ { id: 'deepseek-flash', …(9) } ]`）。

本地验证：

```
npx vitest run tests/unit/model-admin-merge.test.ts   # 8 passed
npx vitest run                                        # 487 passed（3 个 pty 测试文件因本机未装构建工具、node-pty 原生模块缺失而无法加载，与本次改动无关）
npm run typecheck && npm run lint && npm run format:check
```

## 兼容性

对 UI 表单**认识**的字段，语义与改动前完全一致（提供即写、清空即删）；唯一行为变化是"UI 不认识的字段不再被删除"，因此不会破坏既有配置，反而修复了静默丢字段。
