### PR TITLE
feat(web): 流式中补一个「插队」按钮（移动端唯一的插队入口）

### DIFF
--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useRef, useState } from "react";
-import { FiSend, FiSquare, FiPaperclip, FiArrowUp, FiGrid } from "react-icons/fi";
+import { FiSend, FiSquare, FiPaperclip, FiArrowUp, FiGrid, FiZap } from "react-icons/fi";
 import type { ClientMessage, ModelInfo, ProviderKeyInfo, SlashCommandInfo, UiMessage, UiState } from "../types";
 import { useT, useI18n } from "../i18n";
 import { isRasterImage } from "../image-paste";
@@ -510,9 +510,16 @@ export const ChatInput = memo(function ChatInput({
 			{streaming ? (
 				<>
 					{text.trim() !== "" && (
-						<button type="button" className="btn supplement" title={t("supplementTip")} onClick={() => submit(true)}>
-							<FiSend /> {t("supplement")}
-						</button>
+						<>
+							{/* 插队（steer）：当前回合结算后立刻送达。桌面端等同 Enter；移动端软键盘
+							 *  没有 Shift/Ctrl，Enter 被有意留作换行，所以这里是移动端唯一的插队入口。 */}
+							<button type="button" className="btn steer" title={t("queueSteerTag")} onClick={() => submit()}>
+								<FiZap /> {t("queueSteerTag")}
+							</button>
+							<button type="button" className="btn supplement" title={t("supplementTip")} onClick={() => submit(true)}>
+								<FiSend /> {t("supplement")}
+							</button>
+						</>
 					)}
 					<button type="button" className="btn stop" title={t("stopAgent")} onClick={() => send({ type: "abort" })}>
 						<FiSquare />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6862,6 +6862,23 @@ div.chead[role="button"]:focus-visible,
 	box-shadow: 0 4px 16px rgba(59, 130, 246, 0.45);
 }
 
+/* 插队: steer —— 当前回合结算后立刻送达（桌面端等同 Enter；移动端软键盘没有 Shift/
+   Ctrl、Enter 被有意留作换行，所以这是移动端唯一的插队入口）。 */
+.inputbox .btn.steer {
+	width: auto;
+	border-radius: 999px;
+	padding: 0 16px;
+	gap: 5px;
+	font-size: 13px;
+	border-color: rgba(251, 191, 36, 0.45);
+	color: var(--amber);
+}
+.inputbox .btn.steer:hover:not(:disabled) {
+	background: var(--amber);
+	border-color: var(--amber);
+	color: var(--on-amber);
+}
+
 /* 补充: queue a message that sends the moment the current reply finishes. */
 .inputbox .btn.supplement {
 	width: auto;


### PR DESCRIPTION
## 背景与必要性

**服务端/协议早就支持"插队"**：`prompt` 消息的默认语义就是 steer（协议注释原文："plain Enter keeps the steer semantic"），只有「补充」按钮才带 `queue=true`（followUp）。

**但 UI 上插队只有一条路：桌面端按 Enter。** `ChatInput` 的 Enter 语义是：

```
on desktop (fine pointer) Enter sends …
on touch devices Enter must insert a newline instead (no physical Shift);
the user sends with the on-screen button or an explicit Ctrl/Cmd+Enter
```

触摸设备上 Enter 被**有意**留作换行（便于写多行），而软键盘**没有 Ctrl/Cmd** → **移动端实际上无法插队**。

更要命的是**流式期间**：工具栏只剩「补充」（followUp）和「停止」（abort）（`ChatInput.renderActions()` 的 streaming 分支），连发送按钮都被替换掉了。于是移动端用户在 agent 工作时只有两个选择——**排队**或**中断**，无法把"这句话现在就说"插进去。这恰恰是移动端最高频的场景（插队的语义正是"当前回合结算后立刻送达，跳过剩余工具调用"）。

所以这不是"移动端少个快捷键"，而是**一条能力在移动端完全不可达**。

## 改动

- 流式中且输入非空时，在「补充」左侧新增「插队」按钮（`FiZap` + 文案），点击调用 `submit()` —— **与桌面端 Enter 完全同一条路径**。
- 配色与排队气泡上的「插队」标签一致（`--amber`；hover 用 `--on-amber`）。
- **不新增 i18n key**：label/title 复用已有 `queueSteerTag`（"插队"/"Steer"，8 个语言包均已翻译）。若想要更细的 tooltip（如"当前回合结算后立即发送、跳过剩余工具调用"），可另开 PR 加 key（需同步 9 个 i18n 文件）。
- 无协议改动、无服务端改动。

## 验证

- `npm run typecheck`（三个 tsconfig）/ `npm run lint` / `npm run format:check` 全过
- `npm run build:web` 通过（JSX + 打包层，比 typecheck 更能抓到渲染结构问题）
- `npx vitest run` 全绿
- `node tests/steer-queue-smoke.mjs` 通过（steer/queue 协议链路）
- 说明：本机没有可用的浏览器内核，**未做视觉验证**——这点如实说明；按钮只是把桌面 Enter 的动作显式化，不引入新逻辑。

## 备注（待你定）

- **显示范围**：我倾向两端都显示（桌面也多一个显式入口，行为与 Enter 一致，避免平台分歧）；若你希望只在触摸设备（`IS_TOUCH`）显示，我可以改。
- 移动端窄屏下三个按钮（插队 / 补充 / 停止）可能挤一点；如果你觉得拥挤，我可以给 `@media (max-width: 420px)` 加"只显示图标"的规则。
