### PR TITLE
feat(slash): /new takes an optional first prompt

### DIFF
--- a/server/agent-service.ts
+++ b/server/agent-service.ts
@@ -3073,6 +3073,8 @@ export class ClientSession {
 		cwd: () => this.cwd,
 		getSession: () => this.session,
 		newChat: () => this.newChat(),
+		// /new <prompt>: deliver the text as the new session's first prompt.
+		prompt: (text) => this.prompt(text),
 		setModel: (id) => this.setModel(id),
 		setCwd: (path) => this.setCwd(path),
 		setThinking: (level) => this.setThinking(level),

--- a/server/slash-commands.ts
+++ b/server/slash-commands.ts
@@ -24,6 +24,8 @@ export interface SlashHost {
 	/** 活动对话的 session。 */
 	getSession: () => AgentSession;
 	newChat: () => Promise<void>;
+	/** Send a prompt in the active conversation (used by /new <prompt>). */
+	prompt?: (text: string) => Promise<void>;
 	setModel: (modelId: string) => Promise<void>;
 	setCwd: (path: string) => Promise<void>;
 	setThinking: (level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max") => void;
@@ -51,7 +53,13 @@ export const NATIVE_COMMANDS: {
 	argumentHint?: string;
 	argumentHintEn?: string;
 }[] = [
-	{ name: "new", description: "新建对话", descriptionEn: "New chat" },
+	{
+		name: "new",
+		description: "新建对话（可带首条提示：/new <提示>）",
+		descriptionEn: "New chat (optional first prompt: /new <prompt>)",
+		argumentHint: "[提示]",
+		argumentHintEn: "[prompt]",
+	},
 	{
 		name: "name",
 		description: "重命名当前会话",
@@ -177,9 +185,15 @@ export class SlashCommandsService {
 	 *  name is not a native command (the prompt falls through to the SDK). */
 	async exec(name: string, args: string): Promise<boolean> {
 		switch (name) {
-			case "new":
+			case "new": {
+				const first = args.trim();
 				await this.host.newChat();
+				// /new <prompt>: deliver the text as the new session's first
+				// prompt, exactly as if typed after the switch. Empty = old
+				// behavior (blank chat, no send).
+				if (first && this.host.prompt) await this.host.prompt(first);
 				return true;
+			}
 			case "name": {
 				const trimmed = args.trim();
 				if (!trimmed) {

--- a/tests/unit/slash-new.test.ts
+++ b/tests/unit/slash-new.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { SlashCommandsService, parseSlash } from "../../server/slash-commands.js";
+
+const host = (over: Record<string, unknown> = {}) => ({
+	emit: vi.fn(),
+	cwd: () => "/tmp",
+	getSession: () => ({}) as never,
+	newChat: vi.fn(async () => {}),
+	setModel: vi.fn(async () => {}),
+	setCwd: vi.fn(async () => {}),
+	setThinking: vi.fn(),
+	...over,
+});
+
+describe("parseSlash", () => {
+	it("splits /new args", () => {
+		expect(parseSlash("/new hello world")).toEqual({ name: "new", args: "hello world" });
+		expect(parseSlash("/new")).toEqual({ name: "new", args: "" });
+	});
+});
+
+describe("/new <prompt>", () => {
+	it("bare /new opens a chat and sends nothing", async () => {
+		const h = host();
+		const svc = new SlashCommandsService(h as never);
+		expect(await svc.exec("new", "")).toBe(true);
+		expect(h.newChat).toHaveBeenCalledTimes(1);
+		expect((h as { prompt?: unknown }).prompt).toBeUndefined();
+	});
+	it("sends the args as the first prompt after the switch", async () => {
+		const prompt = vi.fn(async (_t: string) => {});
+		const h = host({ prompt });
+		const svc = new SlashCommandsService(h as never);
+		expect(await svc.exec("new", "hello world")).toBe(true);
+		expect(h.newChat).toHaveBeenCalledTimes(1);
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(prompt).toHaveBeenCalledWith("hello world");
+	});
+});


### PR DESCRIPTION
/new <prompt> opens a new chat and sends the text as its first prompt, exactly as if typed after the switch. Bare /new keeps the old behavior (blank chat, no send).

- Slash exec passes /new args to the new session via host.prompt after the switch.
- Picker shows /new [prompt] hint in both languages.
- Unit test covers parse, empty send, and first-prompt send.