### PR TITLE
fix(i18n): bash head/tail omission notes follow server lang

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -215,7 +215,11 @@ Many legacy Chinese text files (.html/.txt/.md/.log, exported documents) are GBK
  * terminal) plus head/tail (post-processed on the returned output) so the parameter
  * schema stays consistent with the terminal-backed tool.
  */
-export function makeKillableBashTool(cwd: string, kills: Set<AbortController>): ToolDefinition {
+export function makeKillableBashTool(
+	cwd: string,
+	kills: Set<AbortController>,
+	lang: () => ServerLang = () => "en" as ServerLang,
+): ToolDefinition {
 	const base = createLocalBashOperations();
 	const tool = createBashTool(cwd, {
 		operations: {
@@ -275,7 +279,7 @@ export function makeKillableBashTool(cwd: string, kills: Set<AbortController>): 
 			// head/tail 后处理（native 无终端，直接截返回行即可）。
 			const p = params as { head?: number; tail?: number };
 			if ((p?.head || p?.tail) && result?.content?.[0]?.text != null) {
-				result.content![0].text = applyHeadTail(result.content![0].text!, p.head, p.tail);
+				result.content![0].text = applyHeadTail(result.content![0].text!, p.head, p.tail, lang());
 			}
 			return result as never;
 		},
@@ -1757,7 +1761,8 @@ export class ClientSession {
 				// 开 → 终端接管 bash（persist 决定一次性/持久，可静默自动转后台）。
 				customTools: [
 					makeAdaptiveBashTool(
-						makeKillableBashTool(effectiveCwd, this.bashKills),
+						// issue #91：bash 返回按客户端 UI 语言出中英（英文默认）。
+						makeKillableBashTool(effectiveCwd, this.bashKills, () => this.getLang()),
 						makeTerminalBashTool(terminals, {
 							cwd: effectiveCwd,
 							// 设置开 = 用终端；此分支里 persist 未显式给时默认一次性（false）。

--- a/server/terminals.ts
+++ b/server/terminals.ts
@@ -1486,18 +1486,24 @@ let oneShotBashSeq = 0;
 /** 应用 head / tail 参数到输出顶层行（替代 `| head` / `| tail` 管道——管道会
  *  缓冲输出、让可见终端全程哑火，还容易白白触发静默解阻）。两者同时给时先
  *  截头再截尾。 */
-export function applyHeadTail(text: string, head?: number, tail?: number): string {
+export function applyHeadTail(text: string, head?: number, tail?: number, lang: ServerLang = "en"): string {
 	// 只对真实数据行切片；省略提示行单独存，最后再包回输出，避免提示行在
 	// head+tail 组合时被当成数据行参与第二次截取（导致尾部少截一行）。
 	let data = text.split("\n");
 	let headNote: string | null = null;
 	let tailNote: string | null = null;
 	if (head && head > 0 && data.length > head) {
-		headNote = `…（后 ${data.length - head} 行已省略）`;
+		const n = data.length - head;
+		headNote = pick(lang, `…（后 ${n} 行已省略）`, `…[${n} lines omitted below]…`, "terminals.headtail.omitted.below", {
+			n,
+		});
 		data = data.slice(0, head);
 	}
 	if (tail && tail > 0 && data.length > tail) {
-		tailNote = `…（前 ${data.length - tail} 行已省略）`;
+		const n = data.length - tail;
+		tailNote = pick(lang, `…（前 ${n} 行已省略）`, `…[${n} lines omitted above]…`, "terminals.headtail.omitted.above", {
+			n,
+		});
 		data = data.slice(-tail);
 	}
 	const parts: string[] = [];
@@ -1669,7 +1675,7 @@ export function makeTerminalBashTool(
 					if (m) {
 						terminals.setSentinelPending(termId, false);
 						closeOneShot();
-						const text = applyHeadTail(cleanBashOutput(collected), p.head, effectiveTail);
+						const text = applyHeadTail(cleanBashOutput(collected), p.head, effectiveTail, lang);
 						return {
 							content: [
 								{
@@ -1701,7 +1707,7 @@ export function makeTerminalBashTool(
 							terminals,
 							opts,
 							runCommand,
-							applyHeadTail(cleanBashOutput(collected), p.head, effectiveTail),
+							applyHeadTail(cleanBashOutput(collected), p.head, effectiveTail, lang),
 							Math.round((Date.now() - lastDataAt) / 1000),
 							lang,
 						);

--- a/tests/unit/terminal-key.test.ts
+++ b/tests/unit/terminal-key.test.ts
@@ -58,3 +58,16 @@ describe("encodeTerminalKey", () => {
 		expect("error" in b && b.error).toBeTruthy();
 	});
 });
+
+describe("applyHeadTail omission notes follow server lang", () => {
+	it("zh keeps the Chinese note", async () => {
+		const { applyHeadTail } = await import("../../server/terminals.js");
+		expect(applyHeadTail("a\nb\nc", undefined, 1, "zh")).toBe("…（前 2 行已省略）\nc");
+		expect(applyHeadTail("a\nb\nc", 1, undefined, "zh")).toBe("a\n…（后 2 行已省略）");
+	});
+	it("en uses the English note and falls back for other langs", async () => {
+		const { applyHeadTail } = await import("../../server/terminals.js");
+		expect(applyHeadTail("a\nb\nc", undefined, 1, "en")).toBe("…[2 lines omitted above]…\nc");
+		expect(applyHeadTail("a\nb\nc", undefined, 1, "ja")).toBe("…[2 lines omitted above]…\nc");
+	});
+});


### PR DESCRIPTION
The …（前 N 行已省略）/…（后 N 行已省略） notes from applyHeadTail() were hardcoded Chinese in all locales.

- applyHeadTail() takes lang, emits English …[N lines omitted above/below]… for non-zh via pick() with keys terminals.headtail.omitted.above/below.
- All three call sites (terminal bash x2, native bash x1) pass the per-call lang.
- Third langs fall back to English until packs add the keys.