### PR TITLE
fix(server): MCP 桥子进程崩溃后自动重启（自愈），不再需要重启服务

### DIFF
--- a/server/mcp-bridge.ts
+++ b/server/mcp-bridge.ts
@@ -57,6 +57,8 @@ let rpcSeq = 0;
 /**
  * 单个 MCP 服务器的客户端：管理子进程、请求/响应按 id 关联、握手与工具调用。
  * 线程模型：无需并发控制（MCP 允许乱序 + 我们按请求 id 匹配响应）。
+ * 自愈：子进程意外退出（崩溃/被杀）后不永久失效 —— 下一次工具调用会惰性重启并
+ * 重新握手、重新拉取工具列表；显式 close() 之后才永久停用。
  */
 export class McpClient {
 	private child: ChildProcess | null = null;
@@ -71,6 +73,10 @@ export class McpClient {
 	/** 已握手的工具列表（tools/list 结果缓存）。 */
 	private tools: McpToolDefinition[] = [];
 	private shuttingDown = false;
+	/** 进行中的启动/重启（并发调用共享同一次重连）。 */
+	private starting: Promise<void> | null = null;
+	/** 已启动次数（含自愈重启；诊断/测试用）。 */
+	private startedCount = 0;
 
 	constructor(
 		name: string,
@@ -81,11 +87,12 @@ export class McpClient {
 		this.log = log ?? (() => {});
 	}
 
-	/** 启动子进程 + 握手 + 拉取工具列表。 */
-	async start(_timeoutMs = 8000): Promise<void> {
+	/** 启动子进程 + 握手 + 拉取工具列表。可安全重入：子进程退出后再次调用即全新启动。 */
+	async start(timeoutMs = 8000): Promise<void> {
 		if (this.child) return;
 		const { command, args = [], cwd, env } = this.spec;
 		this.log(`[mcp:${this.name}] starting: ${command} ${args.join(" ")}`);
+		this.buffer = "";
 		const child = spawn(command, args, {
 			cwd: cwd ?? undefined,
 			env: { ...process.env, ...env },
@@ -93,32 +100,83 @@ export class McpClient {
 			windowsHide: true,
 		});
 		this.child = child;
+		// 进程退出后向 stdin 写请求会触发 EPIPE —— 静默忽略（send 也会判 child 存活）。
+		child.stdin?.on("error", () => {});
 		child.stderr.on("data", (d) => this.log(`[mcp:${this.name}] stderr:`, d.toString().trimEnd()));
 		child.on("error", (err) => this.rejectAll(new Error(`[mcp:${this.name}] spawn error: ${err.message}`)));
 		child.on("exit", (code, sig) => {
 			this.child = null;
-			if (!this.shuttingDown) this.rejectAll(new Error(`[mcp:${this.name}] 进程退出 (${sig ?? code})`));
+			this.buffer = "";
+			if (!this.shuttingDown) {
+				this.log(`[mcp:${this.name}] 进程退出 (${sig ?? code})，下次调用将自动重启`);
+				this.rejectAll(new Error(`[mcp:${this.name}] 进程退出 (${sig ?? code})`));
+			}
 		});
 		child.stdout.setEncoding("utf8");
 		child.stdout.on("data", (chunk: string) => this.onData(chunk));
+		this.startedCount++;
 
-		// 握手
-		const handshake = await this.request("initialize", {
-			protocolVersion: this.spec.protocolVersion ?? PROTOCOL_VERSION,
-			capabilities: {},
-			clientInfo: { name: "pi-web-ui", version: "0.41.0" },
-		});
-		const version =
-			(handshake as { protocolVersion?: string })?.protocolVersion ?? this.spec.protocolVersion ?? PROTOCOL_VERSION;
-		// 通知 initialized（无 id 的 notification）
-		this.send({ jsonrpc: "2.0", method: "notifications/initialized" });
-		// 仍以协商协议版本调用 tools（多数服务器对新版本容忍，这里用协商结果）
-		void version;
-		const listed = ((await this.request("tools/list", {})) ?? {}) as {
-			tools?: McpToolDefinition[];
-		};
-		this.tools = Array.isArray(listed.tools) ? listed.tools : [];
-		this.log(`[mcp:${this.name}] ready, ${this.tools.length} tools`);
+		try {
+			// 握手
+			const handshake = await this.request(
+				"initialize",
+				{
+					protocolVersion: this.spec.protocolVersion ?? PROTOCOL_VERSION,
+					capabilities: {},
+					clientInfo: { name: "pi-web-ui", version: "0.41.0" },
+				},
+				timeoutMs,
+			);
+			const version =
+				(handshake as { protocolVersion?: string })?.protocolVersion ?? this.spec.protocolVersion ?? PROTOCOL_VERSION;
+			// 通知 initialized（无 id 的 notification）
+			this.send({ jsonrpc: "2.0", method: "notifications/initialized" });
+			// 仍以协商协议版本调用 tools（多数服务器对新版本容忍，这里用协商结果）
+			void version;
+			const listed = ((await this.request("tools/list", {}, timeoutMs)) ?? {}) as {
+				tools?: McpToolDefinition[];
+			};
+			this.tools = Array.isArray(listed.tools) ? listed.tools : [];
+			this.log(`[mcp:${this.name}] ready, ${this.tools.length} tools`);
+			// 若重启过程中被显式 close()，趁机回收刚启动的子进程，不留孤儿。
+			if (this.shuttingDown) {
+				try {
+					child.kill();
+				} catch {
+					/* 已退出 */
+				}
+				if (this.child === child) this.child = null;
+			}
+		} catch (err) {
+			// 启动/握手失败：回收本次子进程，避免泄漏；调用方可安全重试（自愈会再试）。
+			try {
+				child.kill();
+			} catch {
+				/* 已退出 */
+			}
+			if (this.child === child) this.child = null;
+			throw err;
+		}
+	}
+
+	/** 已启动次数（含自愈重启；诊断/测试用）。 */
+	get startCount(): number {
+		return this.startedCount;
+	}
+
+	/**
+	 * 保活：子进程还活着就直接返回；已意外退出则惰性重启（并发调用共享同一次重连）。
+	 * 显式 close() 后抛错，绝不复活。
+	 */
+	private async ensureStarted(timeoutMs: number): Promise<void> {
+		if (this.child) return;
+		if (this.shuttingDown) throw new Error(`[mcp:${this.name}] 客户端已关闭，不会重启`);
+		if (!this.starting) {
+			this.starting = this.start(timeoutMs).finally(() => {
+				this.starting = null;
+			});
+		}
+		await this.starting;
 	}
 
 	/** 已发现工具。 */
@@ -131,6 +189,14 @@ export class McpClient {
 	 * 纯文本块拼接成字符串（老形状，向后兼容）；出现非文本块（image/resource/audio 等）时按序透传或退化提示，不再静默丢弃。
 	 */
 	async call(name: string, args: Record<string, unknown>, timeoutMs = 60000): Promise<unknown> {
+		if (this.shuttingDown) throw new Error(`[mcp:${this.name}] 客户端已关闭，不会重启`);
+		try {
+			// 自愈：子进程已退出（非主动关闭）→ 先惰性重启再发；重启失败给出明确错误而不是挂 60s 超时。
+			await this.ensureStarted(8000);
+		} catch (err) {
+			const detail = err instanceof Error ? err.message : String(err);
+			throw new Error(`[mcp:${this.name}] 服务器进程已退出且自动重启失败：${detail}`);
+		}
 		const res = (await this.request("tools/call", { name, arguments: args }, timeoutMs)) as {
 			content?: McpContentBlock[];
 			isError?: boolean;

--- a/tests/fixtures/mcp-echo-server.mjs
+++ b/tests/fixtures/mcp-echo-server.mjs
@@ -3,7 +3,8 @@
  * MCP 测试夹具服务器 —— 极简 NDJSON JSON-RPC 实现，用作 mcp-bridge 的对手端。
  * 工具：echo（原样回传 parameters）、add（a+b）、fail（isError 工具）、
  * slow（延迟后返回，用于校验超时）、screenshot（image 块）、pdf（资源 blob 块）、
- * textfile（资源 text 块）、mixed（文本 + 图片混合块，校验保序透传）。
+ * textfile（资源 text 块）、mixed（文本 + 图片混合块，校验保序透传）、
+ * crash（收到调用即 process.exit 自杀，模拟 MCP 服务器崩溃，校验桥的自愈重启）。
  * 用法：node mcp-echo-server.mjs [delay-resp-ms]
  */
 import { createInterface } from "node:readline";
@@ -31,6 +32,7 @@ const TOOLS = [
 	{ name: "pdf", description: "返回一个 PDF 资源（resource 块，blob）", inputSchema: { type: "object" } },
 	{ name: "textfile", description: "返回一个文本资源（resource 块，text）", inputSchema: { type: "object" } },
 	{ name: "mixed", description: "文本 + 图片混合结果", inputSchema: { type: "object" } },
+	{ name: "crash", description: "调用即自杀（模拟 MCP 服务器崩溃）", inputSchema: { type: "object" } },
 ];
 
 function reply(msg) {
@@ -129,6 +131,10 @@ rl.on("line", (line) => {
 					},
 				],
 			});
+		}
+		if (name === "crash") {
+			// 模拟崩溃：不等应答直接退出（非零退出码），观察桥端是否自愈重启。
+			return process.exit(2);
 		}
 		return finish(msg.id, {
 			content: [{ type: "text", text: `unknown tool: ${name}` }],

--- a/tests/mcp-bridge-test.mjs
+++ b/tests/mcp-bridge-test.mjs
@@ -2,7 +2,7 @@
  * MCP 工具桥端到端冒烟（零 token、自包含、独立端口 8990）：
  * 临时 data-dir 写 mcp.json（指向本地夹具服务器），起真实 server：
  *  - server 启动时 MCP 服务器被拉起（stdout 出现 ready 日志）
- *  - 工具数量正确（8）
+ *  - 工具数量正确（9）
  *  - MCP 服务器失败不炸 server 进程
  */
 import { spawn } from "node:child_process";
@@ -53,10 +53,10 @@ async function main() {
 	let ok = false;
 	for (let i = 0; i < 60 && !ok; i++) {
 		await sleep(250);
-		if (/listening|ready|available/i.test(out) && /\[mcp:csrv\] ready, 8 tools/.test(out)) ok = true;
+		if (/listening|ready|available/i.test(out) && /\[mcp:csrv\] ready, 9 tools/.test(out)) ok = true;
 	}
 	if (!ok) throw new Error("server 或 MCP 未就绪。输出：\n" + out);
-	console.log("✓ MCP 服务器启动并握手（日志：[mcp:csrv] ready, 8 tools）");
+	console.log("✓ MCP 服务器启动并握手（日志：[mcp:csrv] ready, 9 tools）");
 
 	// badsrv 失败不应影响 server 存活
 	if (/definitely-not-a-real-cmd-xyz/.test(out) && !/\[mcp\] 服务器「badsrv」启动失败/.test(out)) {

--- a/tests/unit/mcp-bridge.test.ts
+++ b/tests/unit/mcp-bridge.test.ts
@@ -8,7 +8,8 @@
  *  - 错误工具 fail → isError → 抛错
  *  - 未知工具 / 最上层 McpBridge.load + getTools 适配
  *  - slow 超时（MCP_SLOW_MS 注入短延迟）
- *  - 非文本块映射：image（screenshot）、resource（pdf）、混合保序（mixed）
+ *  - 非文本块映射：image（screenshot）、resource（pdf/textfile）、混合保序（mixed）
+ *  - 自愈：子进程崩溃（crash 工具）/ 启动即退出 → 在途请求立即报错而非挂超时、下一次调用自动重启
  */
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { dirname, join, resolve } from "node:path";
@@ -38,11 +39,11 @@ afterEach(() => {
 });
 
 describe("McpClient 握手与工具", () => {
-	it("start 握手 + 列出 8 个工具", async () => {
+	it("start 握手 + 列出 9 个工具", async () => {
 		const c = client();
 		await c.start();
 		const names = c.getTools().map((t) => t.name);
-		expect(names).toEqual(["echo", "add", "fail", "slow", "screenshot", "pdf", "textfile", "mixed"]);
+		expect(names).toEqual(["echo", "add", "fail", "slow", "screenshot", "pdf", "textfile", "mixed", "crash"]);
 	});
 
 	it("echo 原样返回；add 求和", async () => {
@@ -109,6 +110,38 @@ describe("McpClient 握手与工具", () => {
 	});
 });
 
+describe("McpClient 自愈（子进程崩溃后自动重启）", () => {
+	it("crash 令子进程退出：在途调用立即报「进程退出」，下一次调用自动重启并成功", async () => {
+		const c = client();
+		await c.start();
+		expect(c.startCount).toBe(1);
+		// 首次调用 crash：子进程自杀 → 在途请求被立刻拒绝（不是挂 60s 超时）
+		await expect(c.call("crash", {}, 1000)).rejects.toThrow(/进程退出/);
+		expect(c.startCount).toBe(1);
+		// 下一次调用：惰性重启 + 重新握手拉取工具列表，服务恢复
+		const echo = (await c.call("echo", { msg: "重启后" })) as { content: string };
+		expect(JSON.parse(echo.content)).toEqual({ msg: "重启后" });
+		expect(c.startCount).toBe(2);
+		expect(c.getTools().map((t) => t.name)).toContain("crash");
+	});
+
+	it("启动即退出的服务器：每次调用都快速报「自动重启失败」的明确错误，不挂死", async () => {
+		const c = new McpClient("gone", { command: process.execPath, args: ["-e", "process.exit(7)"] }, () => {});
+		clients.push(c);
+		// 进程一启动就 exit(7)，握手请求被立刻拒绝 → 错误信息里带根因，而不是等到 60s 超时
+		await expect(c.call("echo", {}, 1000)).rejects.toThrow(/自动重启失败.*进程退出/);
+		// 下次调用同样快速失败（每次都尝试重启，不累积成永久坏状态）
+		await expect(c.call("echo", {}, 1000)).rejects.toThrow(/自动重启失败/);
+	});
+
+	it("close 之后不再重启：调用报「客户端已关闭」", async () => {
+		const c = client();
+		await c.start();
+		c.close();
+		await expect(c.call("echo", {}, 1000)).rejects.toThrow(/客户端已关闭/);
+	});
+});
+
 describe("McpBridge 聚合适配", () => {
 	it("load 启动并适配成 PluginAgentTool（execute 经 MCP 转发）", async () => {
 		const bridge = new McpBridge("/nonexistent", () => {}, {
@@ -116,11 +149,27 @@ describe("McpBridge 聚合适配", () => {
 		});
 		await bridge.load();
 		const tools = bridge.getTools();
-		expect(tools.length).toBe(8);
+		expect(tools.length).toBe(9);
 		const add = tools.find((t) => t.name === "add")!;
 		expect(add.label).toContain("csrv");
 		expect(typeof add.execute).toBe("function");
 		// 直接调用 execute（不经 LLM）
+		const res = (await add.execute("id", { a: 10, b: 20 })) as { content: string };
+		expect(JSON.parse(res.content)).toBe(30);
+		bridge.dispose();
+	});
+
+	it("子进程崩溃后经适配工具（PluginAgentTool.execute）自动重启", async () => {
+		const bridge = new McpBridge("/nonexistent", () => {}, {
+			specOverride: [{ name: "csrv", spec: { command: process.execPath, args: [FIXTURE] } }],
+		});
+		await bridge.load();
+		const tools = bridge.getTools();
+		const crash = tools.find((t) => t.name === "crash")!;
+		// 崩溃调用：在途请求被立刻拒绝
+		await expect(crash.execute("id", {})).rejects.toThrow(/进程退出/);
+		// 随后的普通工具调用 = 用户视角的「自动恢复」
+		const add = tools.find((t) => t.name === "add")!;
 		const res = (await add.execute("id", { a: 10, b: 20 })) as { content: string };
 		expect(JSON.parse(res.content)).toBe(30);
 		bridge.dispose();


### PR DESCRIPTION
# fix(server): MCP 桥子进程崩溃后自动重启（自愈），不再需要重启服务

## 背景

MCP 服务器子进程一旦崩溃/被杀（OOM、外部 kill、浏览器类 MCP 的会话崩等），`McpClient` 只拒绝在途请求并把 `child` 置空，**没有重连逻辑**。此后该服务器所有工具调用 `send()` 落空，挂满 60s 后报「tools/call 超时」，且**永久**如此——只能 `systemctl restart piwebui` 才能恢复。
**改动前失败证据**（旧实现跑本 PR 新增的回归测试，全部以「超时」失败——正是线上症状）：

> 说明：本 PR 基于包含 #126 系列（非文本内容块转发，昨晚 `129ff60`）的 `origin/main` 开发，与那组修复互不重叠——它处理「内容块怎么映射」，本 PR 处理「子进程生命周期怎么自愈」。
```
FAIL tests/unit/mcp-bridge.test.ts > McpClient 自愈 > 启动即退出的服务器：每次调用都快速报「自动重启失败」的明确错误，不挂死
AssertionError: expected [Function] to throw error matching /自动重启失败/ but got '[mcp:gone] tools/call 超时 (1000ms)'
```

（`crash` 自杀后下一次调用、`close` 后调用两例同理，旧实现全是 `tools/call 超时`。）

## 改动（`server/mcp-bridge.ts`，不动协议/SDK/agent-service）

1. **调用时惰性重启**：`McpClient.call()` 发现子进程已退出（非主动关闭）→ 先自动重启（重新 spawn + initialize 握手 + tools/list）再发调用；重启失败 → 抛明确错误「服务器进程已退出且自动重启失败：<根因>」，替代原来 60s 挂死后泛化超时。
2. **`start()` 可安全重入**：并发调用共享同一次重连（`starting` promise 去重）；启动/握手失败时回收半启动的子进程防止泄漏；重启过程中被显式 `close()` 则回收刚启动的进程、不留孤儿。
3. **`close()` 后永久停用**：错误文案区分「客户端已关闭，不会重启」。
4. **日志可诊断**：退出时记录「进程退出 (code)，下次调用将自动重启」；在途请求仍立即拒绝（原行为保留）。
5. 顺带修两处既有隐患：spawn/握手失败不再漏子进程；退出后向 stdin 写入的 EPIPE 静默（不再可能触发未捕获异常）。

重启后 `McpClient.tools` 重新拉取；Bridge 层已适配的 `PluginAgentTool` 闭包不变、无需重建。

## 测试（新增 4 例 + 夹具 1 个工具）

- 夹具 `mcp-echo-server.mjs` 新增 `crash` 工具（调用即 `process.exit(2)` 自杀）。
- 新增用例：
  1. 崩溃后**在途调用立即报「进程退出」**（而不是挂 60s 超时），下一次调用自动重启并成功（`startCount` 1→2）；
  2. 启动即退出的服务器：每次调用快速报「自动重启失败」，不累积成永久坏状态；
  3. `close()` 之后不再重启；
  4. 崩溃后经 `PluginAgentTool.execute`（真实会话侧工具转发路径）自动恢复。
- 冒烟 `mcp-bridge-test.mjs` 工具数断言 8→9（夹具新增工具所致）。

## 验证（本地实跑）

- `typecheck`（5 个 tsconfig）：✅
- `lint`（oxlint）：✅ 仅 3 条既有 warning（`mermaid.ts`/`marker-service.ts`/`model-admin.ts`，与本改动无关）
- `format:check`（prettier）：✅
- `vitest` 全量：**82 文件 / 873 用例全过**
- `build:server`：✅；协议冒烟 `tests/mcp-bridge-test.mjs`：✅（9 tools 就绪 + 坏服务器隔离）

## 未验证

- 真实浏览器类 MCP 服务器崩溃后的端到端恢复：本机无浏览器内核，无法起真实浏览器 MCP；单测/冒烟覆盖到 `PluginAgentTool.execute` 这一层（与真实会话调用同一代码路径）。浏览器类工具崩溃走的是完全相同的「子进程退出 → 惰性重启」逻辑。

## 需要维护者拍板的点

- **重启时机选「调用时惰性重启」**而非退出后立即后台重启：配置错误的服务器只会在真的被调用时才试一次，不会反复拉进程（重启循环天然受调用频率约束）。若你更倾向「退出后立即自愈」，改动很小。
- 本 PR **不做** `mcp.json` 热加载 / Bridge 层工具列表热刷新（重启后新工具不会自动进会话工具集，与既有「mcp.json 无热加载」问题同范围，可另开 PR）。