### PR TITLE
fix(server): MCP 桥转发非文本内容块（截图/PDF 不再返回空串）

### DIFF
--- a/server/mcp-bridge.ts
+++ b/server/mcp-bridge.ts
@@ -38,6 +38,18 @@ interface RpcIncoming {
 	error?: { code: number; message: string; data?: unknown };
 }
 
+/** MCP 服务器返回的内容块（规范子集：text / image / resource / audio…）。 */
+interface McpContentBlock {
+	type?: string;
+	text?: string;
+	data?: string;
+	mimeType?: string;
+	resource?: { uri?: string; mimeType?: string; blob?: string } | string;
+}
+
+/** 桥透传给会话的内容块：text 原样；image 字段与 SDK 的 ImageContent（type/data/mimeType）一致。 */
+type McpToolResultBlock = { type: "text"; text: string } | { type: "image"; data: string; mimeType: string };
+
 const PROTOCOL_VERSION = "2025-03-26"; // 广泛支持的工具版本
 
 let rpcSeq = 0;
@@ -114,10 +126,13 @@ export class McpClient {
 		return this.tools.map((t) => ({ ...t }));
 	}
 
-	/** 调用一个工具，返回结果文本（多 content 拼接为 JSON 字符串保真）。 */
+	/**
+	 * 调用一个工具，返回其结果。
+	 * 纯文本块拼接成字符串（老形状，向后兼容）；出现非文本块（image/resource/audio 等）时按序透传或退化提示，不再静默丢弃。
+	 */
 	async call(name: string, args: Record<string, unknown>, timeoutMs = 60000): Promise<unknown> {
 		const res = (await this.request("tools/call", { name, arguments: args }, timeoutMs)) as {
-			content?: Array<{ type?: string; text?: string }>;
+			content?: McpContentBlock[];
 			isError?: boolean;
 			structuredContent?: unknown;
 		};
@@ -129,13 +144,41 @@ export class McpClient {
 					.trim() || "MCP 工具错误";
 			throw new Error(msg);
 		}
-		// 结构化结果优先，其次文本内容。
+		// 结构化结果优先，其次内容块。
 		if (res?.structuredContent !== undefined) return res.structuredContent;
-		const text = (res.content ?? [])
-			.map((c) => c.text ?? "")
-			.filter((x) => x)
-			.join("\n");
-		return { content: text, isError: !!res.isError };
+		const blocks: McpToolResultBlock[] = [];
+		let hasNonText = false;
+		for (const c of res.content ?? []) {
+			if (c.type === "image" && typeof c.data === "string" && c.data) {
+				// MCP image 块字段（type/data/mimeType）与 SDK 的 ImageContent 完全一致，原样透传；
+				// 超大图由 SDK 的 normalizeToolResultImages 统一缩放（afterToolCall 钩子，默认 autoResize）。
+				blocks.push({ type: "image", data: c.data, mimeType: c.mimeType?.trim() || "image/png" });
+				hasNonText = true;
+				continue;
+			}
+			if (c.type && c.type !== "text") {
+				// resource/audio 等块在 SDK 内容联合里没有载体（只有 text|image|thinking|toolCall），
+				// 退化为文本提示，让模型至少知道工具返回了什么，而不是看到一个空串。
+				const r = typeof c.resource === "object" && c.resource !== null ? c.resource : {};
+				const mime = (c.mimeType ?? r.mimeType ?? "").trim();
+				const blob = typeof r.blob === "string" && r.blob ? r.blob : c.data;
+				const size =
+					typeof blob === "string" && blob ? `，约 ${Math.max(1, Math.round((blob.length * 3) / 4))} 字节` : "";
+				blocks.push({
+					type: "text",
+					text: `[MCP 工具返回了非文本内容块（${mime || c.type || "未知类型"}${size}），当前会话无法内联，已跳过。]`,
+				});
+				hasNonText = true;
+				continue;
+			}
+			const text = c.text ?? "";
+			if (text) blocks.push({ type: "text", text });
+		}
+		if (!hasNonText) {
+			// 纯文本结果保持旧形状（拼接字符串），不破坏既有调用方。
+			return { content: blocks.map((b) => (b.type === "text" ? b.text : "")).join("\n"), isError: !!res.isError };
+		}
+		return { content: blocks, isError: !!res.isError };
 	}
 
 	/** 关闭：kill 子进程，拒绝所有在途请求。 */

--- a/tests/fixtures/mcp-echo-server.mjs
+++ b/tests/fixtures/mcp-echo-server.mjs
@@ -2,7 +2,8 @@
 /**
  * MCP 测试夹具服务器 —— 极简 NDJSON JSON-RPC 实现，用作 mcp-bridge 的对手端。
  * 工具：echo（原样回传 parameters）、add（a+b）、fail（isError 工具）、
- * slow（延迟后返回，用于校验超时）。
+ * slow（延迟后返回，用于校验超时）、screenshot（image 块）、pdf（resource 块）、
+ * mixed（文本 + 图片混合块，校验保序透传）。
  * 用法：node mcp-echo-server.mjs [delay-resp-ms]
  */
 import { createInterface } from "node:readline";
@@ -26,6 +27,9 @@ const TOOLS = [
 	},
 	{ name: "fail", description: "总是失败（isError）", inputSchema: { type: "object" } },
 	{ name: "slow", description: "睡眠 resp-delay 后返回", inputSchema: { type: "object" } },
+	{ name: "screenshot", description: "返回一张 PNG 图片（image 块）", inputSchema: { type: "object" } },
+	{ name: "pdf", description: "返回一个 PDF 资源（resource 块）", inputSchema: { type: "object" } },
+	{ name: "mixed", description: "文本 + 图片混合结果", inputSchema: { type: "object" } },
 ];
 
 function reply(msg) {
@@ -73,6 +77,43 @@ rl.on("line", (line) => {
 			// 用进程参数里的延迟；默认 5000ms（测试里会注入更小的波长 → 超时）
 			const d = Number(process.env.MCP_SLOW_MS ?? 5000);
 			return setTimeout(() => finish(msg.id, { content: [{ type: "text", text: "slow done" }] }), d);
+		}
+		if (name === "screenshot") {
+			return finish(msg.id, {
+				content: [
+					{
+						type: "image",
+						data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+						mimeType: "image/png",
+					},
+				],
+			});
+		}
+		if (name === "pdf") {
+			return finish(msg.id, {
+				content: [
+					{
+						type: "resource",
+						resource: {
+							uri: "obscura://capture/current-page.pdf",
+							mimeType: "application/pdf",
+							blob: "JVBERi0xLjQK",
+						},
+					},
+				],
+			});
+		}
+		if (name === "mixed") {
+			return finish(msg.id, {
+				content: [
+					{ type: "text", text: "文本在前" },
+					{
+						type: "image",
+						data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+						mimeType: "image/png",
+					},
+				],
+			});
 		}
 		return finish(msg.id, {
 			content: [{ type: "text", text: `unknown tool: ${name}` }],

--- a/tests/mcp-bridge-test.mjs
+++ b/tests/mcp-bridge-test.mjs
@@ -2,7 +2,7 @@
  * MCP 工具桥端到端冒烟（零 token、自包含、独立端口 8990）：
  * 临时 data-dir 写 mcp.json（指向本地夹具服务器），起真实 server：
  *  - server 启动时 MCP 服务器被拉起（stdout 出现 ready 日志）
- *  - 工具数量正确（4）
+ *  - 工具数量正确（7）
  *  - MCP 服务器失败不炸 server 进程
  */
 import { spawn } from "node:child_process";
@@ -53,10 +53,10 @@ async function main() {
 	let ok = false;
 	for (let i = 0; i < 60 && !ok; i++) {
 		await sleep(250);
-		if (/listening|ready|available/i.test(out) && /\[mcp:csrv\] ready, 4 tools/.test(out)) ok = true;
+		if (/listening|ready|available/i.test(out) && /\[mcp:csrv\] ready, 7 tools/.test(out)) ok = true;
 	}
 	if (!ok) throw new Error("server 或 MCP 未就绪。输出：\n" + out);
-	console.log("✓ MCP 服务器启动并握手（日志：[mcp:csrv] ready, 4 tools）");
+	console.log("✓ MCP 服务器启动并握手（日志：[mcp:csrv] ready, 7 tools）");
 
 	// badsrv 失败不应影响 server 存活
 	if (/definitely-not-a-real-cmd-xyz/.test(out) && !/\[mcp\] 服务器「badsrv」启动失败/.test(out)) {

--- a/tests/unit/mcp-bridge.test.ts
+++ b/tests/unit/mcp-bridge.test.ts
@@ -8,6 +8,7 @@
  *  - 错误工具 fail → isError → 抛错
  *  - 未知工具 / 最上层 McpBridge.load + getTools 适配
  *  - slow 超时（MCP_SLOW_MS 注入短延迟）
+ *  - 非文本块映射：image（screenshot）、resource（pdf）、混合保序（mixed）
  */
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { dirname, join, resolve } from "node:path";
@@ -37,11 +38,11 @@ afterEach(() => {
 });
 
 describe("McpClient 握手与工具", () => {
-	it("start 握手 + 列出 4 个工具", async () => {
+	it("start 握手 + 列出 7 个工具", async () => {
 		const c = client();
 		await c.start();
 		const names = c.getTools().map((t) => t.name);
-		expect(names).toEqual(["echo", "add", "fail", "slow"]);
+		expect(names).toEqual(["echo", "add", "fail", "slow", "screenshot", "pdf", "mixed"]);
 	});
 
 	it("echo 原样返回；add 求和", async () => {
@@ -64,6 +65,40 @@ describe("McpClient 握手与工具", () => {
 		await c.start();
 		await expect(c.call("nope", {})).rejects.toThrow(/unknown tool/);
 	});
+
+	it("screenshot 的 image 块原样透传（type/data/mimeType 保真）", async () => {
+		const c = client();
+		await c.start();
+		const res = (await c.call("screenshot", {})) as {
+			content: Array<{ type: string; data?: string; mimeType?: string }>;
+		};
+		expect(res.content).toHaveLength(1);
+		expect(res.content[0].type).toBe("image");
+		expect(res.content[0].mimeType).toBe("image/png");
+		// base64 必须逐字保留（改写/截断都会毁掉图片）
+		expect(res.content[0].data).toBe(
+			"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+		);
+	});
+
+	it("pdf 的 resource 块退化为文本提示（含 mimeType 与字节数）", async () => {
+		const c = client();
+		await c.start();
+		const res = (await c.call("pdf", {})) as { content: Array<{ type: string; text?: string }> };
+		expect(res.content).toHaveLength(1);
+		expect(res.content[0].type).toBe("text");
+		expect(res.content[0].text).toContain("application/pdf");
+		// blob "JVBERi0xLjQK" = 12 个 base64 字符 ≈ 9 字节
+		expect(res.content[0].text).toContain("9 字节");
+	});
+
+	it("mixed 保序透传（文本块在前、图片块在后）", async () => {
+		const c = client();
+		await c.start();
+		const res = (await c.call("mixed", {})) as { content: Array<{ type: string; text?: string }> };
+		expect(res.content.map((b) => b.type)).toEqual(["text", "image"]);
+		expect(res.content[0].text).toBe("文本在前");
+	});
 });
 
 describe("McpBridge 聚合适配", () => {
@@ -73,7 +108,7 @@ describe("McpBridge 聚合适配", () => {
 		});
 		await bridge.load();
 		const tools = bridge.getTools();
-		expect(tools.length).toBe(4);
+		expect(tools.length).toBe(7);
 		const add = tools.find((t) => t.name === "add")!;
 		expect(add.label).toContain("csrv");
 		expect(typeof add.execute).toBe("function");


### PR DESCRIPTION
# fix(server): MCP 桥转发非文本内容块（截图/PDF 不再返回空串）

## 背景

`server/mcp-bridge.ts` 的 `McpClient.call()` 之前只把 `type === "text"` 的内容块拼成字符串，其它块（`image` / `resource`）被静默丢弃，结果是**任何经 MCP 桥挂进会话的截图/图返回型/PDF 工具都返回 `""`**——模型既不报错也拿不到任何信息，工具形同虚设。

实测对照（同一 `browser_screenshot` 调用）：
- 桥内 → 会话得到 `""`；
- 桥外直连 stdio 探针 → `image/png` base64 22840 字符。

影响面不只截图：任何返回图片/资源的 MCP 服务器（图像生成、图表、PDF 导出）通过 `customTools` 管线进会话时都是「哑的」。

## 改动

`server/mcp-bridge.ts` 的 `call()` 按块类型映射（保序透传）：

1. **`image` 块原样透传**为 `{ type: "image", data, mimeType }` —— 字段与 SDK 的 `ImageContent` 完全一致，进 `{ content: [...] }` 数组后由 `pluginToolToDefinition().normalize()` 原样收编，零适配层改动；
2. **`resource` / `audio` 等无 SDK 载体的块退化为文本提示**（含 mimeType + 约 N 字节），模型至少知道工具返回了什么、而不是看到一个空串（具体策略见「需要拍板」1）；
3. **纯文本结果保持旧形状**（多块拼接字符串），不破坏既有调用方与行为；
4. 多个块按服务器返回顺序透传，文本/图片混合不错位。

## 验证（本机实跑）

**改动前失败证据**（新回归测试跑在旧实现上）：

```
FAIL screenshot 的 image 块原样透传: AssertionError: expected '' to have a length of 1 but got +0
FAIL pdf 的 resource 块退化为文本提示: AssertionError: expected '' to have a length of 1 but got +0
FAIL mixed 保序透传: TypeError: res.content.map is not a function   ← content 是 ''
```

**改动后**：

- `tests/unit/mcp-bridge.test.ts`：10/10 通过（新增 screenshot/pdf/mixed 3 例）
- 全量 `vitest run`：**74 文件 / 671 用例全部通过**
- `typecheck`（server/web/tests/desktop 四份 tsconfig）：0 错误
- `lint`：无新增告警（仅存量无关 warning）；`format:check`：通过
- `build:server` + `tests/mcp-bridge-test.mjs` 协议冒烟：通过（7 tools 握手）

## 未验证（如实）

- **前端展示**：`ToolCallBlock.tsx` 的 toolCall 卡只渲染文本块（`b.type === "text" ? b.text : ""`），所以图片会进入**模型上下文**（本次修复的目标），但不会在 Web UI 的 tool 卡里显示图片——这与插件工具图片结果的行为一致，属展示层既有表现，不在本次范围；如希望 UI 里也渲染工具结果图片，可另开 PR。
- **真 MCP 服务器端到端**：本机未在真实 Web UI 会话里跑一次 obscura 截图（无浏览器 UI 环境）；桥内/桥外对照取自 stdio 探针与夹具。

## 需要你拍板

1. **`resource`/blob（如 PDF）的处理策略**：SDK 的 content 联合只有 `text | image | thinking | toolCall`，没有 pdf/blob 类型，无法内联。本 PR 采用「退化为文本提示（mimeType + 字节数）」；备选：(a) 落盘到临时目录并提示模型用 `read` 读；(b) 其它。如倾向落盘方案，我可以跟进。
2. **超大图的归一化边界**：已确认 SDK（`@earendil-works/pi-coding-agent` 0.84.4）的 `AgentSession.afterToolCall` 钩子对**每个**工具结果执行 `normalizeToolResultImages`（`autoResizeImages` 默认开）——桥透传的 image 块会经过它，超限图片会被缩放，不会让 provider 整段会话报错。这条我已按 SDK 源码核实，如你确认行为一致则无需额外改动。
3. **混合块策略**：当前为保序全量透传（含文本块 + 图片块）。如更想「只取第一张图」或「图片块置顶」可以再调。