### PR TITLE
fix(settings): use language-aware marker guidance in the marker list

### DIFF
--- a/server/marker-service.ts
+++ b/server/marker-service.ts
@@ -314,7 +314,11 @@ export class MarkerService {
 		for (const m of allMarkers()) {
 			if (seen.has(m.name)) continue;
 			seen.add(m.name);
-			out.push({ name: m.name, enabled: this.isMarkerEnabled(m.name), guidance: m.guidance });
+			out.push({
+				name: m.name,
+				enabled: this.isMarkerEnabled(m.name),
+				guidance: m.getGuidance?.(this.lang()) ?? m.guidance,
+			});
 		}
 		return out;
 	}


### PR DESCRIPTION
The Settings → Markers list (descriptions + "?" tooltips) stays in Chinese for every UI language: `listForUi()` sends the static `m.guidance` instead of the language-aware `m.getGuidance(lang)` that `collectGuidance`/`buildGuidance` already use (its pack keys `markers.*.guidance` are already translated).