### PR TITLE
fix(server): 移除单条排队消息只删一条（同文本重复排队不再连带删除）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ pi-web-ui/
 │   ├── agent-service.ts        # 核心：ClientSession（每客户端一个会话组，可并行多个对话）+ AgentService
 │   ├── serialize.ts            # SDK 消息 → UiMessage 序列化
 │   ├── text-sniff.ts           # 文件预览纯函数（previewKind/looksLikeText/decodeText/sniffImageMime/hexDump/countLines）
+│   ├── queue-utils.ts          # 排队消息纯函数（removeFirstOccurrence：只移除第一条匹配，重复文本不连带删除）
 │   ├── process-utils.ts        # 进程工具：snapshotListeningPorts/killPidTree/lookupProcessName
 │   ├── client-state.ts         # ClientStateStore：<dataDir>/client-state.json 持久化
 │   ├── uploads.ts              # 文件对话上传 + 保留期清理

--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -45,6 +45,7 @@ import {
 	type UpdateItem,
 } from "./update-check.js";
 import { hasActiveSubagentRun, hasPendingWaitSubscription, shouldRetainActive } from "./wait-subscription-scan.js";
+import { removeFirstOccurrence } from "./queue-utils.js";
 import type {
 	PluginAgentTool,
 	PluginCommandDef,
@@ -3642,8 +3643,10 @@ export class ClientSession {
 			return;
 		}
 		const { steering, followUp } = s.clearQueue();
-		const keptSteering = steering.filter((t) => !(kind === "steer" && t === text));
-		const keptFollowUp = followUp.filter((t) => !(kind === "followUp" && t === text));
+		// 只移除第一条匹配：气泡 ✕ 对应的是「一条」消息，重复文本不能连带删除
+		// （旧实现用值过滤会把所有同文本项一起删掉，与本地显示镜像不一致）。
+		const keptSteering = kind === "steer" ? removeFirstOccurrence(steering, text) : steering;
+		const keptFollowUp = kind === "followUp" ? removeFirstOccurrence(followUp, text) : followUp;
 		// Re-queue the survivors in original order. Guard each call so a single
 		// failure can't leave the queue half-drained silently.
 		for (const t of keptSteering) {

--- a/server/queue-utils.ts
+++ b/server/queue-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * 排队消息（插队 steer / 排队 followUp）纯函数 —— 独立成模块是为了可单测
+ * （`AgentService` 依赖 SDK 与运行时，不适合在单测里 import）。
+ *
+ * 背景：pi SDK 没有「按条操作队列」的 API，服务端移除一条排队消息的做法是
+ * `clearQueue()` 之后把幸存者按原顺序重新入队（见 `AgentService.removeQueued`）。
+ * 重建时若用值过滤（`list.filter((t) => t !== text)`），会把**所有**同文本项一起删掉；
+ * 而气泡上的 ✕ 只对应一条消息、本地显示镜像也只移除一条 → 同一条文本被排队两次时
+ * 「点一次 ✕ 删两条」，且显示与真实队列在下次 `queue_update` 之前不一致。
+ * 因此统一按「只移除第一处匹配」处理。
+ */
+
+/** 移除列表中第一处等于 `text` 的项；找不到时返回入参的拷贝（不修改入参）。 */
+export function removeFirstOccurrence(list: readonly string[], text: string): string[] {
+	const index = list.indexOf(text);
+	if (index < 0) return [...list];
+	return [...list.slice(0, index), ...list.slice(index + 1)];
+}

--- a/tests/unit/queue-utils.test.ts
+++ b/tests/unit/queue-utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { removeFirstOccurrence } from "../../server/queue-utils.js";
+
+describe("removeFirstOccurrence", () => {
+	it("移除唯一匹配项", () => {
+		expect(removeFirstOccurrence(["a", "b", "c"], "b")).toEqual(["a", "c"]);
+	});
+
+	it("重复文本只移除第一条（✕ 对应一条消息）", () => {
+		expect(removeFirstOccurrence(["dup", "x", "dup"], "dup")).toEqual(["x", "dup"]);
+		expect(removeFirstOccurrence(["dup", "dup"], "dup")).toEqual(["dup"]);
+	});
+
+	it("找不到时原样返回（拷贝，不是同一引用）", () => {
+		const list = ["a", "b"];
+		const out = removeFirstOccurrence(list, "zzz");
+		expect(out).toEqual(["a", "b"]);
+		expect(out).not.toBe(list);
+	});
+
+	it("空列表与空字符串", () => {
+		expect(removeFirstOccurrence([], "a")).toEqual([]);
+		expect(removeFirstOccurrence(["", "a"], "")).toEqual(["a"]);
+	});
+
+	it("不修改入参", () => {
+		const list = ["a", "b", "a"];
+		removeFirstOccurrence(list, "a");
+		expect(list).toEqual(["a", "b", "a"]);
+	});
+
+	it("保持其余项顺序（重新入队依赖原顺序）", () => {
+		expect(removeFirstOccurrence(["1", "2", "3", "4"], "3")).toEqual(["1", "2", "4"]);
+	});
+});


### PR DESCRIPTION
## 问题

排队/插队气泡上的 ✕ 只对应**一条**消息（`MessageList` 逐条渲染 `state.queue.steering[i]`，本地显示镜像也只 `indexOf + splice` 一条），但服务端 `AgentService.removeQueued` 重建队列时用的是**值过滤**：

```ts
const { steering, followUp } = s.clearQueue();
const keptSteering = steering.filter((t) => !(kind === "steer" && t === text));
const keptFollowUp = followUp.filter((t) => !(kind === "followUp" && t === text));
```

→ **同一条文本被排队两次时，点一次 ✕ 会把两条都删掉**，而 UI 只消失一条（要等下一次 `queue_update` 才对齐，期间显示与真实队列不一致）。重复发送「继续」「跑测试」这类短语很容易踩到。

## 改动

- **新增 `server/queue-utils.ts`**：纯函数 `removeFirstOccurrence(list, text)` —— 只移除第一处匹配；找不到返回拷贝（不动入参）；其余项顺序不变（重新入队依赖原顺序）。
- `AgentService.removeQueued`：两条队列（steer / followUp）都改用它，与气泡 UI、本地镜像的"删一条"语义对齐。
- `AGENTS.md` 的 `server/` 文件清单同步加一行。

**为什么独立成模块**：`AgentService` 顶部有 `import "./patch-remote-catalog.js"`（import 时就会改写 `node_modules` 里的 SDK 文件），不适合在单测里 import；把判定抽成纯函数才能单测。

## 验证

- 新增 6 例单测 `tests/unit/queue-utils.test.ts`：唯一匹配 / 重复文本只删第一条 / 找不到时返回拷贝 / 空列表与空串 / 不修改入参 / 保持其余项顺序
- `npx vitest run` → **576 passed**（含上述 6 例）
- `npx tsc -p tsconfig.server.json --noEmit`、`npx tsc -p tsconfig.tests.json --noEmit`、`npm run lint`、`npm run format:check` 全过
- `node tests/steer-queue-smoke.mjs` 通过（`queue_remove` 协议 dispatch 链路）
- 如实说明：`clearQueue()` → 重新入队那一段需要真实 SDK 会话（要有 key），单测只覆盖"保留哪些条目"的判定；本机 steer-queue 冒烟组件通过。

## 关联

这是「排队气泡增加撤回按钮（撤回并放回输入框）」的前置 PR：把单条移除的语义先修正，UI 改动放在另一个 PR 里，避免一个 PR 混协议语义 + 交互两件事。
