### PR TITLE
feat(web): 右栏「文件区 ↔ widgets」可拖拽调高（与左栏同款权重模型）

### DIFF
--- a/tests/unit/panel-sash.test.ts
+++ b/tests/unit/panel-sash.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { applySashDrag, parseWeights } from "../../web/src/panel-sash.js";
+
+describe("parseWeights", () => {
+	const defaults = { files: 4, widgets: 1 };
+
+	it("没有存档时返回默认权重", () => {
+		expect(parseWeights(null, defaults)).toEqual(defaults);
+	});
+
+	it("坏 JSON / 非对象 / 数组 → 默认权重", () => {
+		expect(parseWeights("{不是 JSON", defaults)).toEqual(defaults);
+		expect(parseWeights("42", defaults)).toEqual(defaults);
+		expect(parseWeights("[4,1]", defaults)).toEqual(defaults);
+	});
+
+	it("逐键校验：0 / 负数 / NaN / 字符串 → 该键回落默认", () => {
+		expect(parseWeights(JSON.stringify({ files: 0, widgets: -2 }), defaults)).toEqual(defaults);
+		expect(parseWeights(JSON.stringify({ files: "9", widgets: null }), defaults)).toEqual(defaults);
+		expect(parseWeights(JSON.stringify({ files: 7 }), defaults)).toEqual({ files: 7, widgets: 1 });
+	});
+
+	it("合法存档原样读取（含小数）", () => {
+		expect(parseWeights(JSON.stringify({ files: 2.5, widgets: 0.5 }), defaults)).toEqual({ files: 2.5, widgets: 0.5 });
+	});
+});
+
+describe("applySashDrag", () => {
+	const base = { start: { above: 4, below: 1 }, availablePx: 400, totalWeight: 5, minAbovePx: 120, minBelowPx: 56 };
+
+	it("可用高度 / 总权重 → 像素与权重的线性换算", () => {
+		// 400px / 5 权重 = 80px 每权重；向下拖 20px → above +0.25（仍在最小像素之间）
+		const r = applySashDrag({ ...base, deltaPx: 20 });
+		expect(r.above).toBeCloseTo(4.25, 10);
+		expect(r.below).toBeCloseTo(0.75, 10);
+	});
+
+	it("总权重守恒", () => {
+		for (const deltaPx of [-999, -37, 0, 12, 260, 9999]) {
+			const { above, below } = applySashDrag({ ...base, deltaPx });
+			expect(above + below).toBeCloseTo(5, 10);
+		}
+	});
+
+	it("上边界：above 不低于最小像素（120px → 1.5 权重）", () => {
+		const r = applySashDrag({ ...base, deltaPx: -9999 });
+		expect(r.above).toBeCloseTo(1.5, 10);
+		expect(r.below).toBeCloseTo(3.5, 10);
+	});
+
+	it("下边界：below 不低于最小像素（56px → 0.7 权重）", () => {
+		const r = applySashDrag({ ...base, deltaPx: 9999 });
+		expect(r.above).toBeCloseTo(4.3, 10);
+		expect(r.below).toBeCloseTo(0.7, 10);
+	});
+
+	it("可用高度为 0（面板被压缩）不产生 NaN / Infinity", () => {
+		const r = applySashDrag({ ...base, availablePx: 0, deltaPx: 100 });
+		expect(Number.isFinite(r.above)).toBe(true);
+		expect(Number.isFinite(r.below)).toBe(true);
+		expect(r.above).toBeGreaterThan(0);
+		expect(r.below).toBeGreaterThan(0);
+	});
+
+	it("两个最小值之和超过可用高度时折中，不翻转", () => {
+		// 60px 高、最小 120 + 56：装不下 → above/below 折中且都为正
+		const r = applySashDrag({ ...base, availablePx: 60, deltaPx: 40 });
+		expect(r.above).toBeGreaterThan(0);
+		expect(r.below).toBeGreaterThan(0);
+		expect(r.above + r.below).toBeCloseTo(5, 10);
+		expect(applySashDrag({ ...base, availablePx: 60, deltaPx: -40 })).toEqual(r);
+	});
+
+	it("totalWeight 传 0 / 负数时按 1 处理（不炸）", () => {
+		for (const totalWeight of [0, -3]) {
+			const r = applySashDrag({ ...base, totalWeight, deltaPx: 10 });
+			expect(Number.isFinite(r.above)).toBe(true);
+			expect(r.above + r.below).toBeCloseTo(5, 10);
+		}
+	});
+});

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -17,9 +17,17 @@ import {
 import type { ClientMessage, FileListing } from "../types";
 import { useT } from "../i18n";
 import { downloadFile, DOWNLOAD_FILE_NOT_FOUND } from "../download";
+import { applySashDrag, parseWeights } from "../panel-sash";
 
 /** 机器根（此电脑/盘符列表）wire 字面量 —— 与 server/files-service.ts 的 MACHINE_ROOT 同值。 */
 const MACHINE_ROOT = "@root";
+
+/** 右栏纵向分割（文件区 ↔ widgets）的默认权重与最小高度 —— 与左栏同一套权重模型。 */
+const LS_RP_SIZES = "pi-web-ui:rp-sizes";
+type RpWeights = { files: number; widgets: number };
+const DEFAULT_RP_WEIGHTS: RpWeights = { files: 4, widgets: 1 };
+const RP_MIN_FILES_PX = 120;
+const RP_MIN_WIDGETS_PX = 56;
 
 type AttachMode = "inline" | "reference";
 
@@ -62,6 +70,57 @@ export const RightPanel = memo(function RightPanel({
 	// 点击放大的 widget（居中浮层展示完整宽度输出）。
 	const [expandedWidget, setExpandedWidget] = useState<string | null>(null);
 	const [loading, setLoading] = useState(false);
+
+	// ---- 文件区 ↔ widgets 的纵向分割（与左栏 VSCode 风格分割同款：拖动改权重、双击复位） ----
+	const panelRef = useRef<HTMLElement>(null);
+	const crumbsRef = useRef<HTMLDivElement>(null);
+	const [rpWeights, setRpWeights] = useState<RpWeights>(() => {
+		try {
+			return parseWeights(localStorage.getItem(LS_RP_SIZES), DEFAULT_RP_WEIGHTS);
+		} catch {
+			return { ...DEFAULT_RP_WEIGHTS };
+		}
+	});
+	useEffect(() => {
+		try {
+			localStorage.setItem(LS_RP_SIZES, JSON.stringify(rpWeights));
+		} catch {}
+	}, [rpWeights]);
+	const hasWidgets = widgets.some((w) => w.lines.length > 0);
+	const onSashDown = useCallback(
+		(e: React.PointerEvent<HTMLDivElement>) => {
+			e.preventDefault();
+			const panel = panelRef.current;
+			if (!panel) return;
+			const target = e.currentTarget;
+			const startY = e.clientY;
+			const start = { above: rpWeights.files, below: rpWeights.widgets };
+			// 面包屑是固定高的头部（不参与权重）：可用高度要扣掉它
+			const available = Math.max(120, panel.clientHeight - (crumbsRef.current?.offsetHeight ?? 32));
+			target.classList.add("dragging");
+			document.body.classList.add("rp-resizing");
+			const onMove = (ev: PointerEvent) => {
+				const { above, below } = applySashDrag({
+					start,
+					deltaPx: ev.clientY - startY,
+					availablePx: available,
+					totalWeight: start.above + start.below,
+					minAbovePx: RP_MIN_FILES_PX,
+					minBelowPx: RP_MIN_WIDGETS_PX,
+				});
+				setRpWeights({ files: above, widgets: below });
+			};
+			const onUp = () => {
+				window.removeEventListener("pointermove", onMove);
+				window.removeEventListener("pointerup", onUp);
+				target.classList.remove("dragging");
+				document.body.classList.remove("rp-resizing");
+			};
+			window.addEventListener("pointermove", onMove);
+			window.addEventListener("pointerup", onUp);
+		},
+		[rpWeights.files, rpWeights.widgets],
+	);
 
 	// ---- Right-click context menu ------------------------------------
 	// Menu shows at (x, y); dir = the dir uploaded files land in ("" = root).
@@ -343,13 +402,13 @@ export const RightPanel = memo(function RightPanel({
 	})();
 
 	return (
-		<aside className="panel panel-right">
+		<aside className="panel panel-right" ref={panelRef}>
 			{collapsible && onToggleCollapse && (
 				<button type="button" className="panel-collapse-btn" title={t("collapsePanel")} onClick={onToggleCollapse}>
 					<FiChevronsRight />
 				</button>
 			)}
-			<div className="panel-crumbs">
+			<div className="panel-crumbs" ref={crumbsRef}>
 				<button type="button" className={`crumb ${currentPath === "" ? "active" : ""}`} onClick={() => request("")}>
 					{t("rootDir")}
 				</button>
@@ -377,6 +436,7 @@ export const RightPanel = memo(function RightPanel({
 			<div
 				ref={bodyRef}
 				className="panel-body"
+				style={hasWidgets ? { flexGrow: rpWeights.files, minHeight: RP_MIN_FILES_PX } : undefined}
 				onContextMenu={(e) => openCtxMenu(e, currentPath)}
 				onDragOver={(e) => {
 					if (!isFileDrag(e)) return;
@@ -547,8 +607,16 @@ export const RightPanel = memo(function RightPanel({
 				)}
 				{!loading && !files && <div className="panel-empty">{t("noFiles")}</div>}
 			</div>
-			{widgets.filter((w) => w.lines.length > 0).length > 0 && (
-				<div className="panel-widgets">
+			{hasWidgets && (
+				<div
+					className="rp-sash"
+					onPointerDown={onSashDown}
+					onDoubleClick={() => setRpWeights({ ...DEFAULT_RP_WEIGHTS })}
+					title={t("dragToResize")}
+				/>
+			)}
+			{hasWidgets && (
+				<div className="panel-widgets" style={{ flexGrow: rpWeights.widgets, minHeight: RP_MIN_WIDGETS_PX }}>
 					{widgets
 						.filter((w) => w.lines.length > 0)
 						.map((w) => (

--- a/web/src/panel-sash.ts
+++ b/web/src/panel-sash.ts
@@ -1,0 +1,73 @@
+/**
+ * 面板纵向分割（sash）纯计算 —— 与左栏 VSCode 风格分割同一套「权重」模型：
+ * 各段用 flex-grow 权重按比例分配高度，拖动只改相邻两段的权重、总权重守恒，
+ * 双击复位到默认权重。
+ *
+ * 这里只放可单测的数学与解析；量高度、挂 pointer 事件留在组件里
+ * （见 `components/RightPanel.tsx`；左栏的等价逻辑目前内联在 `LeftPanel.tsx`）。
+ */
+
+/** 相邻两段的权重（above = 上方/前一段，below = 下方/后一段）。 */
+export interface SashPair {
+	above: number;
+	below: number;
+}
+
+/**
+ * 解析持久化的权重（localStorage 里可能是旧版本、被手改或截断的 JSON）：
+ * 逐键校验，非「有限正数」的键回落默认值，整体坏 JSON 则全量默认。
+ */
+export function parseWeights<T extends Record<string, number>>(raw: string | null, defaults: T): T {
+	const out: Record<string, number> = { ...defaults };
+	if (!raw) return out as T;
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			for (const key of Object.keys(defaults)) {
+				const value = (parsed as Record<string, unknown>)[key];
+				if (typeof value === "number" && Number.isFinite(value) && value > 0) out[key] = value;
+			}
+		}
+	} catch {
+		// 坏 JSON → 全量默认
+	}
+	return out as T;
+}
+
+export interface SashDragInput {
+	/** 开始拖动时的权重快照。 */
+	start: SashPair;
+	/** 指针纵向位移（向下为正，px）。 */
+	deltaPx: number;
+	/** 参与分配的可用高度（px）；面板被压缩到 0 时也安全。 */
+	availablePx: number;
+	/** 参与分配的总权重（含未拖动裁剪的其它段）。 */
+	totalWeight: number;
+	/** 上下两段的最小高度（px）。 */
+	minAbovePx: number;
+	minBelowPx: number;
+}
+
+/**
+ * 拖动结果：两段权重总和守恒，且各自不小于最小像素；
+ * 退化情形（可用高度为 0、两个最小值之和超过可用高度）不产生 NaN / 负数 / 抖动。
+ */
+export function applySashDrag(input: SashDragInput): SashPair {
+	const pairTotal = input.start.above + input.start.below;
+	const available = Math.max(1, input.availablePx);
+	const totalWeight = input.totalWeight > 0 ? input.totalWeight : 1;
+	const pxPerWeight = available / totalWeight;
+	const minAboveWeight = input.minAbovePx / pxPerWeight;
+	const minBelowWeight = input.minBelowPx / pxPerWeight;
+	if (minAboveWeight + minBelowWeight >= pairTotal) {
+		// 面板太矮：两个最小值已装不下（甚至重叠）→ 按最小像素比例折中，保证都为正且总量守恒
+		const minTotal = input.minAbovePx + input.minBelowPx || 1;
+		const above = (pairTotal * input.minAbovePx) / minTotal;
+		return { above, below: pairTotal - above };
+	}
+	const above = Math.min(
+		pairTotal - minBelowWeight,
+		Math.max(minAboveWeight, input.start.above + input.deltaPx / pxPerWeight),
+	);
+	return { above, below: pairTotal - above };
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -497,7 +497,8 @@ body.panel-resizing {
 }
 
 /* Sash between two expanded sections — 仅在两端均为展开态时渲染 (JS 控制) */
-.lp-sash {
+.lp-sash,
+.rp-sash {
 	flex-shrink: 0;
 	height: 6px;
 	margin: -3px 0;
@@ -506,7 +507,8 @@ body.panel-resizing {
 	cursor: row-resize;
 	touch-action: none;
 }
-.lp-sash::after {
+.lp-sash::after,
+.rp-sash::after {
 	content: "";
 	position: absolute;
 	left: 0;
@@ -520,16 +522,20 @@ body.panel-resizing {
 		height 0.15s ease;
 }
 .lp-sash:hover::after,
-.lp-sash.dragging::after {
+.lp-sash.dragging::after,
+.rp-sash:hover::after,
+.rp-sash.dragging::after {
 	background: var(--accent);
 	height: 2px;
 	margin-top: -1px;
 }
-body.lp-resizing {
+body.lp-resizing,
+body.rp-resizing {
 	cursor: row-resize;
 	user-select: none;
 }
-body.lp-resizing .lp-sash.dragging::after {
+body.lp-resizing .lp-sash.dragging::after,
+body.rp-resizing .rp-sash.dragging::after {
 	opacity: 0.9;
 }
 
@@ -629,11 +635,10 @@ body.lp-resizing .lp-sash.dragging::after {
 /* ------------------------------------------------------ extension widgets */
 
 .panel-widgets {
-	flex-shrink: 0;
-	max-height: 40%;
+	/* 高度由「文件区 ↔ widgets」的权重决定（见 RightPanel 的 rp-sash）；分隔线交给 sash 画。 */
+	flex: 1 1 0;
 	overflow-y: auto;
 	padding: 8px;
-	border-top: 1px solid var(--border-soft);
 	background: rgba(0, 0, 0, 0.15);
 }
 


### PR DESCRIPTION
## 背景

右栏（`RightPanel`）底部的 widgets 区高度是写死的：`.panel-widgets { flex-shrink: 0; max-height: 40% }`——内容少时白占一块地方，内容多时只能挤在小框里滚，用户无法调整。左栏早就是 VSCode 风格的可拖拽分割（权重 + 双击复位 + 本地记忆），右栏缺这一半。

## 改动

- **新增 `web/src/panel-sash.ts`**（纯函数，配单测）：
  - `parseWeights(raw, defaults)`：解析 localStorage 存档，坏 JSON / 非对象 / 非法值逐键回落默认；
  - `applySashDrag(...)`：像素位移 → 权重换算，双侧最小像素钳制，两段权重总量守恒；面板被压得很矮（可用高度 0、两个最小值装不下）时按最小像素比例折中，不产生 NaN / 负数 / 拖动翻转。
- **`RightPanel`**：文件区（固定高的面包屑 + `.panel-body`）与 widgets 区按权重 flex 分配；两区之间插入 `.rp-sash`（`pointerdown` 拖动、双击复位、`localStorage` 记忆，键 `pi-web-ui:rp-sizes`，与左栏 `pi-web-ui:lp-sizes` 对齐）。
- **`styles.css`**：`.rp-sash` 与 `.lp-sash` 共用同一套样式（6px 命中区、负 margin 压边、悬停/拖拽高亮、`touch-action: none`）；`.panel-widgets` 从「固定 max-height」改为权重弹性（`flex: 1 1 0`），原本的分隔线交给 sash 画（去掉它自己的 `border-top`，避免双线）。
- **无新 i18n key**（复用已有 `dragToResize`），**无协议改动**，**未改动左栏**（其等价逻辑仍内联在 `LeftPanel.tsx`，后续可统一到 `panel-sash.ts`）。

## 验证

- `npx vitest run tests/unit/panel-sash.test.ts` → **11 passed**
- `npx vitest run` → **509 passed**（本机 3 个 node-pty 相关测试文件因未构建原生模块无法加载，与本次改动无关；CI 正常构建）
- `npm run typecheck` / `npm run lint` / `npm run format:check` 全过
- 手测：拖分隔条上下移动、双击复位、刷新后高度保持；widgets 为空时行为与改动前一致（不渲染 sash，文件区占满）。

## 备注

- 默认权重 `files: 4 / widgets: 1`（约 80/20，接近原 `max-height: 40%` 常见形态）；最小高度 120px / 56px，面板过矮时按最小比例折中而不是抖动。
- 移动端：sash 走 pointer 事件（含触摸），抽屉模式下同样可拖。
