### PR TITLE
fix(web): pin anchor row as composer grows

### DIFF
--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -266,13 +266,35 @@ export const ChatInput = memo(function ChatInput({
 	}, [showHelp]);
 
 	// Auto-grow the textarea; no scrollbar until it hits the height cap.
+	// Pin the anchor row: the composer sits BELOW the message list, so its
+	// growth shrinks the list box from the bottom. Hold the row above the
+	// composer stationary by scrolling down the exact grown amount, pre-paint.
+	// Without this the input covers one more line per row. Runs in useEffect
+	// on purpose: the layout effect measured the composer BEFORE the browser
+	// applied the new textarea height (getBoundingClientRect reads the stale
+	// box), so lines 2+ computed delta 0. The passive effect runs after the
+	// flex layout settles — the measured delta is real each line.
+	const composerRef = useRef<HTMLDivElement>(null);
 	useEffect(() => {
 		const ta = taRef.current;
-		if (!ta) return;
+		const box = composerRef.current;
+		if (!ta || !box) return;
+		// Save BEFORE the auto reset below: collapsing the textarea transiently
+		// grows the list box, which clamps its scrollTop down. Restore after.
+		const list = ta.closest("main")?.querySelector<HTMLElement>(".messages");
+		const hBefore = box.getBoundingClientRect().height;
+		const stBefore = list?.scrollTop ?? 0;
 		ta.style.height = "auto"; // natural height first, then clamp
 		const capped = ta.scrollHeight > 220;
 		ta.style.height = `${Math.min(ta.scrollHeight, 220)}px`;
 		ta.style.overflowY = capped ? "auto" : "hidden";
+		if (list) {
+			const grew = box.getBoundingClientRect().height - hBefore;
+			// Pre-transient position plus net growth: the row above the composer
+			// stays stationary, pinned or reading history. grew=0 still
+			// restores (undoes the transient clamp).
+			list.scrollTop = stBefore + grew;
+		}
 	}, [text]);
 
 	/** 输入框光标是否在第一行（Up 才进入历史；多行时光标在首行内才触发，避免打断多行编辑）。 */
@@ -534,6 +556,7 @@ export const ChatInput = memo(function ChatInput({
 
 	return (
 		<div
+			ref={composerRef}
 			className={`inputbar${dragOver ? " drop-active" : ""}`}
 			onDragOver={(e) => {
 				e.preventDefault();

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -577,28 +577,22 @@ export function MessageList({
 		}
 	}, [queueSig]);
 
-	// Geometry-driven stick (RO era): the composer sits BELOW this scroll
-	// container in a flex column. Typing grows the composer → the container's
-	// border-box shrinks → distance-to-bottom grows with NO scroll event (scrollTop
-	// untouched), so the entire scroll-event-driven stick machinery is blind to
-	// the drift. A ResizeObserver on the container catches it directly: any box
-	// change while stuck && !escaped re-pins the bottom. Observing the container
-	// (not the composer / a content sentinel) is sufficient: composer growth is
-	// exactly a container-box shrink; content-height growth (streaming appends,
-	// image loads) is already covered by the messages/liveOutputs snap effects.
-	// No feedback loop: the snap mutates scrollTop only — RO reports box size,
-	// which is unchanged. The snap's echo scroll event carries positive dSt with
-	// dSh=0, which classifyScroll no-ops (dSt >= -4) — no grace restamp needed.
+	// The composer sits BELOW this scroll container in a flex column. Its
+	// growth shrinks this box from the bottom; ChatInput sets scrollTop =
+	// pre-transient position + net growth, so the anchor row stays stationary.
+	// Only box GROWTH (composer shrink) needs a nudge — clamp the stranded
+	// scrollTop back so no dead gap lingers at the bottom. Content-height
+	// growth (streaming appends, image loads) doesn't change the box and stays
+	// covered by the messages/liveOutputs snap effects.
 	useEffect(() => {
 		const el = scrollRef.current;
 		if (!el || typeof ResizeObserver === "undefined") return;
+		let prevH = el.clientHeight;
 		const ro = new ResizeObserver(() => {
-			if (stickRef.current && !escapedRef.current) {
-				el.scrollTop = el.scrollHeight;
-				// stickRef is already true; keep the chip's state source in sync so
-				// the Back-to-bottom button can never linger after an RO re-pin.
-				setStickBottom(true);
-			}
+			const h = el.clientHeight;
+			const grew = h - prevH;
+			prevH = h;
+			if (grew > 0) el.scrollTop = Math.min(el.scrollTop, el.scrollHeight - el.clientHeight);
 		});
 		ro.observe(el);
 		return () => ro.disconnect();


### PR DESCRIPTION
Composer growth no longer covers the conversation or pops Back-to-bottom.

- ChatInput: save list scrollTop before the textarea auto reset, restore to pre-transient spot plus net composer growth.
- MessageList: observer clamps only on box growth; removed snap-to-bottom on shrink.